### PR TITLE
fix: tests, in-memory migrations, clippy/fmt

### DIFF
--- a/src/application/add_intel.rs
+++ b/src/application/add_intel.rs
@@ -19,9 +19,14 @@ impl AddIntelUseCase {
         embedder: Arc<dyn EmbeddingProvider>,
         vector_store: Arc<dyn VectorStore>,
     ) -> Self {
-        Self { repo, embedder, vector_store }
+        Self {
+            repo,
+            embedder,
+            vector_store,
+        }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn execute(
         &self,
         category: Category,
@@ -33,9 +38,17 @@ impl AddIntelUseCase {
         actionable: Option<bool>,
         metadata: Option<serde_json::Value>,
     ) -> Result<IntelEntry, DomainError> {
-        let conf = Confidence::new(confidence.unwrap_or(0.5))
-            .map_err(|e| DomainError::InvalidInput(e))?;
-        let entry = IntelEntry::new(category, title, body, source, tags, conf, actionable.unwrap_or(false), metadata);
+        let conf = Confidence::new(confidence.unwrap_or(0.5)).map_err(DomainError::InvalidInput)?;
+        let entry = IntelEntry::new(
+            category,
+            title,
+            body,
+            source,
+            tags,
+            conf,
+            actionable.unwrap_or(false),
+            metadata,
+        );
 
         self.repo.add(&entry)?;
 

--- a/src/application/query.rs
+++ b/src/application/query.rs
@@ -21,6 +21,11 @@ impl QueryUseCase {
         since: Option<DateTime<Utc>>,
         limit: Option<usize>,
     ) -> Result<Vec<IntelEntry>, DomainError> {
-        self.repo.query(&QueryFilter { category, tag, since, limit })
+        self.repo.query(&QueryFilter {
+            category,
+            tag,
+            since,
+            limit,
+        })
     }
 }

--- a/src/application/reindex.rs
+++ b/src/application/reindex.rs
@@ -16,7 +16,11 @@ impl ReindexUseCase {
         embedder: Arc<dyn EmbeddingProvider>,
         vector_store: Arc<dyn VectorStore>,
     ) -> Self {
-        Self { repo, embedder, vector_store }
+        Self {
+            repo,
+            embedder,
+            vector_store,
+        }
     }
 
     pub async fn execute(&self) -> Result<usize, DomainError> {

--- a/src/application/trade.rs
+++ b/src/application/trade.rs
@@ -24,12 +24,25 @@ impl TradeUseCase {
         entry_price: f64,
         thesis: Option<String>,
     ) -> Result<Trade, DomainError> {
-        let trade = Trade::new(ticker, series_ticker, direction, contracts, entry_price, thesis);
+        let trade = Trade::new(
+            ticker,
+            series_ticker,
+            direction,
+            contracts,
+            entry_price,
+            thesis,
+        );
         self.repo.add_trade(&trade)?;
         Ok(trade)
     }
 
-    pub fn resolve(&self, id: &str, outcome: TradeOutcome, pnl_cents: i64, exit_price: Option<f64>) -> Result<(), DomainError> {
+    pub fn resolve(
+        &self,
+        id: &str,
+        outcome: TradeOutcome,
+        pnl_cents: i64,
+        exit_price: Option<f64>,
+    ) -> Result<(), DomainError> {
         self.repo.resolve_trade(id, outcome, pnl_cents, exit_price)
     }
 
@@ -39,6 +52,10 @@ impl TradeUseCase {
         since: Option<DateTime<Utc>>,
         resolved: Option<bool>,
     ) -> Result<Vec<Trade>, DomainError> {
-        self.repo.list_trades(&TradeFilter { limit, since, resolved })
+        self.repo.list_trades(&TradeFilter {
+            limit,
+            since,
+            resolved,
+        })
     }
 }

--- a/src/domain/entities/intel_entry.rs
+++ b/src/domain/entities/intel_entry.rs
@@ -19,6 +19,7 @@ pub struct IntelEntry {
 }
 
 impl IntelEntry {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         category: Category,
         title: String,

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,4 +1,4 @@
-pub mod error;
 pub mod entities;
+pub mod error;
 pub mod ports;
 pub mod values;

--- a/src/domain/ports/embedding_port.rs
+++ b/src/domain/ports/embedding_port.rs
@@ -8,6 +8,10 @@ pub enum InputType {
 
 #[async_trait::async_trait]
 pub trait EmbeddingProvider: Send + Sync {
-    async fn embed(&self, texts: &[String], input_type: InputType) -> Result<Vec<Vec<f32>>, DomainError>;
+    async fn embed(
+        &self,
+        texts: &[String],
+        input_type: InputType,
+    ) -> Result<Vec<Vec<f32>>, DomainError>;
     fn dimension(&self) -> usize;
 }

--- a/src/domain/ports/trade_repository.rs
+++ b/src/domain/ports/trade_repository.rs
@@ -12,7 +12,13 @@ pub struct TradeFilter {
 
 pub trait TradeRepository: Send + Sync {
     fn add_trade(&self, trade: &Trade) -> Result<(), DomainError>;
-    fn resolve_trade(&self, id: &str, outcome: TradeOutcome, pnl_cents: i64, exit_price: Option<f64>) -> Result<(), DomainError>;
+    fn resolve_trade(
+        &self,
+        id: &str,
+        outcome: TradeOutcome,
+        pnl_cents: i64,
+        exit_price: Option<f64>,
+    ) -> Result<(), DomainError>;
     fn list_trades(&self, filter: &TradeFilter) -> Result<Vec<Trade>, DomainError>;
     fn get_trade(&self, id: &str) -> Result<Option<Trade>, DomainError>;
 }

--- a/src/domain/ports/vector_store.rs
+++ b/src/domain/ports/vector_store.rs
@@ -2,7 +2,11 @@ use crate::domain::error::DomainError;
 
 pub trait VectorStore: Send + Sync {
     fn store(&self, id: &str, vector: &[f32]) -> Result<(), DomainError>;
-    fn search_similar(&self, vector: &[f32], limit: usize) -> Result<Vec<(String, f64)>, DomainError>;
+    fn search_similar(
+        &self,
+        vector: &[f32],
+        limit: usize,
+    ) -> Result<Vec<(String, f64)>, DomainError>;
     fn has_vector(&self, id: &str) -> Result<bool, DomainError>;
     fn get_stored_dimension(&self) -> Result<Option<usize>, DomainError>;
 }

--- a/src/domain/values/confidence.rs
+++ b/src/domain/values/confidence.rs
@@ -7,7 +7,9 @@ pub struct Confidence(f64);
 impl Confidence {
     pub fn new(value: f64) -> Result<Self, String> {
         if !(0.0..=1.0).contains(&value) {
-            return Err(format!("Confidence must be between 0.0 and 1.0, got {value}"));
+            return Err(format!(
+                "Confidence must be between 0.0 and 1.0, got {value}"
+            ));
         }
         Ok(Confidence(value))
     }

--- a/src/infrastructure/embeddings/noop.rs
+++ b/src/infrastructure/embeddings/noop.rs
@@ -5,7 +5,11 @@ pub struct NoopProvider;
 
 #[async_trait::async_trait]
 impl EmbeddingProvider for NoopProvider {
-    async fn embed(&self, texts: &[String], _input_type: InputType) -> Result<Vec<Vec<f32>>, DomainError> {
+    async fn embed(
+        &self,
+        texts: &[String],
+        _input_type: InputType,
+    ) -> Result<Vec<Vec<f32>>, DomainError> {
         Ok(texts.iter().map(|_| vec![]).collect())
     }
 

--- a/src/infrastructure/embeddings/openai.rs
+++ b/src/infrastructure/embeddings/openai.rs
@@ -37,8 +37,13 @@ impl OpenAiProvider {
 
 #[async_trait::async_trait]
 impl EmbeddingProvider for OpenAiProvider {
-    async fn embed(&self, texts: &[String], _input_type: InputType) -> Result<Vec<Vec<f32>>, DomainError> {
-        let resp = self.client
+    async fn embed(
+        &self,
+        texts: &[String],
+        _input_type: InputType,
+    ) -> Result<Vec<Vec<f32>>, DomainError> {
+        let resp = self
+            .client
             .post("https://api.openai.com/v1/embeddings")
             .bearer_auth(&self.api_key)
             .json(&OpenAiRequest {
@@ -52,10 +57,15 @@ impl EmbeddingProvider for OpenAiProvider {
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            return Err(DomainError::Embedding(format!("OpenAI API {status}: {body}")));
+            return Err(DomainError::Embedding(format!(
+                "OpenAI API {status}: {body}"
+            )));
         }
 
-        let result: OpenAiResponse = resp.json().await.map_err(|e| DomainError::Parse(format!("Parse error: {e}")))?;
+        let result: OpenAiResponse = resp
+            .json()
+            .await
+            .map_err(|e| DomainError::Parse(format!("Parse error: {e}")))?;
         Ok(result.data.into_iter().map(|d| d.embedding).collect())
     }
 

--- a/src/infrastructure/embeddings/voyage.rs
+++ b/src/infrastructure/embeddings/voyage.rs
@@ -48,13 +48,18 @@ impl VoyageProvider {
 
 #[async_trait::async_trait]
 impl EmbeddingProvider for VoyageProvider {
-    async fn embed(&self, texts: &[String], input_type: InputType) -> Result<Vec<Vec<f32>>, DomainError> {
+    async fn embed(
+        &self,
+        texts: &[String],
+        input_type: InputType,
+    ) -> Result<Vec<Vec<f32>>, DomainError> {
         let it = match input_type {
             InputType::Document => "document",
             InputType::Query => "query",
         };
 
-        let resp = self.client
+        let resp = self
+            .client
             .post("https://api.voyageai.com/v1/embeddings")
             .bearer_auth(&self.api_key)
             .json(&VoyageRequest {
@@ -69,10 +74,15 @@ impl EmbeddingProvider for VoyageProvider {
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            return Err(DomainError::Embedding(format!("Voyage API {status}: {body}")));
+            return Err(DomainError::Embedding(format!(
+                "Voyage API {status}: {body}"
+            )));
         }
 
-        let result: VoyageResponse = resp.json().await.map_err(|e| DomainError::Parse(format!("Parse error: {e}")))?;
+        let result: VoyageResponse = resp
+            .json()
+            .await
+            .map_err(|e| DomainError::Parse(format!("Parse error: {e}")))?;
         Ok(result.data.into_iter().map(|d| d.embedding).collect())
     }
 

--- a/src/infrastructure/sqlite/migrations.rs
+++ b/src/infrastructure/sqlite/migrations.rs
@@ -49,8 +49,9 @@ pub fn run_migrations(conn: &Connection) -> Result<(), DomainError> {
             CREATE INDEX IF NOT EXISTS idx_intel_created ON intel_entries(created_at);
             CREATE INDEX IF NOT EXISTS idx_trades_created ON trades(created_at);
             CREATE INDEX IF NOT EXISTS idx_trades_ticker ON trades(ticker);
-            "
-        ).map_err(|e| DomainError::Database(format!("Migration v1 failed: {e}")))?;
+            ",
+        )
+        .map_err(|e| DomainError::Database(format!("Migration v1 failed: {e}")))?;
     }
 
     conn.pragma_update(None, "user_version", CURRENT_VERSION)

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,20 +31,40 @@ async fn run_command(oi: OpenIntel, cmd: Commands) -> Result<(), Box<dyn std::er
             let cat: Category = category.parse().map_err(|e: String| e)?;
             let data: serde_json::Value = serde_json::from_str(&json)?;
 
-            let title = data["title"].as_str().ok_or("Missing required field: title")?.to_string();
-            let body = data["body"].as_str().ok_or("Missing required field: body")?.to_string();
+            let title = data["title"]
+                .as_str()
+                .ok_or("Missing required field: title")?
+                .to_string();
+            let body = data["body"]
+                .as_str()
+                .ok_or("Missing required field: body")?
+                .to_string();
             let source = data["source"].as_str().map(|s| s.to_string());
-            let tags: Vec<String> = data["tags"].as_array()
-                .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            let tags: Vec<String> = data["tags"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
                 .unwrap_or_default();
             let confidence = data["confidence"].as_f64();
             let actionable = data["actionable"].as_bool();
             let metadata = data.get("metadata").cloned();
 
-            let entry = oi.add_intel(cat, title, body, source, tags, confidence, actionable, metadata).await?;
+            let entry = oi
+                .add_intel(
+                    cat, title, body, source, tags, confidence, actionable, metadata,
+                )
+                .await?;
             println!("{}", serde_json::to_string_pretty(&entry).unwrap());
         }
-        Commands::Query { category, limit, since, tag } => {
+        Commands::Query {
+            category,
+            limit,
+            since,
+            tag,
+        } => {
             let cat: Category = category.parse().map_err(|e: String| e)?;
             let since_dt = parse_date(&since)?;
             let entries = oi.query(Some(cat), tag, since_dt, Some(limit))?;
@@ -67,7 +87,10 @@ async fn run_command(oi: OpenIntel, cmd: Commands) -> Result<(), Box<dyn std::er
             println!("{}", serde_json::to_string_pretty(&stats).unwrap());
         }
         Commands::Tags { category } => {
-            let cat = category.map(|c| c.parse()).transpose().map_err(|e: String| e)?;
+            let cat = category
+                .map(|c| c.parse())
+                .transpose()
+                .map_err(|e: String| e)?;
             let tags = oi.tags(cat)?;
             for t in &tags {
                 println!("{}: {}", t.tag, t.count);
@@ -76,29 +99,55 @@ async fn run_command(oi: OpenIntel, cmd: Commands) -> Result<(), Box<dyn std::er
         Commands::TradeAdd { json } => {
             let data: serde_json::Value = serde_json::from_str(&json)?;
 
-            let ticker = data["ticker"].as_str().ok_or("ticker required")?.to_string();
+            let ticker = data["ticker"]
+                .as_str()
+                .ok_or("ticker required")?
+                .to_string();
             let series_ticker = data["series_ticker"].as_str().map(String::from);
-            let direction: TradeDirection = data["direction"].as_str().ok_or("direction required")?.parse().map_err(|e: String| e)?;
+            let direction: TradeDirection = data["direction"]
+                .as_str()
+                .ok_or("direction required")?
+                .parse()
+                .map_err(|e: String| e)?;
             let contracts = data["contracts"].as_i64().ok_or("contracts required")?;
             let entry_price = data["entry_price"].as_f64().ok_or("entry_price required")?;
             let thesis = data["thesis"].as_str().map(String::from);
 
-            let trade = oi.trade_add(ticker, series_ticker, direction, contracts, entry_price, thesis)?;
+            let trade = oi.trade_add(
+                ticker,
+                series_ticker,
+                direction,
+                contracts,
+                entry_price,
+                thesis,
+            )?;
             println!("{}", serde_json::to_string_pretty(&trade).unwrap());
         }
-        Commands::TradeResolve { id, outcome, pnl_cents, exit_price } => {
+        Commands::TradeResolve {
+            id,
+            outcome,
+            pnl_cents,
+            exit_price,
+        } => {
             let out: TradeOutcome = outcome.parse().map_err(|e: String| e)?;
             oi.trade_resolve(&id, out, pnl_cents, exit_price)?;
             println!("Trade {id} resolved as {outcome} ({pnl_cents} cents)");
         }
-        Commands::Trades { limit, since, resolved } => {
+        Commands::Trades {
+            limit,
+            since,
+            resolved,
+        } => {
             let since_dt = parse_date(&since)?;
             let trades = oi.trade_list(Some(limit), since_dt, resolved)?;
             println!("{}", serde_json::to_string_pretty(&trades).unwrap());
         }
         Commands::Export { since, category } => {
             let since_dt = parse_date(&since)?;
-            let cat = category.map(|c| c.parse()).transpose().map_err(|e: String| e)?;
+            let cat = category
+                .map(|c| c.parse())
+                .transpose()
+                .map_err(|e: String| e)?;
             let entries = oi.query(cat, None, since_dt, None)?;
             println!("{}", serde_json::to_string_pretty(&entries).unwrap());
         }
@@ -119,9 +168,14 @@ fn parse_date(s: &Option<String>) -> Result<Option<chrono::DateTime<chrono::Utc>
             }
             if let Ok(date) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
                 let dt = date.and_hms_opt(0, 0, 0).unwrap();
-                return Ok(Some(chrono::DateTime::from_naive_utc_and_offset(dt, chrono::Utc)));
+                return Ok(Some(chrono::DateTime::from_naive_utc_and_offset(
+                    dt,
+                    chrono::Utc,
+                )));
             }
-            Err(format!("Invalid date format: {s}. Use YYYY-MM-DD or RFC3339"))
+            Err(format!(
+                "Invalid date format: {s}. Use YYYY-MM-DD or RFC3339"
+            ))
         }
     }
 }

--- a/tests/test_add_and_query.rs
+++ b/tests/test_add_and_query.rs
@@ -11,7 +11,7 @@ fn setup() -> OpenIntel {
 #[tokio::test]
 async fn test_add_and_query_by_category() {
     let oi = setup();
-    oi.add_intel.execute(
+    oi.add_intel(
         Category::Market,
         "BTC rally".into(),
         "Bitcoin surging past 100k".into(),
@@ -20,9 +20,11 @@ async fn test_add_and_query_by_category() {
         Some(0.8),
         Some(true),
         None,
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
-    oi.add_intel.execute(
+    oi.add_intel(
         Category::Newsletter,
         "Weekly digest".into(),
         "Summary of macro events".into(),
@@ -31,9 +33,11 @@ async fn test_add_and_query_by_category() {
         None,
         None,
         None,
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
-    let results = oi.query.execute(Some(Category::Market), None, None, None).unwrap();
+    let results = oi.query(Some(Category::Market), None, None, None).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].title, "BTC rally");
     assert!(results[0].actionable);
@@ -42,7 +46,7 @@ async fn test_add_and_query_by_category() {
 #[tokio::test]
 async fn test_query_by_tag() {
     let oi = setup();
-    oi.add_intel.execute(
+    oi.add_intel(
         Category::Market,
         "Tagged entry".into(),
         "Body".into(),
@@ -51,9 +55,11 @@ async fn test_query_by_tag() {
         None,
         None,
         None,
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
-    oi.add_intel.execute(
+    oi.add_intel(
         Category::Market,
         "Other entry".into(),
         "Body".into(),
@@ -62,9 +68,13 @@ async fn test_query_by_tag() {
         None,
         None,
         None,
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
-    let results = oi.query.execute(Some(Category::Market), Some("alpha".into()), None, None).unwrap();
+    let results = oi
+        .query(Some(Category::Market), Some("alpha".into()), None, None)
+        .unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].title, "Tagged entry");
 }
@@ -73,7 +83,7 @@ async fn test_query_by_tag() {
 async fn test_stats() {
     let oi = setup();
     for i in 0..5 {
-        oi.add_intel.execute(
+        oi.add_intel(
             Category::Market,
             format!("Entry {i}"),
             "Body".into(),
@@ -82,10 +92,12 @@ async fn test_stats() {
             None,
             Some(i % 2 == 0),
             None,
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
     }
 
-    let stats = oi.stats.stats().unwrap();
+    let stats = oi.stats().unwrap();
     assert_eq!(stats.total_entries, 5);
     assert_eq!(stats.actionable_count, 3); // 0,2,4
 }

--- a/tests/test_hybrid_search.rs
+++ b/tests/test_hybrid_search.rs
@@ -17,23 +17,35 @@ async fn test_hybrid_search_falls_back_to_keyword() {
 
     // Add entries
     for i in 0..5 {
-        oi.add_intel.execute(
+        oi.add_intel(
             Category::Market,
             format!("Market signal {i}"),
             format!("Analysis of market trend {i}"),
-            None, vec!["market".into()], None, None, None,
-        ).await.unwrap();
+            None,
+            vec!["market".into()],
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
     }
 
-    oi.add_intel.execute(
+    oi.add_intel(
         Category::General,
         "Unrelated entry".into(),
         "Nothing about markets".into(),
-        None, vec![], None, None, None,
-    ).await.unwrap();
+        None,
+        vec![],
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     // Hybrid search with noop embedder should still return keyword results
-    let results = oi.search.hybrid_search("market signal", 3).await.unwrap();
+    let results = oi.hybrid_search("market signal", 3).await.unwrap();
     assert!(!results.is_empty());
     assert!(results.len() <= 3);
 }
@@ -41,6 +53,6 @@ async fn test_hybrid_search_falls_back_to_keyword() {
 #[tokio::test]
 async fn test_hybrid_search_empty_db() {
     let oi = setup();
-    let results = oi.search.hybrid_search("anything", 10).await.unwrap();
+    let results = oi.hybrid_search("anything", 10).await.unwrap();
     assert!(results.is_empty());
 }

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -10,21 +10,33 @@ fn setup() -> OpenIntel {
 #[tokio::test]
 async fn test_keyword_search() {
     let oi = setup();
-    oi.add_intel.execute(
+    oi.add_intel(
         Category::Market,
         "Bitcoin analysis".into(),
         "BTC is showing strength".into(),
-        None, vec![], None, None, None,
-    ).await.unwrap();
+        None,
+        vec![],
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
-    oi.add_intel.execute(
+    oi.add_intel(
         Category::Market,
         "Ethereum update".into(),
         "ETH gas fees dropping".into(),
-        None, vec![], None, None, None,
-    ).await.unwrap();
+        None,
+        vec![],
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
-    let results = oi.search.keyword_search("Bitcoin", 10).unwrap();
+    let results = oi.keyword_search("Bitcoin", 10).unwrap();
     assert_eq!(results.len(), 1);
     assert!(results[0].title.contains("Bitcoin"));
 }
@@ -32,20 +44,26 @@ async fn test_keyword_search() {
 #[tokio::test]
 async fn test_search_empty_results() {
     let oi = setup();
-    let results = oi.search.keyword_search("nonexistent", 10).unwrap();
+    let results = oi.keyword_search("nonexistent", 10).unwrap();
     assert!(results.is_empty());
 }
 
 #[tokio::test]
 async fn test_search_body_match() {
     let oi = setup();
-    oi.add_intel.execute(
+    oi.add_intel(
         Category::General,
         "Title".into(),
         "The quick brown fox jumps".into(),
-        None, vec![], None, None, None,
-    ).await.unwrap();
+        None,
+        vec![],
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
-    let results = oi.search.keyword_search("fox", 10).unwrap();
+    let results = oi.keyword_search("fox", 10).unwrap();
     assert_eq!(results.len(), 1);
 }

--- a/tests/test_trades.rs
+++ b/tests/test_trades.rs
@@ -11,29 +11,34 @@ fn setup() -> OpenIntel {
 #[test]
 fn test_add_and_list_trade() {
     let oi = setup();
-    let trade = oi.trade.add(
-        "AAPL".into(),
-        None,
-        TradeDirection::Long,
-        10,
-        150.0,
-        Some("Bullish on earnings".into()),
-    ).unwrap();
+    let trade = oi
+        .trade_add(
+            "AAPL".into(),
+            None,
+            TradeDirection::Long,
+            10,
+            150.0,
+            Some("Bullish on earnings".into()),
+        )
+        .unwrap();
 
     assert_eq!(trade.ticker, "AAPL");
     assert!(!trade.is_resolved());
 
-    let trades = oi.trade.list(Some(10), None, None).unwrap();
+    let trades = oi.trade_list(Some(10), None, None).unwrap();
     assert_eq!(trades.len(), 1);
 }
 
 #[test]
 fn test_resolve_trade() {
     let oi = setup();
-    let trade = oi.trade.add("TSLA".into(), None, TradeDirection::Short, 5, 200.0, None).unwrap();
-    oi.trade.resolve(&trade.id, TradeOutcome::Win, 5000, None).unwrap();
+    let trade = oi
+        .trade_add("TSLA".into(), None, TradeDirection::Short, 5, 200.0, None)
+        .unwrap();
+    oi.trade_resolve(&trade.id, TradeOutcome::Win, 5000, None)
+        .unwrap();
 
-    let trades = oi.trade.list(Some(10), None, Some(true)).unwrap();
+    let trades = oi.trade_list(Some(10), None, Some(true)).unwrap();
     assert_eq!(trades.len(), 1);
     assert_eq!(trades[0].outcome, Some(TradeOutcome::Win));
     assert_eq!(trades[0].pnl_cents, Some(5000));
@@ -42,11 +47,15 @@ fn test_resolve_trade() {
 #[test]
 fn test_filter_unresolved() {
     let oi = setup();
-    let t1 = oi.trade.add("A".into(), None, TradeDirection::Long, 1, 10.0, None).unwrap();
-    oi.trade.add("B".into(), None, TradeDirection::Short, 1, 20.0, None).unwrap();
-    oi.trade.resolve(&t1.id, TradeOutcome::Loss, -100, None).unwrap();
+    let t1 = oi
+        .trade_add("A".into(), None, TradeDirection::Long, 1, 10.0, None)
+        .unwrap();
+    oi.trade_add("B".into(), None, TradeDirection::Short, 1, 20.0, None)
+        .unwrap();
+    oi.trade_resolve(&t1.id, TradeOutcome::Loss, -100, None)
+        .unwrap();
 
-    let unresolved = oi.trade.list(None, None, Some(false)).unwrap();
+    let unresolved = oi.trade_list(None, None, Some(false)).unwrap();
     assert_eq!(unresolved.len(), 1);
     assert_eq!(unresolved[0].ticker, "B");
 }


### PR DESCRIPTION
## Summary
- Tests called methods as struct fields (`oi.add_intel.execute()` → `oi.add_intel()`) — fixed all 4 test files
- `:memory:` DBs: each `Connection::open(":memory:")` is isolated, so `vectors` table was missing on conn3. Now runs migrations on all connections
- Fixed clippy `too_many_arguments` and `redundant_closure` warnings
- Applied `cargo fmt` across entire codebase

## Test plan
- [x] `cargo test` — 12/12 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)