### PR TITLE
feat(reddit): real Reddit OAuth social source + social-side DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ approval. That boundary *is* the safety model; keep it.
 Hexagonal (ports & adapters). The domain is pure and synchronous; IO and the clock live at the edge.
 
 - `domain/` — entities, value objects, the pure `SpeculationEngine`, and port traits.
-- `adapters/` — `LexiconAnalyzer`, the `YahooMarketSource` (real, keyless), and mock social sources.
+- `adapters/` — `LexiconAnalyzer`, the `YahooMarketSource` (real, keyless), the `RedditSource` (real via OAuth when configured), and mock X/Bluesky sources.
 - `config/` — env-only secrets (`secrecy`) and runtime settings.
 - `cli/` — clap args, orchestration, rendering.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cargo install --path .
 openintel analyze AAPL
 ```
 
-> **Market data is live (Yahoo Finance, keyless); social sources are still mock.** `analyze` fetches real price/volume over the network — offline runs degrade to a social-only report. Real social adapters are the next milestone.
+> **Market data is live (Yahoo Finance, keyless). Reddit is live when configured (OAuth — see below); X and Bluesky are still mock.** `analyze` fetches over the network — offline or unconfigured sources degrade gracefully with a note.
 
 ## Usage
 
@@ -40,6 +40,21 @@ openintel analyze AAPL --no-market --format json
 | `--no-market` | Skip the market snapshot (social-only report) |
 | `--limit <N>` | Posts per source (default 50) |
 | `--format table\|json` | Output format (default table) |
+
+## Enable the Reddit source (optional)
+
+Reddit requires OAuth (there is no keyless access). One-time setup:
+
+1. Create a **script** app at <https://www.reddit.com/prefs/apps> → note the **client id** (under the app name) and **secret**.
+2. Export them before running:
+
+```bash
+export OPENINTEL_REDDIT_CLIENT_ID=your_client_id
+export OPENINTEL_REDDIT_CLIENT_SECRET=your_secret
+openintel analyze AAPL --enable-reddit
+```
+
+Without these, `--enable-reddit` yields a `reddit enabled but not configured` note and the other sources still run. Credentials are read only from the environment, wrapped in `SecretString` (never logged or written to disk), and sent only to Reddit over TLS.
 
 ## Use with an AI agent (MCP)
 
@@ -116,14 +131,14 @@ Hexagonal (ports & adapters). The domain is pure and synchronous; IO and the clo
 - `config/` — env-only secrets (`secrecy`) and runtime settings.
 - `cli/` — clap args, orchestration, rendering.
 
-Secrets come only from environment variables (`OPENINTEL_REDDIT_TOKEN`, `OPENINTEL_X_BEARER`, `OPENINTEL_BLUESKY_APP_PASSWORD`, `OPENINTEL_MARKET_API_KEY`), wrapped in `SecretString` — never logged or written to disk.
+Secrets come only from environment variables (`OPENINTEL_REDDIT_CLIENT_ID`, `OPENINTEL_REDDIT_CLIENT_SECRET`, `OPENINTEL_X_BEARER`, `OPENINTEL_BLUESKY_APP_PASSWORD`, `OPENINTEL_MARKET_API_KEY`), wrapped in `SecretString` — never logged or written to disk.
 
 ## Extending
 
-**Add a social source** (e.g. real Reddit):
+**Add a social source** (e.g. real Bluesky):
 1. New struct in `src/adapters/sources/`, `impl SocialDataSource`.
-2. Add a `SourceKind` variant in `src/domain/values/source_kind.rs`.
-3. Add one arm to `build_sources` in `src/cli/run.rs`.
+2. Add a `SourceKind` variant in `src/domain/values/source_kind.rs` if new.
+3. Construct it at the composition roots — `main.rs` (analyze branch) and `mcp::server::serve()` — and push it onto the injected social list. No engine or application change.
 
 **Add a market source** (e.g. a keyed provider):
 1. New struct in `src/adapters/market/`, `impl MarketDataSource`.

--- a/docs/superpowers/plans/2026-07-02-reddit-social-adapter.md
+++ b/docs/superpowers/plans/2026-07-02-reddit-social-adapter.md
@@ -1,0 +1,1348 @@
+# Reddit OAuth Social Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a real Reddit `SocialDataSource` (app-only OAuth over finance subreddits), injected via DI, replacing the mock Reddit fixtures in production while keeping tests hermetic.
+
+**Architecture:** A pure `parse_posts` maps Reddit search JSON to `SocialPost`; `auth.rs` holds the cached-token OAuth (`client_credentials`); `RedditSource` (`mod.rs`) does the token + search HTTP and delegates to the parser. Social sources become an injected `&[Box<dyn SocialDataSource>]`; the composition roots build the list (Reddit only when creds are set), tests inject mocks.
+
+**Tech Stack:** Rust, tokio, reqwest (rustls, already a dependency), serde_json, chrono, secrecy.
+
+## Global Constraints
+
+- Reddit access is **app-only OAuth `client_credentials`** — verified live that keyless Reddit 403s. Token: `POST https://www.reddit.com/api/v1/access_token`, body `grant_type=client_credentials`, HTTP Basic (`client_id`:`client_secret`); API base `https://oauth.reddit.com`, `Authorization: bearer <token>`.
+- **User-Agent is mandatory** and must be descriptive: `rust:openintel:v{CARGO_PKG_VERSION} (by /u/openintel)` on every Reddit request (token + search). Generic UAs are throttled.
+- Secrets are env-only via `secrecy::SecretString`: `OPENINTEL_REDDIT_CLIENT_ID`, `OPENINTEL_REDDIT_CLIENT_SECRET` (replacing the unused `OPENINTEL_REDDIT_TOKEN`). Never logged, never written to disk; `.expose_secret()` only at the HTTP call.
+- All failures map to `DomainError::SourceFailure { name: "reddit".into(), message }` — no new error variant. **No `unwrap`/`expect` on network data.**
+- Clock at the edge: `fetch`/`ensure_token` read `Utc::now()` and pass it into the pure `parse_posts` / `parse_token`; those are deterministic.
+- `cargo test` must be **hermetic** — the only live test is `#[ignore]`d and reads creds from env.
+- Bearer token is cached (`RwLock`) and reused across a `scan_watchlist`; refreshed 60s before `expires_in`.
+- Graceful absence: no creds → Reddit source not wired → enabling reddit yields a `"reddit enabled but not configured"` note; other sources + market still run.
+- YAGNI: submissions only (no comments), fixed subreddit set, no retry/backoff, no OS keychain.
+- Each task passes `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`.
+
+---
+
+## File Structure
+
+**Create**
+- `src/adapters/sources/reddit/response.rs` — serde DTOs + pure `parse_posts` + tests.
+- `src/adapters/sources/reddit/auth.rs` — `CachedToken`, `parse_token`, `request_token` + tests.
+- `src/adapters/sources/reddit/mod.rs` — `RedditSource` (HTTP shell + `impl SocialDataSource`).
+
+**Modify**
+- `src/adapters/sources/mod.rs` — `pub mod reddit;`.
+- `src/config/secrets.rs` — Reddit client id/secret.
+- `src/application/analyze.rs` — inject social sources; drop `build_sources`.
+- `src/cli/run.rs`, `src/main.rs` — build + inject the social list.
+- `src/mcp/tools.rs`, `src/mcp/server.rs` — thread + own the social list.
+- `tests/analyze_flow.rs` — inject the mock social list.
+- `README.md` — Reddit setup + secret guidance.
+
+---
+
+## Task 1: Pure Reddit response parser
+
+**Files:**
+- Create: `src/adapters/sources/reddit/mod.rs` (this task: only `mod response;`)
+- Create: `src/adapters/sources/reddit/response.rs`
+- Modify: `src/adapters/sources/mod.rs`
+- Test: unit tests in `response.rs`
+
+**Interfaces:**
+- Consumes: `SocialPost`, `PostText` (`src/domain/entities/social_post.rs`); `SourceKind::Reddit`; `DomainError::SourceFailure { name, message }`.
+- Produces: `pub(crate) fn parse_posts(body: &str, limit: usize, fetched_at: DateTime<Utc>) -> Result<Vec<SocialPost>, DomainError>`.
+
+- [ ] **Step 1: Register the module tree**
+
+`src/adapters/sources/mod.rs` — add `pub mod reddit;` (keep existing `pub mod mock_reddit;` etc.).
+
+Create `src/adapters/sources/reddit/mod.rs` with only:
+
+```rust
+mod response;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `src/adapters/sources/reddit/response.rs` with this test module at the bottom:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 2, 0, 0, 0).unwrap()
+    }
+
+    const HAPPY: &str = r#"{"kind":"Listing","data":{"children":[
+        {"kind":"t3","data":{"name":"t3_aaa","author":"wsbtrader","title":"$AAPL calls printing","selftext":"loading more","score":420,"created_utc":1782504000.0}},
+        {"kind":"t3","data":{"name":"t3_bbb","author":"[deleted]","title":"AAPL puts","selftext":"","score":-5,"created_utc":1782500000.0}}
+    ]}}"#;
+
+    const EMPTY: &str = r#"{"kind":"Listing","data":{"children":[]}}"#;
+
+    #[test]
+    fn happy_maps_posts() {
+        let posts = parse_posts(HAPPY, 50, at()).unwrap();
+        assert_eq!(posts.len(), 2);
+        assert_eq!(posts[0].id, "t3_aaa");
+        assert_eq!(posts[0].author, "wsbtrader");
+        assert_eq!(posts[0].text.as_str(), "$AAPL calls printing\nloading more");
+        assert_eq!(posts[0].engagement, 420);
+        assert_eq!(posts[0].source, SourceKind::Reddit);
+        assert_eq!(
+            posts[0].created_at,
+            Utc.timestamp_opt(1782504000, 0).single().unwrap()
+        );
+    }
+
+    #[test]
+    fn empty_selftext_is_title_only_and_deleted_author_kept() {
+        let posts = parse_posts(HAPPY, 50, at()).unwrap();
+        assert_eq!(posts[1].text.as_str(), "AAPL puts");
+        assert_eq!(posts[1].author, "[deleted]");
+    }
+
+    #[test]
+    fn negative_score_clamps_to_zero() {
+        let posts = parse_posts(HAPPY, 50, at()).unwrap();
+        assert_eq!(posts[1].engagement, 0);
+    }
+
+    #[test]
+    fn limit_is_honored() {
+        assert_eq!(parse_posts(HAPPY, 1, at()).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn empty_children_is_empty() {
+        assert!(parse_posts(EMPTY, 50, at()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn missing_created_utc_falls_back_to_fetched_at() {
+        let body = r#"{"kind":"Listing","data":{"children":[
+            {"kind":"t3","data":{"name":"t3_c","author":"a","title":"AAPL","score":1}}
+        ]}}"#;
+        assert_eq!(parse_posts(body, 50, at()).unwrap()[0].created_at, at());
+    }
+
+    #[test]
+    fn overlong_text_is_truncated() {
+        let big = "A".repeat(20_000);
+        let body = format!(
+            r#"{{"kind":"Listing","data":{{"children":[{{"kind":"t3","data":{{"name":"t3_d","author":"a","title":"{big}","score":1,"created_utc":1.0}}}}]}}}}"#
+        );
+        let posts = parse_posts(&body, 50, at()).unwrap();
+        assert_eq!(posts[0].text.as_str().chars().count(), 10_000);
+    }
+
+    #[test]
+    fn post_with_no_id_is_skipped() {
+        let body = r#"{"kind":"Listing","data":{"children":[
+            {"kind":"t3","data":{"author":"a","title":"AAPL","score":1}}
+        ]}}"#;
+        assert!(parse_posts(body, 50, at()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn malformed_json_is_source_failure() {
+        assert!(parse_posts("not json", 50, at()).is_err());
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test -p openintel --lib adapters::sources::reddit`
+Expected: FAIL to compile — `parse_posts` not found.
+
+- [ ] **Step 4: Write the implementation**
+
+Prepend to `src/adapters/sources/reddit/response.rs` (above the tests):
+
+```rust
+#![allow(dead_code)]
+
+use chrono::{DateTime, TimeZone, Utc};
+use serde::Deserialize;
+
+use crate::domain::entities::social_post::{PostText, SocialPost};
+use crate::domain::error::DomainError;
+use crate::domain::values::source_kind::SourceKind;
+
+const MAX_TEXT_CHARS: usize = 10_000;
+
+#[derive(Debug, Deserialize)]
+struct Listing {
+    data: ListingData,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListingData {
+    #[serde(default)]
+    children: Vec<Child>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Child {
+    data: ChildData,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChildData {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    author: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    selftext: Option<String>,
+    #[serde(default)]
+    score: Option<i64>,
+    #[serde(default)]
+    created_utc: Option<f64>,
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "reddit".into(),
+        message: message.into(),
+    }
+}
+
+pub(crate) fn parse_posts(
+    body: &str,
+    limit: usize,
+    fetched_at: DateTime<Utc>,
+) -> Result<Vec<SocialPost>, DomainError> {
+    let listing: Listing =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
+
+    let mut posts = Vec::new();
+    for child in listing.data.children {
+        let d = child.data;
+        let id = match d.name.or(d.id) {
+            Some(id) if !id.is_empty() => id,
+            _ => continue,
+        };
+        let title = d.title.unwrap_or_default();
+        let selftext = d.selftext.unwrap_or_default();
+        let combined = if selftext.trim().is_empty() {
+            title
+        } else {
+            format!("{title}\n{selftext}")
+        };
+        let truncated: String = combined.chars().take(MAX_TEXT_CHARS).collect();
+        let text = match PostText::parse(&truncated) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let created_at = d
+            .created_utc
+            .and_then(|s| Utc.timestamp_opt(s as i64, 0).single())
+            .unwrap_or(fetched_at);
+
+        posts.push(SocialPost {
+            id,
+            source: SourceKind::Reddit,
+            author: d.author.unwrap_or_else(|| "[unknown]".to_string()),
+            text,
+            created_at,
+            engagement: d.score.unwrap_or(0).max(0) as u32,
+        });
+        if posts.len() >= limit {
+            break;
+        }
+    }
+    Ok(posts)
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p openintel --lib adapters::sources::reddit`
+Expected: PASS (9 tests).
+
+- [ ] **Step 6: Lint + format**
+
+Run: `cargo clippy --all-targets -- -D warnings && cargo fmt`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/adapters/sources/mod.rs src/adapters/sources/reddit/
+git commit -m "feat(reddit): pure Reddit search response parser"
+```
+
+---
+
+## Task 2: Reddit OAuth source (auth + HTTP fetch)
+
+**Files:**
+- Create: `src/adapters/sources/reddit/auth.rs`
+- Modify: `src/adapters/sources/reddit/mod.rs` (add `RedditSource`; remove the Task-1 `#![allow(dead_code)]` from `response.rs`)
+- Test: unit tests in `auth.rs`; unit + `#[ignore]` live test in `mod.rs`
+
+**Interfaces:**
+- Consumes: `response::parse_posts` (Task 1); `SocialDataSource` port (`fn kind(&self) -> SourceKind`, `async fn fetch(&self, ticker: &Ticker, limit: usize) -> Result<Vec<SocialPost>, DomainError>`); `secrecy::{SecretString, ExposeSecret}`.
+- Produces:
+  - `auth.rs` (`pub(crate)`): `CachedToken { bearer: SecretString, expires_at: DateTime<Utc> }` with `is_expired(&self, now: DateTime<Utc>) -> bool`; `parse_token(body: &str, now: DateTime<Utc>) -> Result<CachedToken, DomainError>`; `async fn request_token(client, client_id, client_secret, user_agent, now) -> Result<CachedToken, DomainError>`.
+  - `mod.rs`: `RedditSource` with `pub fn new(client_id: SecretString, client_secret: SecretString) -> Result<Self, DomainError>`; `impl SocialDataSource` (`kind()` → `Reddit`).
+
+- [ ] **Step 1: Write the failing tests for auth**
+
+Create `src/adapters/sources/reddit/auth.rs` with this test module at the bottom:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 2, 0, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn parse_token_ok_and_expiry() {
+        let body = r#"{"access_token":"abc123","token_type":"bearer","expires_in":3600,"scope":"*"}"#;
+        let t = parse_token(body, at()).unwrap();
+        assert_eq!(t.bearer.expose_secret(), "abc123");
+        assert!(!t.is_expired(at())); // fresh
+        assert!(t.is_expired(at() + Duration::seconds(3600))); // at expiry
+        assert!(t.is_expired(at() + Duration::seconds(3541))); // 60s skew -> refresh early
+        assert!(!t.is_expired(at() + Duration::seconds(3539)));
+    }
+
+    #[test]
+    fn parse_token_error_field_is_failure() {
+        let body = r#"{"error":"invalid_grant"}"#;
+        assert!(parse_token(body, at()).is_err());
+    }
+
+    #[test]
+    fn parse_token_missing_access_token_is_failure() {
+        let body = r#"{"token_type":"bearer","expires_in":3600}"#;
+        assert!(parse_token(body, at()).is_err());
+    }
+
+    #[test]
+    fn parse_token_malformed_is_failure() {
+        assert!(parse_token("nope", at()).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p openintel --lib adapters::sources::reddit::auth`
+Expected: FAIL to compile — `parse_token` / `CachedToken` not found.
+
+- [ ] **Step 3: Implement auth.rs**
+
+Prepend to `src/adapters/sources/reddit/auth.rs`:
+
+```rust
+use chrono::{DateTime, Duration, Utc};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+use crate::domain::error::DomainError;
+
+const SKEW_SECS: i64 = 60;
+const TOKEN_URL: &str = "https://www.reddit.com/api/v1/access_token";
+
+pub(crate) struct CachedToken {
+    pub bearer: SecretString,
+    pub expires_at: DateTime<Utc>,
+}
+
+impl CachedToken {
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        now + Duration::seconds(SKEW_SECS) >= self.expires_at
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    #[serde(default)]
+    access_token: Option<String>,
+    #[serde(default)]
+    expires_in: Option<i64>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "reddit".into(),
+        message: message.into(),
+    }
+}
+
+pub(crate) fn parse_token(body: &str, now: DateTime<Utc>) -> Result<CachedToken, DomainError> {
+    let resp: TokenResponse =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed token response: {e}")))?;
+    if let Some(err) = resp.error {
+        return Err(fail(format!("token error: {err}")));
+    }
+    let access_token = resp
+        .access_token
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| fail("no access_token in response"))?;
+    let expires_in = resp.expires_in.unwrap_or(3600);
+    Ok(CachedToken {
+        bearer: SecretString::new(access_token.into_boxed_str()),
+        expires_at: now + Duration::seconds(expires_in),
+    })
+}
+
+pub(crate) async fn request_token(
+    client: &reqwest::Client,
+    client_id: &SecretString,
+    client_secret: &SecretString,
+    user_agent: &str,
+    now: DateTime<Utc>,
+) -> Result<CachedToken, DomainError> {
+    let resp = client
+        .post(TOKEN_URL)
+        .basic_auth(client_id.expose_secret(), Some(client_secret.expose_secret()))
+        .header(reqwest::header::USER_AGENT, user_agent)
+        .form(&[("grant_type", "client_credentials")])
+        .send()
+        .await
+        .map_err(|e| fail(format!("token request failed: {e}")))?;
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| fail(format!("token body failed (HTTP {status}): {e}")))?;
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(fail("unauthorized — check client id/secret"));
+    }
+    if !status.is_success() {
+        return Err(fail(format!("token request HTTP {status}")));
+    }
+    parse_token(&body, now)
+}
+```
+
+> If `.form(...)` fails to compile under the current `reqwest` features, replace it with `.header(reqwest::header::CONTENT_TYPE, "application/x-www-form-urlencoded").body("grant_type=client_credentials")` — no feature needed. (`.basic_auth`, `.bearer_auth`, `.query`, `.form` are all part of reqwest's always-compiled `RequestBuilder`; only `.json` is behind the `json` feature.)
+
+- [ ] **Step 4: Run auth tests**
+
+Run: `cargo test -p openintel --lib adapters::sources::reddit::auth`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Write the RedditSource tests**
+
+Add this test module at the bottom of `src/adapters/sources/reddit/mod.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::SecretString;
+
+    fn secret(s: &str) -> SecretString {
+        SecretString::new(s.to_string().into_boxed_str())
+    }
+
+    #[test]
+    fn new_builds_and_kind_is_reddit() {
+        let src = RedditSource::new(secret("id"), secret("sec")).unwrap();
+        assert_eq!(src.kind(), SourceKind::Reddit);
+    }
+
+    #[tokio::test]
+    #[ignore = "hits live Reddit; needs OPENINTEL_REDDIT_CLIENT_ID/SECRET; run with --ignored"]
+    async fn live_fetch_returns_posts() {
+        let id = std::env::var("OPENINTEL_REDDIT_CLIENT_ID").unwrap();
+        let secret = std::env::var("OPENINTEL_REDDIT_CLIENT_SECRET").unwrap();
+        let src = RedditSource::new(
+            SecretString::new(id.into_boxed_str()),
+            SecretString::new(secret.into_boxed_str()),
+        )
+        .unwrap();
+        let posts = src
+            .fetch(&Ticker::parse("AAPL").unwrap(), 10)
+            .await
+            .unwrap();
+        // A live search may legitimately return 0; assert the call succeeded and any post is well-formed.
+        for p in &posts {
+            assert!(!p.id.is_empty());
+            assert!(!p.text.as_str().is_empty());
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `cargo test -p openintel --lib adapters::sources::reddit::tests::new_builds_and_kind_is_reddit`
+Expected: FAIL to compile — `RedditSource` not found.
+
+- [ ] **Step 7: Implement RedditSource + remove the Task-1 allow**
+
+Replace the top of `src/adapters/sources/reddit/mod.rs` (keeping the Step-5 test module at the bottom) so it reads:
+
+```rust
+mod auth;
+mod response;
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use secrecy::{ExposeSecret, SecretString};
+use tokio::sync::RwLock;
+
+use crate::domain::entities::social_post::SocialPost;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::social_data_source::SocialDataSource;
+use crate::domain::values::source_kind::SourceKind;
+use auth::CachedToken;
+
+const SUBS: &str = "wallstreetbets+stocks+options+investing+StockMarket";
+const API_BASE: &str = "https://oauth.reddit.com";
+const TIMEOUT_SECS: u64 = 10;
+
+pub struct RedditSource {
+    client: reqwest::Client,
+    client_id: SecretString,
+    client_secret: SecretString,
+    user_agent: String,
+    token: RwLock<Option<CachedToken>>,
+}
+
+impl RedditSource {
+    pub fn new(client_id: SecretString, client_secret: SecretString) -> Result<Self, DomainError> {
+        let user_agent = format!(
+            "rust:openintel:v{} (by /u/openintel)",
+            env!("CARGO_PKG_VERSION")
+        );
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(TIMEOUT_SECS))
+            .user_agent(&user_agent)
+            .build()
+            .map_err(|e| DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: format!("client build failed: {e}"),
+            })?;
+        Ok(Self {
+            client,
+            client_id,
+            client_secret,
+            user_agent,
+            token: RwLock::new(None),
+        })
+    }
+
+    async fn ensure_token(&self) -> Result<SecretString, DomainError> {
+        let now = Utc::now();
+        {
+            let guard = self.token.read().await;
+            if let Some(t) = guard.as_ref() {
+                if !t.is_expired(now) {
+                    return Ok(t.bearer.clone());
+                }
+            }
+        }
+        let mut guard = self.token.write().await;
+        if let Some(t) = guard.as_ref() {
+            if !t.is_expired(now) {
+                return Ok(t.bearer.clone());
+            }
+        }
+        let fresh = auth::request_token(
+            &self.client,
+            &self.client_id,
+            &self.client_secret,
+            &self.user_agent,
+            now,
+        )
+        .await?;
+        let bearer = fresh.bearer.clone();
+        *guard = Some(fresh);
+        Ok(bearer)
+    }
+}
+
+#[async_trait]
+impl SocialDataSource for RedditSource {
+    fn kind(&self) -> SourceKind {
+        SourceKind::Reddit
+    }
+
+    async fn fetch(&self, ticker: &Ticker, limit: usize) -> Result<Vec<SocialPost>, DomainError> {
+        let bearer = self.ensure_token().await?;
+        let fetched_at = Utc::now();
+        let cashtag = format!("${}", ticker.as_str());
+        let limit_str = limit.min(100).to_string();
+        let url = format!("{API_BASE}/r/{SUBS}/search");
+
+        let resp = self
+            .client
+            .get(url)
+            .query(&[
+                ("q", cashtag.as_str()),
+                ("restrict_sr", "1"),
+                ("sort", "new"),
+                ("type", "link"),
+                ("limit", limit_str.as_str()),
+                ("raw_json", "1"),
+            ])
+            .bearer_auth(bearer.expose_secret())
+            .header(reqwest::header::USER_AGENT, &self.user_agent)
+            .send()
+            .await
+            .map_err(|e| DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: format!("search request failed: {e}"),
+            })?;
+        let status = resp.status();
+        let body = resp.text().await.map_err(|e| DomainError::SourceFailure {
+            name: "reddit".into(),
+            message: format!("search body failed (HTTP {status}): {e}"),
+        })?;
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: "rate limited (HTTP 429)".into(),
+            });
+        }
+        if !status.is_success() {
+            return Err(DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: format!("search HTTP {status}"),
+            });
+        }
+        response::parse_posts(&body, limit, fetched_at)
+    }
+}
+```
+
+Then delete the `#![allow(dead_code)]` line at the top of `src/adapters/sources/reddit/response.rs` — `parse_posts` is now consumed by `fetch`, so it is live in the lib target (the Step 9 clippy run confirms no dead-code warnings).
+
+- [ ] **Step 8: Run tests**
+
+Run: `cargo test -p openintel --lib adapters::sources::reddit`
+Expected: PASS (14 non-ignored: 9 parser + 4 auth + `new_builds…`; the live test is ignored).
+
+- [ ] **Step 9: Lint + format**
+
+Run: `cargo clippy --all-targets -- -D warnings && cargo fmt --check`
+Expected: clean (no dead-code warning now that the allow is removed).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/adapters/sources/reddit/
+git commit -m "feat(reddit): app-only OAuth source with cached token + search"
+```
+
+---
+
+## Task 3: Reddit client credentials in config
+
+**Files:**
+- Modify: `src/config/secrets.rs`
+- Test: unit tests in `secrets.rs`
+
+**Interfaces:**
+- Produces: `Credentials { reddit_client_id: Option<SecretString>, reddit_client_secret: Option<SecretString>, x_bearer, bluesky_app_password, market_api_key }`, read from `OPENINTEL_REDDIT_CLIENT_ID` / `OPENINTEL_REDDIT_CLIENT_SECRET`.
+
+- [ ] **Step 1: Update the struct + `from_env`**
+
+In `src/config/secrets.rs`, replace the `reddit_token` field and its `from_env` line so the struct reads:
+
+```rust
+#[derive(Debug)]
+pub struct Credentials {
+    pub reddit_client_id: Option<SecretString>,
+    pub reddit_client_secret: Option<SecretString>,
+    pub x_bearer: Option<SecretString>,
+    pub bluesky_app_password: Option<SecretString>,
+    pub market_api_key: Option<SecretString>,
+}
+
+impl Credentials {
+    pub fn from_env() -> Self {
+        Credentials {
+            reddit_client_id: secret_from(std::env::var("OPENINTEL_REDDIT_CLIENT_ID").ok()),
+            reddit_client_secret: secret_from(std::env::var("OPENINTEL_REDDIT_CLIENT_SECRET").ok()),
+            x_bearer: secret_from(std::env::var("OPENINTEL_X_BEARER").ok()),
+            bluesky_app_password: secret_from(std::env::var("OPENINTEL_BLUESKY_APP_PASSWORD").ok()),
+            market_api_key: secret_from(std::env::var("OPENINTEL_MARKET_API_KEY").ok()),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update the leak test**
+
+In the `#[cfg(test)] mod tests`, update `debug_does_not_leak_secret` to use the new field:
+
+```rust
+    #[test]
+    fn debug_does_not_leak_secret() {
+        let creds = Credentials {
+            reddit_client_id: secret_from(Some("leak-me".to_string())),
+            reddit_client_secret: None,
+            x_bearer: None,
+            bluesky_app_password: None,
+            market_api_key: None,
+        };
+        assert!(!format!("{creds:?}").contains("leak-me"));
+    }
+```
+
+(The `wraps_present_value_and_skips_absent` test uses `secret_from` directly and needs no change.)
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p openintel --lib config::secrets`
+Expected: PASS (2 tests).
+
+- [ ] **Step 4: Lint + format + commit**
+
+Run: `cargo clippy --all-targets -- -D warnings && cargo fmt --check`
+Expected: clean.
+
+```bash
+git add src/config/secrets.rs
+git commit -m "feat(config): Reddit client id/secret env credentials"
+```
+
+---
+
+## Task 4: Inject social sources; wire Reddit at composition roots
+
+Pure DI refactor mirroring the market-source injection: thread `social_sources: &[Box<dyn SocialDataSource>]` through the analysis path, build the list at the entry points (Reddit only when both creds are set), and inject mocks in tests. Behavior on mock input is unchanged.
+
+**Files:**
+- Modify: `src/application/analyze.rs`, `src/cli/run.rs`, `src/main.rs`, `src/mcp/tools.rs`, `src/mcp/server.rs`, `tests/analyze_flow.rs`
+
+**Interfaces:**
+- Consumes: `RedditSource::new(...) -> Result<Self, DomainError>` (Task 2); `Credentials` fields (Task 3); the existing `MockRedditSource`/`MockXSource`/`MockBlueskySource` (unit structs, `impl SocialDataSource`).
+- Produces (new signatures):
+  - `application::analyze(req: &AnalysisRequest, social_sources: &[Box<dyn SocialDataSource>], market_source: Option<&dyn MarketDataSource>) -> Result<SpeculationReport, DomainError>`
+  - `cli::run::analyze(config: &AppConfig, social_sources: &[Box<dyn SocialDataSource>], market_source: Option<&dyn MarketDataSource>) -> Result<(SpeculationReport, String), DomainError>`
+  - `mcp::tools::run_list_sources(social_sources: &[Box<dyn SocialDataSource>], market_source: &dyn MarketDataSource) -> SourcesOutput`
+  - `mcp::tools::run_analyze / run_scan / run_compare(args, social_sources: &[Box<dyn SocialDataSource>], market_source: &dyn MarketDataSource)`
+  - `mcp::server::OpenIntelServer::new(social: Vec<Box<dyn SocialDataSource>>, market: YahooMarketSource)` (field `social: std::sync::Arc<Vec<Box<dyn SocialDataSource>>>`)
+
+- [ ] **Step 1: `application::analyze` — inject social sources, drop `build_sources`**
+
+In `src/application/analyze.rs`: delete the `build_sources` function and the mock-source `use` lines it needed (`MockBlueskySource`, `MockRedditSource`, `MockXSource`). Add `use crate::domain::ports::social_data_source::SocialDataSource;` if not present. Change `analyze`:
+
+```rust
+pub async fn analyze(
+    req: &AnalysisRequest,
+    social_sources: &[Box<dyn SocialDataSource>],
+    market_source: Option<&dyn MarketDataSource>,
+) -> Result<SpeculationReport, DomainError> {
+    let ticker = Ticker::parse(&req.ticker)?;
+
+    let mut notes: Vec<String> = Vec::new();
+    for kind in &req.enabled_sources {
+        if !social_sources.iter().any(|s| s.kind() == *kind) {
+            notes.push(format!("{} enabled but not configured", kind.as_str()));
+        }
+    }
+
+    let fetches = social_sources
+        .iter()
+        .filter(|s| req.enabled_sources.contains(&s.kind()))
+        .map(|source| {
+            let ticker = ticker.clone();
+            async move { (source.kind(), source.fetch(&ticker, req.limit).await) }
+        });
+    let results = join_all(fetches).await;
+
+    let mut posts: Vec<SocialPost> = Vec::new();
+    for (kind, result) in results {
+        match result {
+            Ok(mut fetched) => posts.append(&mut fetched),
+            Err(e) => notes.push(format!("source {} failed: {e}", kind.as_str())),
+        }
+    }
+
+    let market: Option<MarketSnapshot> = match (req.market_enabled, market_source) {
+        (true, Some(source)) => match source.snapshot(&ticker).await {
+            Ok(snapshot) => Some(snapshot),
+            Err(e) => {
+                notes.push(format!("market source failed: {e}"));
+                None
+            }
+        },
+        _ => None,
+    };
+
+    if posts.is_empty() && market.is_none() {
+        return Err(DomainError::NoData);
+    }
+
+    let analyzer = LexiconAnalyzer::new();
+    let signals = analyzer.analyze(&posts).await?;
+
+    let now = Utc::now();
+    let mut report =
+        SpeculationEngine::aggregate(&ticker, &posts, &signals, market.as_ref(), now, &req.engine)?;
+
+    let engine_notes = std::mem::take(&mut report.fusion.notes);
+    report.fusion.notes = notes.into_iter().chain(engine_notes).collect();
+
+    Ok(report)
+}
+```
+
+Update the `#[cfg(test)] mod tests`: add a mock-list helper and pass it. Replace the test module's helpers/calls:
+
+```rust
+    use crate::adapters::market::mock_market::MockMarketSource;
+    use crate::adapters::sources::mock_bluesky::MockBlueskySource;
+    use crate::adapters::sources::mock_reddit::MockRedditSource;
+    use crate::adapters::sources::mock_x::MockXSource;
+
+    fn mock_social() -> Vec<Box<dyn SocialDataSource>> {
+        vec![
+            Box::new(MockRedditSource),
+            Box::new(MockXSource),
+            Box::new(MockBlueskySource),
+        ]
+    }
+
+    #[tokio::test]
+    async fn analyzes_default_request_confirming_bullish() {
+        use crate::domain::values::speculation::Alignment;
+        let report = analyze(&req("AAPL", true), &mock_social(), Some(&MockMarketSource))
+            .await
+            .unwrap();
+        assert_eq!(report.social.total_mentions, 10);
+        assert_eq!(report.fusion.alignment, Alignment::ConfirmingBullish);
+        assert!(report.market.is_some());
+    }
+
+    #[tokio::test]
+    async fn invalid_ticker_errors() {
+        assert!(
+            analyze(&req("$$$", true), &mock_social(), Some(&MockMarketSource))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn social_only_when_no_source_provided() {
+        use crate::domain::values::speculation::Alignment;
+        let report = analyze(&req("AAPL", false), &mock_social(), None)
+            .await
+            .unwrap();
+        assert!(report.market.is_none());
+        assert_eq!(report.fusion.alignment, Alignment::Quiet);
+    }
+
+    #[tokio::test]
+    async fn enabled_source_absent_is_noted() {
+        // reddit enabled but not wired -> note + other sources still counted (x=3, bluesky=3)
+        let social: Vec<Box<dyn SocialDataSource>> =
+            vec![Box::new(MockXSource), Box::new(MockBlueskySource)];
+        let report = analyze(&req("AAPL", false), &social, None).await.unwrap();
+        assert_eq!(report.social.total_mentions, 6);
+        assert!(report
+            .fusion
+            .notes
+            .iter()
+            .any(|n| n.contains("reddit enabled but not configured")));
+    }
+```
+
+- [ ] **Step 2: `cli::run::analyze` — inject and forward**
+
+In `src/cli/run.rs`: add `use crate::domain::ports::social_data_source::SocialDataSource;`. Change the signature + forward:
+
+```rust
+pub async fn analyze(
+    config: &AppConfig,
+    social_sources: &[Box<dyn SocialDataSource>],
+    market_source: Option<&dyn MarketDataSource>,
+) -> Result<(SpeculationReport, String), DomainError> {
+    let req = AnalysisRequest {
+        ticker: config.ticker.clone(),
+        enabled_sources: config.enabled_sources.clone(),
+        market_enabled: config.market_enabled,
+        limit: config.limit,
+        engine: config.engine.clone(),
+    };
+    let report = application::analyze(&req, social_sources, market_source).await?;
+    let rendered = render(&report, config.format);
+    Ok((report, rendered))
+}
+```
+
+Update its tests: add the same `mock_social()` helper and thread it. The market-enabled cases pass `Some(&MockMarketSource)`, the `no_market` case passes `None`:
+
+```rust
+    use crate::adapters::market::mock_market::MockMarketSource;
+    use crate::adapters::sources::mock_bluesky::MockBlueskySource;
+    use crate::adapters::sources::mock_reddit::MockRedditSource;
+    use crate::adapters::sources::mock_x::MockXSource;
+
+    fn mock_social() -> Vec<Box<dyn SocialDataSource>> {
+        vec![
+            Box::new(MockRedditSource),
+            Box::new(MockXSource),
+            Box::new(MockBlueskySource),
+        ]
+    }
+
+    #[tokio::test]
+    async fn full_run_confirms_bullish_with_market() {
+        let (report, rendered) = analyze(
+            &config(false, OutputFormat::Json),
+            &mock_social(),
+            Some(&MockMarketSource),
+        )
+        .await
+        .unwrap();
+        assert!(report.market.is_some());
+        assert_eq!(report.fusion.alignment, Alignment::ConfirmingBullish);
+        assert!(rendered.contains("Not financial advice"));
+        assert!(rendered.contains("speculation_index"));
+    }
+
+    #[tokio::test]
+    async fn no_market_run_is_quiet() {
+        let (report, _) = analyze(&config(true, OutputFormat::Table), &mock_social(), None)
+            .await
+            .unwrap();
+        assert!(report.market.is_none());
+        assert_eq!(report.fusion.alignment, Alignment::Quiet);
+    }
+
+    #[tokio::test]
+    async fn table_output_has_sections_and_disclaimer() {
+        let (_, rendered) = analyze(
+            &config(false, OutputFormat::Table),
+            &mock_social(),
+            Some(&MockMarketSource),
+        )
+        .await
+        .unwrap();
+        assert!(rendered.contains("SOCIAL"));
+        assert!(rendered.contains("MARKET"));
+        assert!(rendered.contains("FUSION"));
+        assert!(rendered.contains("Not financial advice"));
+    }
+
+    #[tokio::test]
+    async fn invalid_ticker_errors() {
+        let cfg = AppConfig::new("$$$".into(), false, false, false, false, 50, OutputFormat::Table);
+        assert!(analyze(&cfg, &mock_social(), Some(&MockMarketSource))
+            .await
+            .is_err());
+    }
+```
+
+- [ ] **Step 3: `main.rs` — build the social list from credentials**
+
+Replace the `Command::Analyze` branch body in `src/main.rs` (and add imports `use openintel::adapters::sources::reddit::RedditSource;`, `use openintel::adapters::sources::mock_bluesky::MockBlueskySource;`, `use openintel::adapters::sources::mock_x::MockXSource;`, `use openintel::domain::ports::social_data_source::SocialDataSource;`). Change the `_credentials` binding to `credentials` and build the list:
+
+```rust
+        Command::Analyze(args) => {
+            let config = to_app_config(&args);
+
+            let mut social: Vec<Box<dyn SocialDataSource>> = Vec::new();
+            if let (Some(id), Some(secret)) =
+                (credentials.reddit_client_id, credentials.reddit_client_secret)
+            {
+                match RedditSource::new(id, secret) {
+                    Ok(src) => social.push(Box::new(src)),
+                    Err(e) => eprintln!("warning: reddit disabled: {e}"),
+                }
+            }
+            social.push(Box::new(MockXSource));
+            social.push(Box::new(MockBlueskySource));
+
+            let outcome = if config.market_enabled {
+                let market = match YahooMarketSource::new() {
+                    Ok(m) => m,
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        return ExitCode::FAILURE;
+                    }
+                };
+                analyze(&config, &social, Some(&market)).await
+            } else {
+                analyze(&config, &social, None).await
+            };
+            match outcome {
+                Ok((_report, rendered)) => {
+                    println!("{rendered}");
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
+```
+
+Change the credentials line above the `match` from `let _credentials = Credentials::from_env();` to `let credentials = Credentials::from_env();` and update its comment to `// Reddit client credentials (if set) enable the real Reddit source; other sources need none.`
+
+- [ ] **Step 4: `mcp::tools` — thread the social slice through all four functions**
+
+In `src/mcp/tools.rs`, add `use crate::domain::ports::social_data_source::SocialDataSource;`. Change:
+
+`run_list_sources` to report the wired social sources:
+
+```rust
+pub fn run_list_sources(
+    social_sources: &[Box<dyn SocialDataSource>],
+    market_source: &dyn MarketDataSource,
+) -> SourcesOutput {
+    SourcesOutput {
+        social: social_sources
+            .iter()
+            .map(|s| s.kind().as_str().to_string())
+            .collect(),
+        market: vec![market_source.name().to_string()],
+    }
+}
+```
+
+`run_analyze` — accept and forward:
+
+```rust
+pub async fn run_analyze(
+    args: AnalyzeArgs,
+    social_sources: &[Box<dyn SocialDataSource>],
+    market_source: &dyn MarketDataSource,
+) -> Result<AnalyzeOutput, DomainError> {
+    let req = request_from(
+        args.ticker,
+        args.enable_reddit,
+        args.enable_x,
+        args.enable_bluesky,
+        args.no_market,
+        args.limit,
+    );
+    let report = application::analyze(&req, social_sources, Some(market_source)).await?;
+    Ok(AnalyzeOutput {
+        summary: summarize(&report),
+        report,
+        disclaimer: DISCLAIMER,
+    })
+}
+```
+
+`run_scan` — accept the slice; each concurrent closure captures both `&[...]` and `&dyn` by copy:
+
+```rust
+pub async fn run_scan(
+    args: ScanArgs,
+    social_sources: &[Box<dyn SocialDataSource>],
+    market_source: &dyn MarketDataSource,
+) -> ScanOutput {
+    let ScanArgs {
+        tickers,
+        enable_reddit,
+        enable_x,
+        enable_bluesky,
+        no_market,
+        limit,
+    } = args;
+    let futures = tickers.into_iter().map(|t| async move {
+        let req = request_from(t.clone(), enable_reddit, enable_x, enable_bluesky, no_market, limit);
+        match application::analyze(&req, social_sources, Some(market_source)).await {
+            Ok(report) => ScanEntry {
+                ticker: t,
+                report: Some(report),
+                error: None,
+            },
+            Err(e) => ScanEntry {
+                ticker: t,
+                report: None,
+                error: Some(e.to_string()),
+            },
+        }
+    });
+    let entries = futures::future::join_all(futures).await;
+    ScanOutput {
+        entries,
+        disclaimer: DISCLAIMER,
+    }
+}
+```
+
+`run_compare` — same threading:
+
+```rust
+pub async fn run_compare(
+    args: CompareArgs,
+    social_sources: &[Box<dyn SocialDataSource>],
+    market_source: &dyn MarketDataSource,
+) -> CompareOutput {
+    let CompareArgs {
+        tickers,
+        rank_by,
+        enable_reddit,
+        enable_x,
+        enable_bluesky,
+        no_market,
+        limit,
+    } = args;
+    let futures = tickers.into_iter().map(|t| async move {
+        let req = request_from(t.clone(), enable_reddit, enable_x, enable_bluesky, no_market, limit);
+        (t, application::analyze(&req, social_sources, Some(market_source)).await)
+    });
+    let results = futures::future::join_all(futures).await;
+
+    let mut ranked: Vec<RankedEntry> = Vec::new();
+    let mut errors: Vec<CompareError> = Vec::new();
+    for (ticker, res) in results {
+        match res {
+            Ok(report) => {
+                let metric = rank_metric(&report, rank_by);
+                ranked.push(RankedEntry { ticker, rank_metric: metric, report });
+            }
+            Err(e) => errors.push(CompareError { ticker, error: e.to_string() }),
+        }
+    }
+    sort_ranked(&mut ranked, rank_by);
+
+    CompareOutput { rank_by, ranked, errors, disclaimer: DISCLAIMER }
+}
+```
+
+Update the `#[cfg(test)] mod tests`: add the mock helpers and thread them. Add the imports and helper at the top of the test module, and pass `&mock_social()` + `&MockMarketSource`:
+
+```rust
+    use crate::adapters::market::mock_market::MockMarketSource;
+    use crate::adapters::sources::mock_bluesky::MockBlueskySource;
+    use crate::adapters::sources::mock_reddit::MockRedditSource;
+    use crate::adapters::sources::mock_x::MockXSource;
+
+    fn mock_social() -> Vec<Box<dyn SocialDataSource>> {
+        vec![
+            Box::new(MockRedditSource),
+            Box::new(MockXSource),
+            Box::new(MockBlueskySource),
+        ]
+    }
+```
+
+Then update each call:
+- `list_sources_reports_all_adapters`: `run_list_sources(&mock_social(), &MockMarketSource)` — assertion `vec!["reddit","x","bluesky"]` and `vec!["mock-market"]` still hold (mock_social is in reddit/x/bluesky order).
+- `run_analyze(args, ...)` → `run_analyze(args, &mock_social(), &MockMarketSource)` (both tests).
+- `run_scan(ScanArgs {...}, ...)` → `run_scan(ScanArgs {...}, &mock_social(), &MockMarketSource)` (both tests).
+- `run_compare(CompareArgs {...}, ...)` → `run_compare(CompareArgs {...}, &mock_social(), &MockMarketSource)`.
+- `sort_ranked_orders_by_crowding_desc` calls no `run_*` — leave unchanged.
+
+- [ ] **Step 5: `mcp::server` — own the social list; build it in `serve()`**
+
+In `src/mcp/server.rs`, add imports:
+
+```rust
+use std::sync::Arc;
+
+use crate::adapters::sources::mock_bluesky::MockBlueskySource;
+use crate::adapters::sources::mock_x::MockXSource;
+use crate::adapters::sources::reddit::RedditSource;
+use crate::adapters::market::yahoo::YahooMarketSource;
+use crate::config::secrets::Credentials;
+use crate::domain::ports::social_data_source::SocialDataSource;
+```
+
+Change the struct + constructor:
+
+```rust
+#[derive(Clone)]
+pub struct OpenIntelServer {
+    tool_router: ToolRouter<OpenIntelServer>,
+    social: Arc<Vec<Box<dyn SocialDataSource>>>,
+    market: YahooMarketSource,
+}
+
+impl OpenIntelServer {
+    pub fn new(social: Vec<Box<dyn SocialDataSource>>, market: YahooMarketSource) -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            social: Arc::new(social),
+            market,
+        }
+    }
+}
+```
+
+Pass `&self.social` + `&self.market` in each tool method body:
+- `list_sources`: `tools::run_list_sources(&self.social, &self.market)`
+- `analyze_ticker`: `tools::run_analyze(args, &self.social, &self.market).await`
+- `scan_watchlist`: `tools::run_scan(args, &self.social, &self.market).await`
+- `compare_tickers`: `tools::run_compare(args, &self.social, &self.market).await`
+
+Build both sources in `serve()`:
+
+```rust
+pub async fn serve() -> Result<(), Box<dyn std::error::Error>> {
+    let credentials = Credentials::from_env();
+    let mut social: Vec<Box<dyn SocialDataSource>> = Vec::new();
+    if let (Some(id), Some(secret)) =
+        (credentials.reddit_client_id, credentials.reddit_client_secret)
+    {
+        match RedditSource::new(id, secret) {
+            Ok(src) => social.push(Box::new(src)),
+            Err(e) => eprintln!("warning: reddit disabled: {e}"),
+        }
+    }
+    social.push(Box::new(MockXSource));
+    social.push(Box::new(MockBlueskySource));
+
+    let market = YahooMarketSource::new()?;
+    let service = OpenIntelServer::new(social, market).serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}
+```
+
+- [ ] **Step 6: `tests/analyze_flow.rs` — inject the mock social list**
+
+In `tests/analyze_flow.rs`, add imports + helper and thread through the three calls (the market-disabled one passes `None`):
+
+```rust
+use openintel::adapters::market::mock_market::MockMarketSource;
+use openintel::adapters::sources::mock_bluesky::MockBlueskySource;
+use openintel::adapters::sources::mock_reddit::MockRedditSource;
+use openintel::adapters::sources::mock_x::MockXSource;
+use openintel::domain::ports::social_data_source::SocialDataSource;
+
+fn mock_social() -> Vec<Box<dyn SocialDataSource>> {
+    vec![
+        Box::new(MockRedditSource),
+        Box::new(MockXSource),
+        Box::new(MockBlueskySource),
+    ]
+}
+```
+
+- `end_to_end_all_sources_with_market`: `analyze(&cfg(false, false, false, false), &mock_social(), Some(&MockMarketSource))`
+- `single_source_only`: `analyze(&cfg(true, false, false, false), &mock_social(), Some(&MockMarketSource))`
+- `social_only_when_market_disabled`: `analyze(&cfg(false, false, false, true), &mock_social(), None)`
+
+- [ ] **Step 7: Run the whole suite (green + hermetic)**
+
+Run: `cargo test`
+Expected: PASS — all prior tests plus Task 1/2/3 tests; only the Reddit + Yahoo live tests are `#[ignore]`d. No network during the run.
+
+- [ ] **Step 8: Lint + format + build**
+
+Run: `cargo clippy --all-targets -- -D warnings && cargo fmt --check && cargo build`
+Expected: clean; binary builds.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/application/analyze.rs src/cli/run.rs src/main.rs src/mcp/tools.rs src/mcp/server.rs tests/analyze_flow.rs
+git commit -m "refactor: inject social sources; wire Reddit at composition roots"
+```
+
+---
+
+## Task 5: Docs
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update the Quickstart data-source note**
+
+In `README.md`, replace the Quickstart caveat line (the `> **Market data is live …` block) with:
+
+```
+> **Market data is live (Yahoo Finance, keyless). Reddit is live when configured (OAuth — see below); X and Bluesky are still mock.** `analyze` fetches over the network — offline or unconfigured sources degrade gracefully with a note.
+```
+
+- [ ] **Step 2: Add a Reddit setup section**
+
+In `README.md`, immediately after the `## Usage` flags table, add:
+
+```
+## Enable the Reddit source (optional)
+
+Reddit requires OAuth (there is no keyless access). One-time setup:
+
+1. Create a **script** app at <https://www.reddit.com/prefs/apps> → note the **client id** (under the app name) and **secret**.
+2. Export them before running:
+
+```bash
+export OPENINTEL_REDDIT_CLIENT_ID=your_client_id
+export OPENINTEL_REDDIT_CLIENT_SECRET=your_secret
+openintel analyze AAPL --enable-reddit
+```
+
+Without these, `--enable-reddit` yields a `reddit enabled but not configured` note and the other sources still run. Credentials are read only from the environment, wrapped in `SecretString` (never logged or written to disk), and sent only to Reddit over TLS.
+```
+
+- [ ] **Step 3: Update the Extending note for social sources**
+
+In the `## Extending` section, replace the "Add a social source" block:
+
+```
+**Add a social source** (e.g. real Reddit):
+1. New struct in `src/adapters/sources/`, `impl SocialDataSource`.
+2. Add a `SourceKind` variant in `src/domain/values/source_kind.rs`.
+3. Add one arm to `build_sources` in `src/cli/run.rs`.
+```
+
+with:
+
+```
+**Add a social source** (e.g. real Bluesky):
+1. New struct in `src/adapters/sources/`, `impl SocialDataSource`.
+2. Add a `SourceKind` variant in `src/domain/values/source_kind.rs` if new.
+3. Construct it at the composition roots — `main.rs` (analyze branch) and `mcp::server::serve()` — and push it onto the injected social list. No engine or application change.
+```
+
+- [ ] **Step 4: Update the secrets paragraph**
+
+In the `## Architecture` section, update the secrets sentence to list the Reddit variables:
+
+Replace `OPENINTEL_REDDIT_TOKEN` in the environment-variables sentence with `OPENINTEL_REDDIT_CLIENT_ID`, `OPENINTEL_REDDIT_CLIENT_SECRET`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: Reddit OAuth setup + injected social-source extending note"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- App-only `client_credentials` OAuth (token endpoint, Basic auth, bearer) → Task 2 `auth.rs`. ✓
+- Mandatory descriptive User-Agent → Task 2 `RedditSource::new` + every request. ✓
+- Env-only `SecretString` creds (`CLIENT_ID`/`CLIENT_SECRET`, replacing `REDDIT_TOKEN`) → Task 3. ✓
+- Token caching + 60s-skew refresh → Task 2 `CachedToken`/`ensure_token`. ✓
+- Finance-subreddit search + field mapping (id/author/text/created/score→engagement) → Task 1 `parse_posts` + Task 2 request. ✓
+- Graceful absence note → Task 4 `analyze` + composition roots. ✓
+- Social-side DI at composition roots, mocks in tests → Task 4. ✓
+- `SourceFailure`-only errors, no `unwrap` on network data → Tasks 1/2. ✓
+- Hermetic tests + one `#[ignore]` live test → Tasks 1/2 units, Task 2 live test, Task 4 Step 7. ✓
+- README setup → Task 5. ✓
+- Non-goals (submissions only, fixed subs, no retry/keychain) → honored. ✓
+
+**Type consistency:** `parse_posts(body, limit, fetched_at)` produced in Task 1, consumed in Task 2. `RedditSource::new(SecretString, SecretString) -> Result` produced in Task 2, consumed in Task 4 roots. `social_sources: &[Box<dyn SocialDataSource>]` identical across `application::analyze`, `cli::run::analyze`, the four `mcp::tools` fns, and the mock `mock_social()` helper. `Credentials.reddit_client_id/reddit_client_secret` produced in Task 3, consumed in Task 4. Server field `Arc<Vec<Box<dyn SocialDataSource>>>` is `Clone`, preserving `#[derive(Clone)]`.
+
+**Placeholder scan:** No TBD/TODO; every code step contains complete code, including the `.form()` fallback note.

--- a/docs/superpowers/specs/2026-07-01-reddit-social-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-01-reddit-social-adapter-design.md
@@ -1,0 +1,221 @@
+# Reddit OAuth Social Adapter — Design
+
+**Date:** 2026-07-01
+**Status:** Draft — awaiting user review (open items flagged inline)
+
+## Goal
+
+Add a real Reddit `SocialDataSource` that searches finance subreddits for a
+ticker via Reddit's app-only OAuth API and returns real `SocialPost`s,
+replacing the mock Reddit fixtures in the production path. Mirrors the Yahoo
+market adapter: fetch/parse split, injected via DI, hermetic tests. X and
+Bluesky stay mock (X is paid-only; Bluesky is keyless but sparse on tickers —
+each is a separate future cycle).
+
+## Why Reddit via OAuth (not keyless)
+
+Verified empirically 2026-07-01: **every** unauthenticated Reddit endpoint
+(`www`/`old`/subreddit listing/`oauth` without token, browser UA included)
+returns HTTP 403 with Reddit's block page. This is policy (post-2023 API
+lockdown), not an IP fluke — there is no keyless path like Yahoo had. Reddit
+(r/wallstreetbets, r/stocks, r/options) is the richest retail-trading
+sentiment source, so the signal quality justifies a one-time app registration.
+
+## Auth — app-only OAuth (`client_credentials`)
+
+Verified against Reddit's OAuth2 + API wiki (2026-07-01):
+
+- One-time user setup: register a **script** (or web) app at
+  `reddit.com/prefs/apps` → `client_id` + `client_secret`.
+- Token request: `POST https://www.reddit.com/api/v1/access_token`, body
+  `grant_type=client_credentials`, HTTP Basic auth (`client_id`:`client_secret`),
+  plus the required `User-Agent` header.
+- Response: `{ access_token, token_type: "bearer", expires_in: <seconds>, scope }`.
+  No refresh token for app-only.
+- API calls: `https://oauth.reddit.com/...` with `Authorization: bearer <token>`
+  and the `User-Agent` header.
+- **User-Agent is mandatory and enforced.** Format
+  `<platform>:<app-id>:<version> (by /u/<user>)`; generic UAs (`python`, `Java`)
+  are "drastically limited." The adapter sends a hardcoded descriptive UA:
+  `rust:openintel:v{CARGO_PKG_VERSION} (by /u/openintel)`.
+  *(Open item C — see below: hardcode vs. env override.)*
+- Rate limit: 60 requests/min for OAuth; `X-Ratelimit-{Used,Remaining,Reset}`
+  headers report status. One search per ticker is well within budget → no
+  rate-limit accounting in v1; a 429 degrades gracefully (below).
+
+## Secret handling
+
+**Model: env-var + `secrecy::SecretString` (consistent with existing
+credentials).** *(Open item — user asked about this; keychain is a documented
+future opt-in, see below.)*
+
+- New secrets: `OPENINTEL_REDDIT_CLIENT_ID` + `OPENINTEL_REDDIT_CLIENT_SECRET`,
+  replacing the unused `OPENINTEL_REDDIT_TOKEN` scaffold in `Credentials`.
+- Both wrapped in `secrecy::SecretString` — `Debug`/`Display` redacted (existing
+  `debug_does_not_leak_secret` test extended), memory zeroized on drop.
+- Env-only: never written to disk, never logged. Sent only to Reddit's token
+  endpoint over rustls TLS, as HTTP Basic auth. The derived bearer token lives
+  in memory (the cache) and is likewise never logged.
+- The MCP AI agent never sees the secrets — they stay in the openintel process
+  environment; the agent only calls read-only tools.
+- **Threat model (honest):** env vars are readable by same-user processes and
+  can leak into shell history if exported inline. Standard for a local
+  single-user CLI. Mitigation guidance in the README (gitignored `.env` +
+  direnv; `read -s`).
+- **Future opt-in (deferred, YAGNI):** OS keychain (macOS Keychain / Linux
+  Secret Service / Windows Credential Manager via the `keyring` crate) with a
+  keychain→env lookup order. This is localized to `config/secrets.rs` and
+  touches no callers, so choosing env-var now does not preclude it.
+
+## Graceful absence
+
+If the Reddit creds are unset, the composition root does not wire the Reddit
+source. Enabling `--enable-reddit` (or the MCP `enable_reddit`) without creds
+yields the note `"reddit: not configured (set OPENINTEL_REDDIT_CLIENT_ID and
+OPENINTEL_REDDIT_CLIENT_SECRET)"`; the market snapshot and other social sources
+still run. (This reuses the application layer's existing per-source note +
+continue behavior.)
+
+## Adapter structure (fetch/parse split, mirroring Yahoo)
+
+```
+src/adapters/sources/reddit/
+  mod.rs       RedditSource { client, client_id, client_secret, user_agent,
+                              token: tokio::sync::RwLock<Option<CachedToken>> }
+                 - new(client_id, client_secret) -> Self
+                 - impl SocialDataSource: kind() -> Reddit
+                     fetch(): ensure_token() → GET search → response::parse_posts
+  auth.rs      CachedToken { bearer: SecretString, expires_at: DateTime<Utc> }
+                 - is_expired(now) (pure, unit-tested; 60s skew margin)
+                 - request_token(client, id, secret, ua) → CachedToken  (the OAuth call)
+                 - ensure_token(&self): return a valid bearer, refreshing if expired
+  response.rs  serde DTOs + parse_posts(body, limit) -> Result<Vec<SocialPost>, DomainError>
+                 - pure, deterministic, fully unit-tested with fixture JSON
+```
+
+The HTTP calls (token POST, search GET) are the only impure parts. Token
+caching uses `RwLock` interior mutability because the port's `fetch(&self, …)`
+is `&self`; one token is reused across a `scan_watchlist` sweep.
+
+## Data flow — query & mapping
+
+Request (one call, curated finance subs):
+
+```
+GET https://oauth.reddit.com/r/wallstreetbets+stocks+options+investing+StockMarket/search
+      ?q=$TICKER&restrict_sr=1&sort=new&type=link&limit={min(limit,100)}&raw_json=1
+Headers: Authorization: bearer <token>,  User-Agent: <required UA>
+```
+
+- `restrict_sr=1` keeps results within the listed subs; `sort=new` for recency;
+  `type=link` = submissions; `raw_json=1` disables HTML entity escaping.
+- `q=$TICKER` (dollar-prefixed cashtag) + subreddit restriction reduces
+  false positives. *(Open item A — subreddit set.)*
+
+Response is a Listing: `{ kind: "Listing", data: { children: [ { kind: "t3",
+data: {...} } ] } }`. Map each `child.data` → `SocialPost`:
+
+| Field | Rule |
+|---|---|
+| `id` | `name` (e.g. `t3_abc`) → fallback `id` |
+| `author` | `author` (may be `"[deleted]"` — kept as-is) |
+| `text` | `title`, plus `"\n" + selftext` when `selftext` is non-empty, truncated to `PostText`'s 10k-char cap before `PostText::parse`; skip the post if the parsed text is empty |
+| `created_at` | `created_utc` (f64 seconds) → `DateTime<Utc>` |
+| `engagement` | `score.max(0) as u32` (Reddit scores can be negative) |
+| `source` | `SourceKind::Reddit` |
+
+*(Open item B — `text` = title+selftext, `engagement` = clamped score.)*
+`limit` is honored via the request param and a final `take(limit)`.
+
+## Social-side DI (parallel to the market DI)
+
+`build_sources` is currently hardcoded to mocks. Replace with injection:
+
+- `application::analyze(req, social_sources: &[Box<dyn SocialDataSource>],
+  market_source: Option<&dyn MarketDataSource>)` — filters `social_sources` by
+  `req.enabled_sources` via `source.kind()`, fetches the enabled ones.
+- Signatures updated the same way through `cli::run::analyze` and the three
+  `mcp::tools` run functions; `run_list_sources` reports the actually-wired
+  social sources (so an agent can see whether Reddit is live).
+- Composition roots build the source list:
+  - **production:** `[MockXSource, MockBlueskySource]` + `RedditSource` when
+    both creds are present.
+  - **tests:** `[MockRedditSource, MockXSource, MockBlueskySource]` (assertions
+    unchanged — mock data is identical).
+- The MCP server holds the social source `Vec` (built once at `serve()`),
+  passing `&self.social` into the tools alongside `&self.market`.
+
+Two injected params (social slice + optional market) is the full set of IO
+ports for now; a `Deps` struct is a future consolidation if the analyzer
+(`PostAnalyzer`) is later injected too (YAGNI now).
+
+## Error handling
+
+All failures → `DomainError::SourceFailure { name: "reddit", message }`:
+
+- token request non-2xx / transport / timeout → `"token request failed: …"`
+- 401 on token or search → `"unauthorized — check client id/secret"`
+- 429 → `"rate limited"` (include `X-Ratelimit-Reset` when present)
+- search non-2xx / malformed JSON → `SourceFailure`
+- **No `unwrap`/`expect` on network data.**
+
+The application layer already catches a failed source into a note and continues
+with the remaining sources.
+
+## Testing
+
+Hermetic by default — `cargo test` never touches the network.
+
+- **Pure `parse_posts` unit tests** (fixture Listing JSON): happy multi-post,
+  `[deleted]` author, empty `selftext` (title only), negative `score` → `0`,
+  over-10k `text` truncation, empty `children`, missing optional fields.
+- **`CachedToken::is_expired`** unit-tested with fixed `now` values (incl. the
+  60s skew margin).
+- **OAuth / HTTP paths** are not unit-testable without live creds → one
+  `#[ignore]`d live test reading `OPENINTEL_REDDIT_CLIENT_ID`/`SECRET` from env
+  (asserts a non-empty search returns ≥0 posts with valid fields); skipped in CI.
+- **Social DI:** existing tests inject `[MockReddit, MockX, MockBluesky]`
+  (assertions unchanged); add a test that enabling reddit with no wired source
+  produces the "not configured" note and still returns other sources.
+
+## Config change
+
+- `Credentials`: replace `reddit_token` with `reddit_client_id` +
+  `reddit_client_secret` (`Option<SecretString>`); update `from_env` and the
+  secret tests.
+- README: Reddit setup (register app → env vars), that it's the richest signal,
+  and that keyless Reddit is not available.
+
+## Non-goals (YAGNI)
+
+- Comment fetching (submissions only).
+- Configurable subreddits / query tuning (curated set is fixed in v1).
+- OS keychain secret storage (documented future opt-in).
+- X (paid) and Bluesky (keyless, sparse) adapters — separate future cycles.
+- Retry/backoff beyond graceful degradation.
+
+## Open items for review
+
+- **A. Subreddit set** — `wallstreetbets + stocks + options + investing +
+  StockMarket`. Good default?
+- **B. Mapping** — `text` = title (+ selftext), `engagement` = `score.max(0)`.
+  Reasonable?
+- **C. User-Agent** — hardcoded `rust:openintel:v{version} (by /u/openintel)`
+  vs. an `OPENINTEL_REDDIT_USER_AGENT` override. Recommendation: hardcoded v1.
+- **Secret storage** — env-var (recommended) vs. OS keychain now.
+
+## Files
+
+**Create**
+- `src/adapters/sources/reddit/mod.rs`
+- `src/adapters/sources/reddit/auth.rs`
+- `src/adapters/sources/reddit/response.rs`
+
+**Modify**
+- `src/adapters/sources/mod.rs` (`pub mod reddit;`)
+- `src/config/secrets.rs` (client id/secret)
+- `src/application/analyze.rs` (inject social sources; drop hardcoded `build_sources`)
+- `src/cli/run.rs`, `src/main.rs` (build + inject the social list)
+- `src/mcp/tools.rs`, `src/mcp/server.rs` (thread + own the social list)
+- `tests/analyze_flow.rs` (inject mock social list)
+- `README.md` (Reddit setup + secret guidance)

--- a/docs/superpowers/specs/2026-07-01-reddit-social-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-01-reddit-social-adapter-design.md
@@ -71,10 +71,10 @@ future opt-in, see below.)*
 
 If the Reddit creds are unset, the composition root does not wire the Reddit
 source. Enabling `--enable-reddit` (or the MCP `enable_reddit`) without creds
-yields the note `"reddit: not configured (set OPENINTEL_REDDIT_CLIENT_ID and
-OPENINTEL_REDDIT_CLIENT_SECRET)"`; the market snapshot and other social sources
-still run. (This reuses the application layer's existing per-source note +
-continue behavior.)
+yields the generic per-source note `"reddit enabled but not configured"` (the
+env-var setup detail lives in the README); the market snapshot and other social
+sources still run. (This reuses the application layer's existing per-source note
++ continue behavior.)
 
 ## Adapter structure (fetch/parse split, mirroring Yahoo)
 
@@ -155,7 +155,7 @@ All failures → `DomainError::SourceFailure { name: "reddit", message }`:
 
 - token request non-2xx / transport / timeout → `"token request failed: …"`
 - 401 on token or search → `"unauthorized — check client id/secret"`
-- 429 → `"rate limited"` (include `X-Ratelimit-Reset` when present)
+- 429 → `"rate limited (HTTP 429)"` (surfacing `X-Ratelimit-Reset` is a tracked follow-up)
 - search non-2xx / malformed JSON → `SourceFailure`
 - **No `unwrap`/`expect` on network data.**
 

--- a/src/adapters/sources/mod.rs
+++ b/src/adapters/sources/mod.rs
@@ -2,3 +2,65 @@ pub mod mock_bluesky;
 pub mod mock_reddit;
 pub mod mock_x;
 pub mod reddit;
+
+use crate::config::secrets::Credentials;
+use crate::domain::ports::social_data_source::SocialDataSource;
+
+/// Assemble the social data sources from credentials: the real `RedditSource`
+/// when both OAuth credentials are set (a `RedditSource::new` failure logs a
+/// warning to stderr and omits it), plus the mock X and Bluesky sources.
+/// Shared by both composition roots (`main.rs` and `mcp::server::serve`).
+pub fn build_social_sources(credentials: &Credentials) -> Vec<Box<dyn SocialDataSource>> {
+    let mut social: Vec<Box<dyn SocialDataSource>> = Vec::new();
+    if let (Some(id), Some(secret)) = (
+        credentials.reddit_client_id.clone(),
+        credentials.reddit_client_secret.clone(),
+    ) {
+        match reddit::RedditSource::new(id, secret) {
+            Ok(src) => social.push(Box::new(src)),
+            Err(e) => eprintln!("warning: reddit disabled: {e}"),
+        }
+    }
+    social.push(Box::new(mock_x::MockXSource));
+    social.push(Box::new(mock_bluesky::MockBlueskySource));
+    social
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::values::source_kind::SourceKind;
+    use secrecy::SecretString;
+
+    fn creds(reddit: bool) -> Credentials {
+        let s = |v: &str| Some(SecretString::new(v.to_string().into_boxed_str()));
+        Credentials {
+            reddit_client_id: if reddit { s("id") } else { None },
+            reddit_client_secret: if reddit { s("secret") } else { None },
+            x_bearer: None,
+            bluesky_app_password: None,
+            market_api_key: None,
+        }
+    }
+
+    #[test]
+    fn omits_reddit_without_creds() {
+        let kinds: Vec<_> = build_social_sources(&creds(false))
+            .iter()
+            .map(|s| s.kind())
+            .collect();
+        assert_eq!(kinds, vec![SourceKind::X, SourceKind::Bluesky]);
+    }
+
+    #[test]
+    fn includes_reddit_with_creds() {
+        let kinds: Vec<_> = build_social_sources(&creds(true))
+            .iter()
+            .map(|s| s.kind())
+            .collect();
+        assert_eq!(
+            kinds,
+            vec![SourceKind::Reddit, SourceKind::X, SourceKind::Bluesky]
+        );
+    }
+}

--- a/src/adapters/sources/mod.rs
+++ b/src/adapters/sources/mod.rs
@@ -7,19 +7,24 @@ use crate::config::secrets::Credentials;
 use crate::domain::ports::social_data_source::SocialDataSource;
 
 /// Assemble the social data sources from credentials: the real `RedditSource`
-/// when both OAuth credentials are set (a `RedditSource::new` failure logs a
-/// warning to stderr and omits it), plus the mock X and Bluesky sources.
-/// Shared by both composition roots (`main.rs` and `mcp::server::serve`).
+/// when both OAuth credentials are set, plus the mock X and Bluesky sources.
+/// A partial config (only one of the two creds) or a `RedditSource::new`
+/// failure logs a warning to stderr and omits Reddit. Shared by both
+/// composition roots (`main.rs` and `mcp::server::serve`).
 pub fn build_social_sources(credentials: &Credentials) -> Vec<Box<dyn SocialDataSource>> {
     let mut social: Vec<Box<dyn SocialDataSource>> = Vec::new();
-    if let (Some(id), Some(secret)) = (
+    match (
         credentials.reddit_client_id.clone(),
         credentials.reddit_client_secret.clone(),
     ) {
-        match reddit::RedditSource::new(id, secret) {
+        (Some(id), Some(secret)) => match reddit::RedditSource::new(id, secret) {
             Ok(src) => social.push(Box::new(src)),
             Err(e) => eprintln!("warning: reddit disabled: {e}"),
-        }
+        },
+        (Some(_), None) | (None, Some(_)) => eprintln!(
+            "warning: reddit disabled: set BOTH OPENINTEL_REDDIT_CLIENT_ID and OPENINTEL_REDDIT_CLIENT_SECRET"
+        ),
+        (None, None) => {}
     }
     social.push(Box::new(mock_x::MockXSource));
     social.push(Box::new(mock_bluesky::MockBlueskySource));
@@ -62,5 +67,13 @@ mod tests {
             kinds,
             vec![SourceKind::Reddit, SourceKind::X, SourceKind::Bluesky]
         );
+    }
+
+    #[test]
+    fn partial_creds_omits_reddit() {
+        let mut c = creds(true);
+        c.reddit_client_secret = None; // only the client id is set
+        let kinds: Vec<_> = build_social_sources(&c).iter().map(|s| s.kind()).collect();
+        assert_eq!(kinds, vec![SourceKind::X, SourceKind::Bluesky]);
     }
 }

--- a/src/adapters/sources/mod.rs
+++ b/src/adapters/sources/mod.rs
@@ -1,3 +1,4 @@
 pub mod mock_bluesky;
 pub mod mock_reddit;
 pub mod mock_x;
+pub mod reddit;

--- a/src/adapters/sources/reddit/auth.rs
+++ b/src/adapters/sources/reddit/auth.rs
@@ -1,0 +1,128 @@
+use chrono::{DateTime, Duration, Utc};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+use crate::domain::error::DomainError;
+
+const SKEW_SECS: i64 = 60;
+const TOKEN_URL: &str = "https://www.reddit.com/api/v1/access_token";
+
+pub(crate) struct CachedToken {
+    pub bearer: SecretString,
+    pub expires_at: DateTime<Utc>,
+}
+
+impl CachedToken {
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        now + Duration::seconds(SKEW_SECS) >= self.expires_at
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    #[serde(default)]
+    access_token: Option<String>,
+    #[serde(default)]
+    expires_in: Option<i64>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "reddit".into(),
+        message: message.into(),
+    }
+}
+
+pub(crate) fn parse_token(body: &str, now: DateTime<Utc>) -> Result<CachedToken, DomainError> {
+    let resp: TokenResponse =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed token response: {e}")))?;
+    if let Some(err) = resp.error {
+        return Err(fail(format!("token error: {err}")));
+    }
+    let access_token = resp
+        .access_token
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| fail("no access_token in response"))?;
+    let expires_in = resp.expires_in.unwrap_or(3600);
+    Ok(CachedToken {
+        bearer: SecretString::new(access_token.into_boxed_str()),
+        expires_at: now + Duration::seconds(expires_in),
+    })
+}
+
+pub(crate) async fn request_token(
+    client: &reqwest::Client,
+    client_id: &SecretString,
+    client_secret: &SecretString,
+    user_agent: &str,
+    now: DateTime<Utc>,
+) -> Result<CachedToken, DomainError> {
+    let resp = client
+        .post(TOKEN_URL)
+        .basic_auth(
+            client_id.expose_secret(),
+            Some(client_secret.expose_secret()),
+        )
+        .header(reqwest::header::USER_AGENT, user_agent)
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded",
+        )
+        .body("grant_type=client_credentials")
+        .send()
+        .await
+        .map_err(|e| fail(format!("token request failed: {e}")))?;
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| fail(format!("token body failed (HTTP {status}): {e}")))?;
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(fail("unauthorized — check client id/secret"));
+    }
+    if !status.is_success() {
+        return Err(fail(format!("token request HTTP {status}")));
+    }
+    parse_token(&body, now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 2, 0, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn parse_token_ok_and_expiry() {
+        let body =
+            r#"{"access_token":"abc123","token_type":"bearer","expires_in":3600,"scope":"*"}"#;
+        let t = parse_token(body, at()).unwrap();
+        assert_eq!(t.bearer.expose_secret(), "abc123");
+        assert!(!t.is_expired(at())); // fresh
+        assert!(t.is_expired(at() + Duration::seconds(3600))); // at expiry
+        assert!(t.is_expired(at() + Duration::seconds(3541))); // 60s skew -> refresh early
+        assert!(!t.is_expired(at() + Duration::seconds(3539)));
+    }
+
+    #[test]
+    fn parse_token_error_field_is_failure() {
+        let body = r#"{"error":"invalid_grant"}"#;
+        assert!(parse_token(body, at()).is_err());
+    }
+
+    #[test]
+    fn parse_token_missing_access_token_is_failure() {
+        let body = r#"{"token_type":"bearer","expires_in":3600}"#;
+        assert!(parse_token(body, at()).is_err());
+    }
+
+    #[test]
+    fn parse_token_malformed_is_failure() {
+        assert!(parse_token("nope", at()).is_err());
+    }
+}

