### PR TITLE
docs: simpler onboarding — Quickstart + complete MCP wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ Security-first CLI that fuses social-media chatter with market action into a **s
 
 > **Not financial advice.** OpenIntel is a research/screening tool. Social data is noisy and easily manipulated. Do your own diligence.
 
+## Quickstart
+
+Run it immediately — no install, uses built-in mock data:
+
+```bash
+cargo run -- analyze AAPL
+```
+
+Or install it on your PATH for the shorter `openintel` command used throughout this README:
+
+```bash
+cargo install --path .
+openintel analyze AAPL
+```
+
+> **Mock data today.** The numbers are illustrative until real data adapters land — a real market source is the next milestone.
+
 ## Usage
 
 ```bash
@@ -36,12 +53,12 @@ your agent (Claude Code on your subscription / ChatGPT / Codex / Cursor / Grok)
   └─ MCP → agent.robinhood.com/mcp/trading    (execution, sandboxed agentic wallet)
 ```
 
-Wire it up (Claude Code shown; other agents add the same `openintel mcp` stdio command in
-their MCP settings):
+Wire up both MCPs (Claude Code shown; other agents add the same commands in their MCP
+settings). Requires `openintel` on your PATH — see [Quickstart](#quickstart):
 
 ```bash
-cargo install --path .          # puts `openintel` on your PATH
 claude mcp add openintel -- openintel mcp
+claude mcp add robinhood-trading --transport http https://agent.robinhood.com/mcp/trading
 ```
 
 Tools exposed (all **read-only** — OpenIntel never places trades):


### PR DESCRIPTION
Tighten first-run UX:

- **Quickstart** — leads with `cargo run -- analyze AAPL` (no install, mock data) so a fresh clone runs in one command; then PATH install for the shorter `openintel` form.
- **Complete MCP wiring** — adds the `claude mcp add robinhood-trading …` command so the agent setup is copy-paste-complete (was only the `openintel` command; the Robinhood side was described in the diagram but not runnable).
- Removes the duplicated `cargo install --path .` line (now canonical in Quickstart).

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a clearer Quickstart section with immediate `cargo run` usage.
  * Documented installing the CLI for the shorter `openintel` command.
  * Noted that current figures are based on built-in mock data.
  * Expanded MCP setup instructions to cover connecting both MCP services, including the required commands and connection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->