### PR TITLE
chore(security): env-only secret hardening (.env.example, SECURITY.md, gitleaks CI)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# openintel credentials — template.
+#
+# Copy to a gitignored .env and fill in, then load it into your shell
+# (e.g. `direnv`, or `set -a; . ./.env; set +a`). openintel reads these ONLY
+# from the process environment — it never reads a committed file and never
+# writes secrets to disk. NEVER commit real values (.env is gitignored).
+
+# --- Reddit (real social source) ---
+# Both are REQUIRED to enable Reddit. Create a "script" app at
+# https://www.reddit.com/prefs/apps — the client id is shown under the app
+# name, the secret next to it. Then run: `openintel analyze AAPL --enable-reddit`.
+OPENINTEL_REDDIT_CLIENT_ID=
+OPENINTEL_REDDIT_CLIENT_SECRET=
+
+# --- Market data ---
+# Yahoo Finance (the current market source) is KEYLESS — leave this unset.
+# Reserved for a future keyed market provider.
+OPENINTEL_MARKET_API_KEY=
+
+# --- Not yet wired to real adapters (mock today) ---
+# Reserved for when the X and Bluesky sources land.
+OPENINTEL_X_BEARER=
+OPENINTEL_BLUESKY_APP_PASSWORD=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default for all jobs (both only read the repo).
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --all-targets
       - run: cargo test
@@ -23,9 +29,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history so gitleaks scans every commit, not just the tip
+          persist-credentials: false # don't leave GITHUB_TOKEN in .git/config for gitleaks to scan
       - name: gitleaks
         env:
-          GITLEAKS_VERSION: 8.30.1 # gitleaks CLI, run directly (no org license, unlike gitleaks-action)
+          # gitleaks CLI, run directly (no org license, unlike gitleaks-action).
+          # Pin the version AND verify the tarball's SHA256 so a swapped/tampered
+          # release can't inject a binary — the hash is trusted from the repo, not the download.
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
         run: |
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          curl -sSfL -o gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
           ./gitleaks detect --source . --redact --no-banner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,16 @@ jobs:
       - run: cargo test
       - run: cargo clippy -- -D warnings
       - run: cargo fmt -- --check
+
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so gitleaks scans every commit, not just the tip
+      - name: gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1 # gitleaks CLI, run directly (no org license, unlike gitleaks-action)
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks detect --source . --redact --no-banner

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Credentials & secrets
+
+openintel reads all credentials **only from environment variables** (see
+[`.env.example`](.env.example)). It never reads them from a committed file and
+never writes them to disk. Secrets are wrapped in `secrecy::SecretString`
+(redacted in debug output, zeroized on drop) and are never logged. When
+openintel runs as an MCP server, the credentials stay in its process
+environment — the connected AI agent never sees them.
+
+**Never commit real credentials:**
+
+- Use a gitignored `.env` (already in `.gitignore`) or export the variables in
+  your shell. Do **not** `git add -f` a `.env`.
+- Never hardcode a secret in source — the env-only design exists so you never
+  have to, and code review should reject any hardcoded key.
+- Prefer a gitignored `.env` + `direnv` over exporting inline (which lands in
+  shell history).
+
+CI runs a [`gitleaks`](https://github.com/gitleaks/gitleaks) secret scan over
+the full git history on every push and pull request; an accidentally-committed
+key fails the build before it can merge.
+
+## Reporting a vulnerability
+
+Please report security issues privately via GitHub's
+[private vulnerability reporting](https://github.com/Kloudy-Sky/openintel/security/advisories/new)
+rather than opening a public issue. We will acknowledge and respond as soon as
+we can.
+
+## Scope reminder
+
+openintel is **analysis-only**: it never executes trades, touches a broker, or
+holds broker credentials. Trade execution happens only through your broker's own
+MCP, gated by that broker's controls and your approval. Read the README's risk
+section before connecting one.


### PR DESCRIPTION
Makes openintel's env-only secret model **safe-by-default for open-source contributors** — answering "will my OAuth creds ever get pushed?" with a structural *no*.

## What's here
- **`.env.example`** — committed template listing every `OPENINTEL_*` var with empty placeholders + comments (Reddit needs both OAuth values; Yahoo is keyless; X/Bluesky reserved). Contributors `cp .env.example .env` (`.env` is already gitignored) and fill it in.
- **`SECURITY.md`** — the env-only credential policy, "never commit secrets / don't `git add -f .env` / don't hardcode" guidance, private vulnerability reporting, and the analysis-only scope reminder.
- **CI `secret-scan` job** — runs the `gitleaks` CLI (pinned `v8.30.1`, invoked directly so there's **no org license requirement** that `gitleaks-action` would impose on this org-owned repo) over full git history on every push/PR; fails the build on any committed key.

## Why this is belt-and-suspenders
Credentials are read **only from environment variables** (`std::env::var`) and never written to disk, so there is no secret file in the tree to commit in the first place. This PR documents that, gives contributors a safe template, and adds a scanner that catches an accidental key (or a hardcoded one) before it can merge.

## Verification
- gitleaks v8.30.1 scanned all 85 commits locally → **no leaks found**.
- `.env` ignored / `.env.example` committable confirmed; workflow YAML validated.
- No Rust code changed — existing `ci` stays green.

Note: `secret-scan` runs on every PR but isn't a *required* status check yet — add it to branch protection if you want it to block merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an environment-variable template with placeholders for required and optional credentials.
  * Published a security policy describing secret-handling practices and vulnerability reporting.

* **Chores**
  * Tightened CI workflow permissions and enhanced CI validation (including formatting checks).
  * Added automated secret scanning to detect leaked credentials using repository-wide history inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->