--- a/src/adapters/sources/reddit/auth.rs
+++ b/src/adapters/sources/reddit/auth.rs
@@ -18,7 +18,7 @@ impl CachedToken {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct TokenResponse {
     #[serde(default)]
     access_token: Option<String>,

--- a/src/adapters/sources/reddit/mod.rs
+++ b/src/adapters/sources/reddit/mod.rs
@@ -1,0 +1,1 @@
+mod response;

--- a/src/adapters/sources/reddit/mod.rs
+++ b/src/adapters/sources/reddit/mod.rs
@@ -1,1 +1,177 @@
+mod auth;
 mod response;
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use secrecy::{ExposeSecret, SecretString};
+use tokio::sync::RwLock;
+
+use crate::domain::entities::social_post::SocialPost;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::social_data_source::SocialDataSource;
+use crate::domain::values::source_kind::SourceKind;
+use auth::CachedToken;
+
+const SUBS: &str = "wallstreetbets+stocks+options+investing+StockMarket";
+const API_BASE: &str = "https://oauth.reddit.com";
+const TIMEOUT_SECS: u64 = 10;
+
+pub struct RedditSource {
+    client: reqwest::Client,
+    client_id: SecretString,
+    client_secret: SecretString,
+    user_agent: String,
+    token: RwLock<Option<CachedToken>>,
+}
+
+impl RedditSource {
+    pub fn new(client_id: SecretString, client_secret: SecretString) -> Result<Self, DomainError> {
+        let user_agent = format!(
+            "rust:openintel:v{} (by /u/openintel)",
+            env!("CARGO_PKG_VERSION")
+        );
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(TIMEOUT_SECS))
+            .user_agent(&user_agent)
+            .build()
+            .map_err(|e| DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: format!("client build failed: {e}"),
+            })?;
+        Ok(Self {
+            client,
+            client_id,
+            client_secret,
+            user_agent,
+            token: RwLock::new(None),
+        })
+    }
+
+    async fn ensure_token(&self) -> Result<SecretString, DomainError> {
+        let now = Utc::now();
+        {
+            let guard = self.token.read().await;
+            if let Some(t) = guard.as_ref() {
+                if !t.is_expired(now) {
+                    return Ok(t.bearer.clone());
+                }
+            }
+        }
+        let mut guard = self.token.write().await;
+        if let Some(t) = guard.as_ref() {
+            if !t.is_expired(now) {
+                return Ok(t.bearer.clone());
+            }
+        }
+        let fresh = auth::request_token(
+            &self.client,
+            &self.client_id,
+            &self.client_secret,
+            &self.user_agent,
+            now,
+        )
+        .await?;
+        let bearer = fresh.bearer.clone();
+        *guard = Some(fresh);
+        Ok(bearer)
+    }
+}
+
+#[async_trait]
+impl SocialDataSource for RedditSource {
+    fn kind(&self) -> SourceKind {
+        SourceKind::Reddit
+    }
+
+    async fn fetch(&self, ticker: &Ticker, limit: usize) -> Result<Vec<SocialPost>, DomainError> {
+        let bearer = self.ensure_token().await?;
+        let fetched_at = Utc::now();
+        let cashtag = format!("${}", ticker.as_str());
+        let limit_str = limit.min(100).to_string();
+        // `.query()` is behind reqwest's `query` feature, which this crate does not enable;
+        // build the query string manually via the re-exported `url::Url` instead.
+        let mut url = reqwest::Url::parse(&format!("{API_BASE}/r/{SUBS}/search")).map_err(|e| {
+            DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: format!("bad search url: {e}"),
+            }
+        })?;
+        url.query_pairs_mut()
+            .append_pair("q", &cashtag)
+            .append_pair("restrict_sr", "1")
+            .append_pair("sort", "new")
+            .append_pair("type", "link")
+            .append_pair("limit", &limit_str)
+            .append_pair("raw_json", "1");
+
+        let resp = self
+            .client
+            .get(url)
+            .bearer_auth(bearer.expose_secret())
+            .header(reqwest::header::USER_AGENT, &self.user_agent)
+            .send()
+            .await
+            .map_err(|e| DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: format!("search request failed: {e}"),
+            })?;
+        let status = resp.status();
+        let body = resp.text().await.map_err(|e| DomainError::SourceFailure {
+            name: "reddit".into(),
+            message: format!("search body failed (HTTP {status}): {e}"),
+        })?;
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: "rate limited (HTTP 429)".into(),
+            });
+        }
+        if !status.is_success() {
+            return Err(DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: format!("search HTTP {status}"),
+            });
+        }
+        response::parse_posts(&body, limit, fetched_at)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::SecretString;
+
+    fn secret(s: &str) -> SecretString {
+        SecretString::new(s.to_string().into_boxed_str())
+    }
+
+    #[test]
+    fn new_builds_and_kind_is_reddit() {
+        let src = RedditSource::new(secret("id"), secret("sec")).unwrap();
+        assert_eq!(src.kind(), SourceKind::Reddit);
+    }
+
+    #[tokio::test]
+    #[ignore = "hits live Reddit; needs OPENINTEL_REDDIT_CLIENT_ID/SECRET; run with --ignored"]
+    async fn live_fetch_returns_posts() {
+        let id = std::env::var("OPENINTEL_REDDIT_CLIENT_ID").unwrap();
+        let secret = std::env::var("OPENINTEL_REDDIT_CLIENT_SECRET").unwrap();
+        let src = RedditSource::new(
+            SecretString::new(id.into_boxed_str()),
+            SecretString::new(secret.into_boxed_str()),
+        )
+        .unwrap();
+        let posts = src
+            .fetch(&Ticker::parse("AAPL").unwrap(), 10)
+            .await
+            .unwrap();
+        // A live search may legitimately return 0; assert the call succeeded and any post is well-formed.
+        for p in &posts {
+            assert!(!p.id.is_empty());
+            assert!(!p.text.as_str().is_empty());
+        }
+    }
+}

