### PR TITLE
feat: Wire embedding provider environment variables

### DIFF
--- a/src/infrastructure/embeddings/voyage.rs
+++ b/src/infrastructure/embeddings/voyage.rs
@@ -33,7 +33,10 @@ impl VoyageProvider {
             client: Client::new(),
             api_key,
             model: model.unwrap_or_else(|| "voyage-4-lite".to_string()),
-            base_url: base_url.unwrap_or_else(|| "https://api.voyageai.com".to_string()),
+            base_url: base_url
+                .unwrap_or_else(|| "https://api.voyageai.com".to_string())
+                .trim_end_matches('/')
+                .to_string(),
         }
     }
 


### PR DESCRIPTION
This PR adds support for configuring embedding providers via environment variables.

## Changes

### Environment Variables Added
- **VOYAGE_API_KEY**: Voyage AI API key
- **OPENAI_API_KEY**: OpenAI API key  
- **OPENINTEL_EMBEDDING_PROVIDER**: Provider name (voyage/openai/noop, defaults to noop)
- **OPENINTEL_EMBEDDING_MODEL**: Override default model
- **VOYAGE_API_BASE**: Custom Voyage API base URL (supports MongoDB endpoint at https://ai.mongodb.com/v1)

### Auto-Detection Logic
- If **VOYAGE_API_KEY** is set but no provider specified → defaults to "voyage"
- If **OPENAI_API_KEY** is set but no provider specified → defaults to "openai"
- Maintains backward compatibility with **OPENINTEL_EMBEDDING_API_KEY** as fallback

### Voyage Provider Updates
- Default model changed from **voyage-3-lite** to **voyage-4-lite**
- Added **voyage-4-lite** dimension support (512)
- Base URL is now configurable via **VOYAGE_API_BASE**
- Default: `https://api.voyageai.com`
- For MongoDB-hosted Voyage: set `VOYAGE_API_BASE=https://ai.mongodb.com`

### Fixes
Resolves the issue where `reindex` and `semantic` commands were using the noop provider because the CLI wasn't configuring an embedding provider when creating the OpenIntel instance.

## Testing
The following checks should pass in CI:
- `cargo build`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo fmt -- --check`