--- a/src/adapters/sources/reddit/response.rs
+++ b/src/adapters/sources/reddit/response.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use chrono::{DateTime, TimeZone, Utc};
 use serde::Deserialize;
 

--- a/src/adapters/sources/reddit/response.rs
+++ b/src/adapters/sources/reddit/response.rs
@@ -3,11 +3,9 @@
 use chrono::{DateTime, TimeZone, Utc};
 use serde::Deserialize;
 
-use crate::domain::entities::social_post::{PostText, SocialPost};
+use crate::domain::entities::social_post::{PostText, SocialPost, MAX_POST_LEN};
 use crate::domain::error::DomainError;
 use crate::domain::values::source_kind::SourceKind;
-
-const MAX_TEXT_CHARS: usize = 10_000;
 
 #[derive(Debug, Deserialize)]
 struct Listing {
@@ -58,6 +56,10 @@ pub(crate) fn parse_posts(
     let listing: Listing =
         serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
 
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
     let mut posts = Vec::new();
     for child in listing.data.children {
         let d = child.data;
@@ -72,7 +74,7 @@ pub(crate) fn parse_posts(
         } else {
             format!("{title}\n{selftext}")
         };
-        let truncated: String = combined.chars().take(MAX_TEXT_CHARS).collect();
+        let truncated: String = combined.chars().take(MAX_POST_LEN).collect();
         let text = match PostText::parse(&truncated) {
             Ok(t) => t,
             Err(_) => continue,
@@ -181,5 +183,26 @@ mod tests {
     #[test]
     fn malformed_json_is_source_failure() {
         assert!(parse_posts("not json", 50, at()).is_err());
+    }
+
+    #[test]
+    fn limit_zero_returns_empty() {
+        assert!(parse_posts(HAPPY, 0, at()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn post_with_empty_title_and_selftext_is_skipped() {
+        let body = r#"{"kind":"Listing","data":{"children":[
+            {"kind":"t3","data":{"name":"t3_e","author":"a","title":"","selftext":"","score":1,"created_utc":1.0}}
+        ]}}"#;
+        assert!(parse_posts(body, 50, at()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn post_with_empty_string_id_is_skipped() {
+        let body = r#"{"kind":"Listing","data":{"children":[
+            {"kind":"t3","data":{"name":"","author":"a","title":"AAPL","score":1,"created_utc":1.0}}
+        ]}}"#;
+        assert!(parse_posts(body, 50, at()).unwrap().is_empty());
     }
 }

--- a/src/adapters/sources/reddit/response.rs
+++ b/src/adapters/sources/reddit/response.rs
@@ -1,0 +1,185 @@
+#![allow(dead_code)]
+
+use chrono::{DateTime, TimeZone, Utc};
+use serde::Deserialize;
+
+use crate::domain::entities::social_post::{PostText, SocialPost};
+use crate::domain::error::DomainError;
+use crate::domain::values::source_kind::SourceKind;
+
+const MAX_TEXT_CHARS: usize = 10_000;
+
+#[derive(Debug, Deserialize)]
+struct Listing {
+    data: ListingData,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListingData {
+    #[serde(default)]
+    children: Vec<Child>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Child {
+    data: ChildData,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChildData {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    author: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    selftext: Option<String>,
+    #[serde(default)]
+    score: Option<i64>,
+    #[serde(default)]
+    created_utc: Option<f64>,
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "reddit".into(),
+        message: message.into(),
+    }
+}
+
+pub(crate) fn parse_posts(
+    body: &str,
+    limit: usize,
+    fetched_at: DateTime<Utc>,
+) -> Result<Vec<SocialPost>, DomainError> {
+    let listing: Listing =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
+
+    let mut posts = Vec::new();
+    for child in listing.data.children {
+        let d = child.data;
+        let id = match d.name.or(d.id) {
+            Some(id) if !id.is_empty() => id,
+            _ => continue,
+        };
+        let title = d.title.unwrap_or_default();
+        let selftext = d.selftext.unwrap_or_default();
+        let combined = if selftext.trim().is_empty() {
+            title
+        } else {
+            format!("{title}\n{selftext}")
+        };
+        let truncated: String = combined.chars().take(MAX_TEXT_CHARS).collect();
+        let text = match PostText::parse(&truncated) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let created_at = d
+            .created_utc
+            .and_then(|s| Utc.timestamp_opt(s as i64, 0).single())
+            .unwrap_or(fetched_at);
+
+        posts.push(SocialPost {
+            id,
+            source: SourceKind::Reddit,
+            author: d.author.unwrap_or_else(|| "[unknown]".to_string()),
+            text,
+            created_at,
+            engagement: d.score.unwrap_or(0).max(0) as u32,
+        });
+        if posts.len() >= limit {
+            break;
+        }
+    }
+    Ok(posts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::values::source_kind::SourceKind;
+    use chrono::{DateTime, TimeZone, Utc};
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 2, 0, 0, 0).unwrap()
+    }
+
+    const HAPPY: &str = r#"{"kind":"Listing","data":{"children":[
+        {"kind":"t3","data":{"name":"t3_aaa","author":"wsbtrader","title":"$AAPL calls printing","selftext":"loading more","score":420,"created_utc":1782504000.0}},
+        {"kind":"t3","data":{"name":"t3_bbb","author":"[deleted]","title":"AAPL puts","selftext":"","score":-5,"created_utc":1782500000.0}}
+    ]}}"#;
+
+    const EMPTY: &str = r#"{"kind":"Listing","data":{"children":[]}}"#;
+
+    #[test]
+    fn happy_maps_posts() {
+        let posts = parse_posts(HAPPY, 50, at()).unwrap();
+        assert_eq!(posts.len(), 2);
+        assert_eq!(posts[0].id, "t3_aaa");
+        assert_eq!(posts[0].author, "wsbtrader");
+        assert_eq!(posts[0].text.as_str(), "$AAPL calls printing\nloading more");
+        assert_eq!(posts[0].engagement, 420);
+        assert_eq!(posts[0].source, SourceKind::Reddit);
+        assert_eq!(
+            posts[0].created_at,
+            Utc.timestamp_opt(1782504000, 0).single().unwrap()
+        );
+    }
+
+    #[test]
+    fn empty_selftext_is_title_only_and_deleted_author_kept() {
+        let posts = parse_posts(HAPPY, 50, at()).unwrap();
+        assert_eq!(posts[1].text.as_str(), "AAPL puts");
+        assert_eq!(posts[1].author, "[deleted]");
+    }
+
+    #[test]
+    fn negative_score_clamps_to_zero() {
+        let posts = parse_posts(HAPPY, 50, at()).unwrap();
+        assert_eq!(posts[1].engagement, 0);
+    }
+
+    #[test]
+    fn limit_is_honored() {
+        assert_eq!(parse_posts(HAPPY, 1, at()).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn empty_children_is_empty() {
+        assert!(parse_posts(EMPTY, 50, at()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn missing_created_utc_falls_back_to_fetched_at() {
+        let body = r#"{"kind":"Listing","data":{"children":[
+            {"kind":"t3","data":{"name":"t3_c","author":"a","title":"AAPL","score":1}}
+        ]}}"#;
+        assert_eq!(parse_posts(body, 50, at()).unwrap()[0].created_at, at());
+    }
+
+    #[test]
+    fn overlong_text_is_truncated() {
+        let big = "A".repeat(20_000);
+        let body = format!(
+            r#"{{"kind":"Listing","data":{{"children":[{{"kind":"t3","data":{{"name":"t3_d","author":"a","title":"{big}","score":1,"created_utc":1.0}}}}]}}}}"#
+        );
+        let posts = parse_posts(&body, 50, at()).unwrap();
+        assert_eq!(posts[0].text.as_str().chars().count(), 10_000);
+    }
+
+    #[test]
+    fn post_with_no_id_is_skipped() {
+        let body = r#"{"kind":"Listing","data":{"children":[
+            {"kind":"t3","data":{"author":"a","title":"AAPL","score":1}}
+        ]}}"#;
+        assert!(parse_posts(body, 50, at()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn malformed_json_is_source_failure() {
+        assert!(parse_posts("not json", 50, at()).is_err());
+    }
+}

--- a/src/application/analyze.rs
+++ b/src/application/analyze.rs
@@ -2,9 +2,6 @@ use chrono::Utc;
 use futures::future::join_all;
 
 use crate::adapters::analyzer::lexicon::LexiconAnalyzer;
-use crate::adapters::sources::mock_bluesky::MockBlueskySource;
-use crate::adapters::sources::mock_reddit::MockRedditSource;
-use crate::adapters::sources::mock_x::MockXSource;
 use crate::application::request::AnalysisRequest;
 use crate::domain::engine::speculation_engine::SpeculationEngine;
 use crate::domain::entities::market_snapshot::MarketSnapshot;
@@ -15,36 +12,31 @@ use crate::domain::error::DomainError;
 use crate::domain::ports::market_data_source::MarketDataSource;
 use crate::domain::ports::post_analyzer::PostAnalyzer;
 use crate::domain::ports::social_data_source::SocialDataSource;
-use crate::domain::values::source_kind::SourceKind;
-
-fn build_sources(req: &AnalysisRequest) -> Vec<Box<dyn SocialDataSource>> {
-    req.enabled_sources
-        .iter()
-        .map(|kind| -> Box<dyn SocialDataSource> {
-            match kind {
-                SourceKind::Reddit => Box::new(MockRedditSource),
-                SourceKind::X => Box::new(MockXSource),
-                SourceKind::Bluesky => Box::new(MockBlueskySource),
-            }
-        })
-        .collect()
-}
 
 pub async fn analyze(
     req: &AnalysisRequest,
+    social_sources: &[Box<dyn SocialDataSource>],
     market_source: Option<&dyn MarketDataSource>,
 ) -> Result<SpeculationReport, DomainError> {
     let ticker = Ticker::parse(&req.ticker)?;
-    let sources = build_sources(req);
 
-    let fetches = sources.iter().map(|source| {
-        let ticker = ticker.clone();
-        async move { (source.kind(), source.fetch(&ticker, req.limit).await) }
-    });
+    let mut notes: Vec<String> = Vec::new();
+    for kind in &req.enabled_sources {
+        if !social_sources.iter().any(|s| s.kind() == *kind) {
+            notes.push(format!("{} enabled but not configured", kind.as_str()));
+        }
+    }
+
+    let fetches = social_sources
+        .iter()
+        .filter(|s| req.enabled_sources.contains(&s.kind()))
+        .map(|source| {
+            let ticker = ticker.clone();
+            async move { (source.kind(), source.fetch(&ticker, req.limit).await) }
+        });
     let results = join_all(fetches).await;
 
     let mut posts: Vec<SocialPost> = Vec::new();
-    let mut notes: Vec<String> = Vec::new();
     for (kind, result) in results {
         match result {
             Ok(mut fetched) => posts.append(&mut fetched),
@@ -84,6 +76,10 @@ pub async fn analyze(
 mod tests {
     use super::*;
     use crate::adapters::market::mock_market::MockMarketSource;
+    use crate::adapters::sources::mock_bluesky::MockBlueskySource;
+    use crate::adapters::sources::mock_reddit::MockRedditSource;
+    use crate::adapters::sources::mock_x::MockXSource;
+    use crate::domain::values::source_kind::SourceKind;
 
     fn req(ticker: &str, market: bool) -> AnalysisRequest {
         AnalysisRequest {
@@ -95,10 +91,18 @@ mod tests {
         }
     }
 
+    fn mock_social() -> Vec<Box<dyn SocialDataSource>> {
+        vec![
+            Box::new(MockRedditSource),
+            Box::new(MockXSource),
+            Box::new(MockBlueskySource),
+        ]
+    }
+
     #[tokio::test]
     async fn analyzes_default_request_confirming_bullish() {
         use crate::domain::values::speculation::Alignment;
-        let report = analyze(&req("AAPL", true), Some(&MockMarketSource))
+        let report = analyze(&req("AAPL", true), &mock_social(), Some(&MockMarketSource))
             .await
             .unwrap();
         assert_eq!(report.social.total_mentions, 10);
@@ -108,16 +112,34 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_ticker_errors() {
-        assert!(analyze(&req("$$$", true), Some(&MockMarketSource))
-            .await
-            .is_err());
+        assert!(
+            analyze(&req("$$$", true), &mock_social(), Some(&MockMarketSource))
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
     async fn social_only_when_no_source_provided() {
         use crate::domain::values::speculation::Alignment;
-        let report = analyze(&req("AAPL", false), None).await.unwrap();
+        let report = analyze(&req("AAPL", false), &mock_social(), None)
+            .await
+            .unwrap();
         assert!(report.market.is_none());
         assert_eq!(report.fusion.alignment, Alignment::Quiet);
+    }
+
+    #[tokio::test]
+    async fn enabled_source_absent_is_noted() {
+        // reddit enabled but not wired -> note + other sources still counted (x=3, bluesky=3)
+        let social: Vec<Box<dyn SocialDataSource>> =
+            vec![Box::new(MockXSource), Box::new(MockBlueskySource)];
+        let report = analyze(&req("AAPL", false), &social, None).await.unwrap();
+        assert_eq!(report.social.total_mentions, 6);
+        assert!(report
+            .fusion
+            .notes
+            .iter()
+            .any(|n| n.contains("reddit enabled but not configured")));
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -3,9 +3,11 @@ use crate::config::settings::{AppConfig, OutputFormat};
 use crate::domain::entities::speculation_report::SpeculationReport;
 use crate::domain::error::DomainError;
 use crate::domain::ports::market_data_source::MarketDataSource;
+use crate::domain::ports::social_data_source::SocialDataSource;
 
 pub async fn analyze(
     config: &AppConfig,
+    social_sources: &[Box<dyn SocialDataSource>],
     market_source: Option<&dyn MarketDataSource>,
 ) -> Result<(SpeculationReport, String), DomainError> {
     let req = AnalysisRequest {
@@ -15,7 +17,7 @@ pub async fn analyze(
         limit: config.limit,
         engine: config.engine.clone(),
     };
-    let report = application::analyze(&req, market_source).await?;
+    let report = application::analyze(&req, social_sources, market_source).await?;
     let rendered = render(&report, config.format);
     Ok((report, rendered))
 }
@@ -119,6 +121,9 @@ fn render_table(report: &SpeculationReport) -> String {
 mod tests {
     use super::*;
     use crate::adapters::market::mock_market::MockMarketSource;
+    use crate::adapters::sources::mock_bluesky::MockBlueskySource;
+    use crate::adapters::sources::mock_reddit::MockRedditSource;
+    use crate::adapters::sources::mock_x::MockXSource;
     use crate::config::settings::{AppConfig, OutputFormat};
     use crate::domain::values::speculation::Alignment;
 
@@ -126,12 +131,23 @@ mod tests {
         AppConfig::new("AAPL".into(), false, false, false, no_market, 50, format)
     }
 
+    fn mock_social() -> Vec<Box<dyn SocialDataSource>> {
+        vec![
+            Box::new(MockRedditSource),
+            Box::new(MockXSource),
+            Box::new(MockBlueskySource),
+        ]
+    }
+
     #[tokio::test]
     async fn full_run_confirms_bullish_with_market() {
-        let (report, rendered) =
-            analyze(&config(false, OutputFormat::Json), Some(&MockMarketSource))
-                .await
-                .unwrap();
+        let (report, rendered) = analyze(
+            &config(false, OutputFormat::Json),
+            &mock_social(),
+            Some(&MockMarketSource),
+        )
+        .await
+        .unwrap();
         assert!(report.market.is_some());
         assert_eq!(report.fusion.alignment, Alignment::ConfirmingBullish);
         assert!(rendered.contains("Not financial advice"));
@@ -140,7 +156,7 @@ mod tests {
 
     #[tokio::test]
     async fn no_market_run_is_quiet() {
-        let (report, _) = analyze(&config(true, OutputFormat::Table), None)
+        let (report, _) = analyze(&config(true, OutputFormat::Table), &mock_social(), None)
             .await
             .unwrap();
         assert!(report.market.is_none());
@@ -149,9 +165,13 @@ mod tests {
 
     #[tokio::test]
     async fn table_output_has_sections_and_disclaimer() {
-        let (_, rendered) = analyze(&config(false, OutputFormat::Table), Some(&MockMarketSource))
-            .await
-            .unwrap();
+        let (_, rendered) = analyze(
+            &config(false, OutputFormat::Table),
+            &mock_social(),
+            Some(&MockMarketSource),
+        )
+        .await
+        .unwrap();
         assert!(rendered.contains("SOCIAL"));
         assert!(rendered.contains("MARKET"));
         assert!(rendered.contains("FUSION"));
@@ -169,6 +189,8 @@ mod tests {
             50,
             OutputFormat::Table,
         );
-        assert!(analyze(&cfg, Some(&MockMarketSource)).await.is_err());
+        assert!(analyze(&cfg, &mock_social(), Some(&MockMarketSource))
+            .await
+            .is_err());
     }
 }

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -2,7 +2,8 @@ use secrecy::SecretString;
 
 #[derive(Debug)]
 pub struct Credentials {
-    pub reddit_token: Option<SecretString>,
+    pub reddit_client_id: Option<SecretString>,
+    pub reddit_client_secret: Option<SecretString>,
     pub x_bearer: Option<SecretString>,
     pub bluesky_app_password: Option<SecretString>,
     pub market_api_key: Option<SecretString>,
@@ -11,7 +12,8 @@ pub struct Credentials {
 impl Credentials {
     pub fn from_env() -> Self {
         Credentials {
-            reddit_token: secret_from(std::env::var("OPENINTEL_REDDIT_TOKEN").ok()),
+            reddit_client_id: secret_from(std::env::var("OPENINTEL_REDDIT_CLIENT_ID").ok()),
+            reddit_client_secret: secret_from(std::env::var("OPENINTEL_REDDIT_CLIENT_SECRET").ok()),
             x_bearer: secret_from(std::env::var("OPENINTEL_X_BEARER").ok()),
             bluesky_app_password: secret_from(std::env::var("OPENINTEL_BLUESKY_APP_PASSWORD").ok()),
             market_api_key: secret_from(std::env::var("OPENINTEL_MARKET_API_KEY").ok()),
@@ -38,7 +40,8 @@ mod tests {
     #[test]
     fn debug_does_not_leak_secret() {
         let creds = Credentials {
-            reddit_token: secret_from(Some("leak-me".to_string())),
+            reddit_client_id: secret_from(Some("leak-me".to_string())),
+            reddit_client_secret: None,
             x_bearer: None,
             bluesky_app_password: None,
             market_api_key: None,

--- a/src/domain/entities/social_post.rs
+++ b/src/domain/entities/social_post.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use crate::domain::error::DomainError;
 use crate::domain::values::source_kind::SourceKind;
 
-const MAX_POST_LEN: usize = 10_000;
+pub(crate) const MAX_POST_LEN: usize = 10_000;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(transparent)]

--- a/src/domain/values/source_kind.rs
+++ b/src/domain/values/source_kind.rs
@@ -10,7 +10,7 @@ pub enum SourceKind {
 
 impl SourceKind {
     /// The full set of social sources, in canonical order — the single source of
-    /// truth used by the CLI source-builder, AppConfig defaults, and `list_sources`.
+    /// truth for the request defaults (`AppConfig` and the MCP `request_from`).
     pub const ALL: [SourceKind; 3] = [SourceKind::Reddit, SourceKind::X, SourceKind::Bluesky];
 
     pub fn as_str(self) -> &'static str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,19 +3,37 @@ use std::process::ExitCode;
 use clap::Parser;
 
 use openintel::adapters::market::yahoo::YahooMarketSource;
+use openintel::adapters::sources::mock_bluesky::MockBlueskySource;
+use openintel::adapters::sources::mock_x::MockXSource;
+use openintel::adapters::sources::reddit::RedditSource;
 use openintel::cli::args::{to_app_config, Cli, Command};
 use openintel::cli::run::analyze;
 use openintel::config::secrets::Credentials;
+use openintel::domain::ports::social_data_source::SocialDataSource;
 
 #[tokio::main]
 async fn main() -> ExitCode {
     let cli = Cli::parse();
-    // Loaded for future keyed adapters; Yahoo (the current market source) needs no key.
-    let _credentials = Credentials::from_env();
+    // Reddit client credentials (if set) enable the real Reddit source; other sources need none.
+    let credentials = Credentials::from_env();
 
     match cli.command {
         Command::Analyze(args) => {
             let config = to_app_config(&args);
+
+            let mut social: Vec<Box<dyn SocialDataSource>> = Vec::new();
+            if let (Some(id), Some(secret)) = (
+                credentials.reddit_client_id,
+                credentials.reddit_client_secret,
+            ) {
+                match RedditSource::new(id, secret) {
+                    Ok(src) => social.push(Box::new(src)),
+                    Err(e) => eprintln!("warning: reddit disabled: {e}"),
+                }
+            }
+            social.push(Box::new(MockXSource));
+            social.push(Box::new(MockBlueskySource));
+
             let outcome = if config.market_enabled {
                 let market = match YahooMarketSource::new() {
                     Ok(m) => m,
@@ -24,9 +42,9 @@ async fn main() -> ExitCode {
                         return ExitCode::FAILURE;
                     }
                 };
-                analyze(&config, Some(&market)).await
+                analyze(&config, &social, Some(&market)).await
             } else {
-                analyze(&config, None).await
+                analyze(&config, &social, None).await
             };
             match outcome {
                 Ok((_report, rendered)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,9 @@ use std::process::ExitCode;
 use clap::Parser;
 
 use openintel::adapters::market::yahoo::YahooMarketSource;
-use openintel::adapters::sources::mock_bluesky::MockBlueskySource;
-use openintel::adapters::sources::mock_x::MockXSource;
-use openintel::adapters::sources::reddit::RedditSource;
 use openintel::cli::args::{to_app_config, Cli, Command};
 use openintel::cli::run::analyze;
 use openintel::config::secrets::Credentials;
-use openintel::domain::ports::social_data_source::SocialDataSource;
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -21,18 +17,7 @@ async fn main() -> ExitCode {
         Command::Analyze(args) => {
             let config = to_app_config(&args);
 
-            let mut social: Vec<Box<dyn SocialDataSource>> = Vec::new();
-            if let (Some(id), Some(secret)) = (
-                credentials.reddit_client_id,
-                credentials.reddit_client_secret,
-            ) {
-                match RedditSource::new(id, secret) {
-                    Ok(src) => social.push(Box::new(src)),
-                    Err(e) => eprintln!("warning: reddit disabled: {e}"),
-                }
-            }
-            social.push(Box::new(MockXSource));
-            social.push(Box::new(MockBlueskySource));
+            let social = openintel::adapters::sources::build_social_sources(&credentials);
 
             let outcome = if config.market_enabled {
                 let market = match YahooMarketSource::new() {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, ContentBlock, Implementation, ServerCapabilities, ServerInfo};
@@ -5,18 +7,25 @@ use rmcp::transport::io::stdio;
 use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler, ServiceExt};
 
 use crate::adapters::market::yahoo::YahooMarketSource;
+use crate::adapters::sources::mock_bluesky::MockBlueskySource;
+use crate::adapters::sources::mock_x::MockXSource;
+use crate::adapters::sources::reddit::RedditSource;
+use crate::config::secrets::Credentials;
+use crate::domain::ports::social_data_source::SocialDataSource;
 use crate::mcp::tools;
 
 #[derive(Clone)]
 pub struct OpenIntelServer {
     tool_router: ToolRouter<OpenIntelServer>,
+    social: Arc<Vec<Box<dyn SocialDataSource>>>,
     market: YahooMarketSource,
 }
 
 impl OpenIntelServer {
-    pub fn new(market: YahooMarketSource) -> Self {
+    pub fn new(social: Vec<Box<dyn SocialDataSource>>, market: YahooMarketSource) -> Self {
         Self {
             tool_router: Self::tool_router(),
+            social: Arc::new(social),
             market,
         }
     }
@@ -28,8 +37,9 @@ impl OpenIntelServer {
         description = "List the social and market data sources OpenIntel can analyze. Read-only metadata."
     )]
     async fn list_sources(&self) -> Result<CallToolResult, ErrorData> {
-        let json = serde_json::to_string_pretty(&tools::run_list_sources(&self.market))
-            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let json =
+            serde_json::to_string_pretty(&tools::run_list_sources(&self.social, &self.market))
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
     }
 
@@ -42,7 +52,7 @@ impl OpenIntelServer {
         &self,
         Parameters(args): Parameters<tools::AnalyzeArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let out = tools::run_analyze(args, &self.market)
+        let out = tools::run_analyze(args, &self.social, &self.market)
             .await
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         let json = serde_json::to_string_pretty(&out)
@@ -59,7 +69,7 @@ impl OpenIntelServer {
         &self,
         Parameters(args): Parameters<tools::ScanArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let out = tools::run_scan(args, &self.market).await;
+        let out = tools::run_scan(args, &self.social, &self.market).await;
         let json = serde_json::to_string_pretty(&out)
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
@@ -74,7 +84,7 @@ impl OpenIntelServer {
         &self,
         Parameters(args): Parameters<tools::CompareArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let out = tools::run_compare(args, &self.market).await;
+        let out = tools::run_compare(args, &self.social, &self.market).await;
         let json = serde_json::to_string_pretty(&out)
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
@@ -102,8 +112,22 @@ impl ServerHandler for OpenIntelServer {
 
 /// Run the MCP server over stdio (blocks until the client disconnects).
 pub async fn serve() -> Result<(), Box<dyn std::error::Error>> {
+    let credentials = Credentials::from_env();
+    let mut social: Vec<Box<dyn SocialDataSource>> = Vec::new();
+    if let (Some(id), Some(secret)) = (
+        credentials.reddit_client_id,
+        credentials.reddit_client_secret,
+    ) {
+        match RedditSource::new(id, secret) {
+            Ok(src) => social.push(Box::new(src)),
+            Err(e) => eprintln!("warning: reddit disabled: {e}"),
+        }
+    }
+    social.push(Box::new(MockXSource));
+    social.push(Box::new(MockBlueskySource));
+
     let market = YahooMarketSource::new()?;
-    let service = OpenIntelServer::new(market).serve(stdio()).await?;
+    let service = OpenIntelServer::new(social, market).serve(stdio()).await?;
     service.waiting().await?;
     Ok(())
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7,9 +7,6 @@ use rmcp::transport::io::stdio;
 use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler, ServiceExt};
 
 use crate::adapters::market::yahoo::YahooMarketSource;
-use crate::adapters::sources::mock_bluesky::MockBlueskySource;
-use crate::adapters::sources::mock_x::MockXSource;
-use crate::adapters::sources::reddit::RedditSource;
 use crate::config::secrets::Credentials;
 use crate::domain::ports::social_data_source::SocialDataSource;
 use crate::mcp::tools;
@@ -113,18 +110,7 @@ impl ServerHandler for OpenIntelServer {
 /// Run the MCP server over stdio (blocks until the client disconnects).
 pub async fn serve() -> Result<(), Box<dyn std::error::Error>> {
     let credentials = Credentials::from_env();
-    let mut social: Vec<Box<dyn SocialDataSource>> = Vec::new();
-    if let (Some(id), Some(secret)) = (
-        credentials.reddit_client_id,
-        credentials.reddit_client_secret,
-    ) {
-        match RedditSource::new(id, secret) {
-            Ok(src) => social.push(Box::new(src)),
-            Err(e) => eprintln!("warning: reddit disabled: {e}"),
-        }
-    }
-    social.push(Box::new(MockXSource));
-    social.push(Box::new(MockBlueskySource));
+    let social = crate::adapters::sources::build_social_sources(&credentials);
 
     let market = YahooMarketSource::new()?;
     let service = OpenIntelServer::new(social, market).serve(stdio()).await?;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -16,6 +16,9 @@ pub struct SourcesOutput {
     pub market: Vec<String>,
 }
 
+/// Report the actually-wired data sources so an agent can see whether an
+/// optional source (e.g. Reddit, which needs OAuth credentials) is live —
+/// `social` reflects the injected list, not the full `SourceKind::ALL` set.
 pub fn run_list_sources(
     social_sources: &[Box<dyn SocialDataSource>],
     market_source: &dyn MarketDataSource,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -6,6 +6,7 @@ use crate::domain::engine::config::EngineConfig;
 use crate::domain::entities::speculation_report::SpeculationReport;
 use crate::domain::error::DomainError;
 use crate::domain::ports::market_data_source::MarketDataSource;
+use crate::domain::ports::social_data_source::SocialDataSource;
 use crate::domain::values::source_kind::SourceKind;
 use crate::domain::values::speculation::Alignment;
 
@@ -15,12 +16,14 @@ pub struct SourcesOutput {
     pub market: Vec<String>,
 }
 
-/// Derived from `SourceKind::ALL` (one source of truth) + the market adapter's name.
-pub fn run_list_sources(market_source: &dyn MarketDataSource) -> SourcesOutput {
+pub fn run_list_sources(
+    social_sources: &[Box<dyn SocialDataSource>],
+    market_source: &dyn MarketDataSource,
+) -> SourcesOutput {
     SourcesOutput {
-        social: SourceKind::ALL
+        social: social_sources
             .iter()
-            .map(|s| s.as_str().to_string())
+            .map(|s| s.kind().as_str().to_string())
             .collect(),
         market: vec![market_source.name().to_string()],
     }
@@ -92,6 +95,7 @@ pub(crate) fn summarize(report: &SpeculationReport) -> String {
 
 pub async fn run_analyze(
     args: AnalyzeArgs,
+    social_sources: &[Box<dyn SocialDataSource>],
     market_source: &dyn MarketDataSource,
 ) -> Result<AnalyzeOutput, DomainError> {
     let req = request_from(
@@ -102,7 +106,7 @@ pub async fn run_analyze(
         args.no_market,
         args.limit,
     );
-    let report = application::analyze(&req, Some(market_source)).await?;
+    let report = application::analyze(&req, social_sources, Some(market_source)).await?;
     Ok(AnalyzeOutput {
         summary: summarize(&report),
         report,
@@ -138,7 +142,11 @@ pub struct ScanOutput {
     pub disclaimer: &'static str,
 }
 
-pub async fn run_scan(args: ScanArgs, market_source: &dyn MarketDataSource) -> ScanOutput {
+pub async fn run_scan(
+    args: ScanArgs,
+    social_sources: &[Box<dyn SocialDataSource>],
+    market_source: &dyn MarketDataSource,
+) -> ScanOutput {
     let ScanArgs {
         tickers,
         enable_reddit,
@@ -156,7 +164,7 @@ pub async fn run_scan(args: ScanArgs, market_source: &dyn MarketDataSource) -> S
             no_market,
             limit,
         );
-        match application::analyze(&req, Some(market_source)).await {
+        match application::analyze(&req, social_sources, Some(market_source)).await {
             Ok(report) => ScanEntry {
                 ticker: t,
                 report: Some(report),
@@ -249,7 +257,11 @@ pub(crate) fn sort_ranked(ranked: &mut [RankedEntry], rank_by: RankBy) {
     });
 }
 
-pub async fn run_compare(args: CompareArgs, market_source: &dyn MarketDataSource) -> CompareOutput {
+pub async fn run_compare(
+    args: CompareArgs,
+    social_sources: &[Box<dyn SocialDataSource>],
+    market_source: &dyn MarketDataSource,
+) -> CompareOutput {
     let CompareArgs {
         tickers,
         rank_by,
@@ -268,7 +280,10 @@ pub async fn run_compare(args: CompareArgs, market_source: &dyn MarketDataSource
             no_market,
             limit,
         );
-        (t, application::analyze(&req, Some(market_source)).await)
+        (
+            t,
+            application::analyze(&req, social_sources, Some(market_source)).await,
+        )
     });
     let results = futures::future::join_all(futures).await;
 
@@ -304,10 +319,21 @@ pub async fn run_compare(args: CompareArgs, market_source: &dyn MarketDataSource
 mod tests {
     use super::*;
     use crate::adapters::market::mock_market::MockMarketSource;
+    use crate::adapters::sources::mock_bluesky::MockBlueskySource;
+    use crate::adapters::sources::mock_reddit::MockRedditSource;
+    use crate::adapters::sources::mock_x::MockXSource;
+
+    fn mock_social() -> Vec<Box<dyn SocialDataSource>> {
+        vec![
+            Box::new(MockRedditSource),
+            Box::new(MockXSource),
+            Box::new(MockBlueskySource),
+        ]
+    }
 
     #[test]
     fn list_sources_reports_all_adapters() {
-        let out = run_list_sources(&MockMarketSource);
+        let out = run_list_sources(&mock_social(), &MockMarketSource);
         assert_eq!(out.social, vec!["reddit", "x", "bluesky"]);
         assert_eq!(out.market, vec!["mock-market"]);
     }
@@ -323,6 +349,7 @@ mod tests {
                 no_market: None,
                 limit: None,
             },
+            &mock_social(),
             &MockMarketSource,
         )
         .await
@@ -342,7 +369,9 @@ mod tests {
             no_market: None,
             limit: None,
         };
-        assert!(run_analyze(args, &MockMarketSource).await.is_err());
+        assert!(run_analyze(args, &mock_social(), &MockMarketSource)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
@@ -356,6 +385,7 @@ mod tests {
                 no_market: None,
                 limit: None,
             },
+            &mock_social(),
             &MockMarketSource,
         )
         .await;
@@ -376,6 +406,7 @@ mod tests {
                 no_market: None,
                 limit: None,
             },
+            &mock_social(),
             &MockMarketSource,
         )
         .await;
@@ -458,6 +489,7 @@ mod tests {
                 no_market: None,
                 limit: None,
             },
+            &mock_social(),
             &MockMarketSource,
         )
         .await;

--- a/tests/analyze_flow.rs
+++ b/tests/analyze_flow.rs
@@ -1,6 +1,10 @@
 use openintel::adapters::market::mock_market::MockMarketSource;
+use openintel::adapters::sources::mock_bluesky::MockBlueskySource;
+use openintel::adapters::sources::mock_reddit::MockRedditSource;
+use openintel::adapters::sources::mock_x::MockXSource;
 use openintel::cli::run::analyze;
 use openintel::config::settings::{AppConfig, OutputFormat};
+use openintel::domain::ports::social_data_source::SocialDataSource;
 use openintel::domain::values::speculation::Alignment;
 
 fn cfg(reddit: bool, x: bool, bluesky: bool, no_market: bool) -> AppConfig {
@@ -15,11 +19,23 @@ fn cfg(reddit: bool, x: bool, bluesky: bool, no_market: bool) -> AppConfig {
     )
 }
 
+fn mock_social() -> Vec<Box<dyn SocialDataSource>> {
+    vec![
+        Box::new(MockRedditSource),
+        Box::new(MockXSource),
+        Box::new(MockBlueskySource),
+    ]
+}
+
 #[tokio::test]
 async fn end_to_end_all_sources_with_market() {
-    let (report, json) = analyze(&cfg(false, false, false, false), Some(&MockMarketSource))
-        .await
-        .unwrap();
+    let (report, json) = analyze(
+        &cfg(false, false, false, false),
+        &mock_social(),
+        Some(&MockMarketSource),
+    )
+    .await
+    .unwrap();
     // 4 + 3 + 3 mock posts across reddit/x/bluesky (>= min_sample of 10)
     assert_eq!(report.social.total_mentions, 10);
     assert_eq!(report.fusion.alignment, Alignment::ConfirmingBullish);
@@ -30,15 +46,19 @@ async fn end_to_end_all_sources_with_market() {
 
 #[tokio::test]
 async fn single_source_only() {
-    let (report, _) = analyze(&cfg(true, false, false, false), Some(&MockMarketSource))
-        .await
-        .unwrap();
+    let (report, _) = analyze(
+        &cfg(true, false, false, false),
+        &mock_social(),
+        Some(&MockMarketSource),
+    )
+    .await
+    .unwrap();
     assert_eq!(report.social.total_mentions, 4); // reddit fixtures only
 }
 
 #[tokio::test]
 async fn social_only_when_market_disabled() {
-    let (report, _) = analyze(&cfg(false, false, false, true), None)
+    let (report, _) = analyze(&cfg(false, false, false, true), &mock_social(), None)
         .await
         .unwrap();
     assert!(report.market.is_none());


### PR DESCRIPTION
Adds a real **Reddit** `SocialDataSource` (app-only OAuth) and the social-side DI refactor that wires it in. Reddit is live when configured; X and Bluesky stay mock. (Verified live that keyless Reddit is 403/blocked — OAuth is the only path; Bluesky/X are separate future cycles.)

## What's here
- **Pure parser** (`adapters/sources/reddit/response.rs`) — Reddit search JSON → `SocialPost`, char-safe truncation to the shared `MAX_POST_LEN`, skip-conditions, fully unit-tested.
- **OAuth + token cache** (`reddit/auth.rs`) — `client_credentials` grant, `parse_token`/`is_expired` pure + tested; **`RwLock` single-flight cache** refreshed 60s early.
- **`RedditSource`** (`reddit/mod.rs`) — token + finance-subreddit search (`r/wallstreetbets+stocks+options+investing+StockMarket`), mandatory descriptive User-Agent, 10s timeout.
- **Social-side DI** — `analyze()` + MCP tools take an injected `&[Box<dyn SocialDataSource>]`; `build_social_sources(&Credentials)` (shared by both composition roots) wires `RedditSource` only when both creds are set; tests inject mocks. `list_sources` now reports actually-wired sources.
- Env creds `OPENINTEL_REDDIT_CLIENT_ID`/`OPENINTEL_REDDIT_CLIENT_SECRET`, `SecretString`, README OAuth setup.

## Guarantees
- **Hermetic** `cargo test` — the only network tests are `#[ignore]`d.
- Secrets never logged (`.expose_secret()` only at the two HTTP header sites), never in the URL/query; `TokenResponse` doesn't derive `Debug`.
- No creds → Reddit gracefully omitted with a `reddit enabled but not configured` note; market + other sources still run. All failures → `SourceFailure`; no `unwrap` on network data. MCP stdout path stays clean.

## Verification
- 91 lib + 3 integration tests pass; clippy `-D warnings` clean; fmt clean.
- Spec: `docs/superpowers/specs/2026-07-01-reddit-social-adapter-design.md`; plan: `docs/superpowers/plans/2026-07-02-reddit-social-adapter.md`.
- Subagent-driven build; per-task reviews + opus whole-branch review (verdict: ready to merge, with the pre-merge tidy-ups applied).

**Follow-ups (deferred, non-blocking):** fold a truncated response-body snippet into 401/429 errors; add HTTP-mock coverage for the `ensure_token` cache/refresh path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Reddit social data support when OAuth credentials are configured (OAuth-enabled; otherwise omitted with clear warnings).
  * Analyze and MCP flows now use the configured social sources explicitly for clearer visibility.
* **Documentation**
  * Updated README setup/status info for live market data vs partially live social sources, including required Reddit OAuth environment variables and behavior when missing.
  * Added Reddit adapter implementation plan and design spec; refreshed architecture/extending guidance.
* **Bug Fixes**
  * Improved reporting when a source is enabled but not available, while other sources still contribute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->