### PR TITLE
feat(cli): interactive setup — prompt, live verify, OS keychain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
-# openintel credentials — template.
+# openintel credentials — env-var template (CI / power users).
 #
-# Copy to a gitignored .env and fill in, then load it into your shell
-# (e.g. `direnv`, or `set -a; . ./.env; set +a`). openintel reads these ONLY
-# from the process environment — it never reads a committed file and never
-# writes secrets to disk. NEVER commit real values (.env is gitignored).
+# Most users don't need this file: run `openintel setup reddit` /
+# `openintel setup bluesky` for a guided flow that verifies live and saves
+# to your OS keychain. Env vars, when set, always OVERRIDE the keychain.
+# If you do use a .env: keep it gitignored, load via direnv or
+# `set -a; . ./.env; set +a`, and NEVER commit real values.
 
 # --- Reddit (real social source) ---
 # Both are REQUIRED to enable Reddit. Create a "script" app at

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +80,137 @@ dependencies = [
  "once_cell_polyfill",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797f94b6a53d7d10b56dc18290e0d40a2158352f108bb4ff32350825081a9f29"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -120,16 +271,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -167,6 +364,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -235,6 +442,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +465,31 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -285,6 +526,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +558,76 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -377,6 +699,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +752,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,10 +789,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -680,6 +1061,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,10 +1169,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "4.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ee8d4dae108d4177d0a0ce241f98acc1ef28e20837bdef43cff4d160cf70fe"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -798,6 +1226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +1243,69 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -838,6 +1338,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "keyring",
  "reqwest",
  "rmcp",
  "schemars",
@@ -853,6 +1354,22 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "pastey"
@@ -873,10 +1390,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -894,6 +1436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1026,6 +1577,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1702,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1259,6 +1852,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,10 +1954,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd_cesu8"
@@ -1432,6 +2076,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1529,6 +2186,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +2298,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +2349,23 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1813,6 +2534,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-result"
@@ -1989,6 +2723,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,6 +2764,78 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
 ]
 
 [[package]]
@@ -2108,3 +2923,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "keyring",
  "reqwest",
  "rmcp",
+ "rpassword",
  "schemars",
  "secrecy",
  "serde",
@@ -1687,6 +1688,27 @@ dependencies = [
  "quote",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2571,6 +2593,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ rmcp = { version = "2", features = ["transport-io"] }
 schemars = "1"
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }
 base64 = "0.22"
+keyring = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ schemars = "1"
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }
 base64 = "0.22"
 keyring = "4"
+rpassword = "7"

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Hexagonal (ports & adapters). The domain is pure and synchronous; IO and the clo
 
 - `domain/` — entities, value objects, the pure `SpeculationEngine`, and port traits.
 - `adapters/` — `LexiconAnalyzer`, the `YahooMarketSource` (real, keyless), the `RedditSource` and `BlueskySource` (real, credential-gated — no mock sources).
-- `config/` — env-only secrets (`secrecy`) and runtime settings.
+- `config/` — secrets resolution (env + OS keychain, via `secrecy`) and runtime settings.
 - `cli/` — clap args, orchestration, rendering.
 
 Secrets come from environment variables (`OPENINTEL_REDDIT_CLIENT_ID`, `OPENINTEL_REDDIT_CLIENT_SECRET`, `OPENINTEL_BLUESKY_HANDLE`, `OPENINTEL_BLUESKY_APP_PASSWORD`, `OPENINTEL_MARKET_API_KEY`) or the OS keychain (written only by `openintel setup` after a live verify; env always wins), wrapped in `SecretString` — plaintext never touches disk, never logged.

--- a/README.md
+++ b/README.md
@@ -43,37 +43,37 @@ openintel analyze AAPL --no-market --format json
 
 ## Enable the Reddit source (optional)
 
-Reddit requires OAuth (there is no keyless access). One-time setup:
+Run `openintel setup reddit` — it walks you through creating a free script app, verifies your credentials live, and saves them to your OS keychain. Rotate by re-running it; remove with `openintel setup reddit --forget`.
 
-1. Create a **script** app at <https://www.reddit.com/prefs/apps> → note the **client id** (under the app name) and **secret**.
-2. Export them, verify, then run:
+<details>
+<summary>CI / power users: environment variables instead</summary>
+
+Env vars always override the keychain. Create a **script** app at <https://www.reddit.com/prefs/apps>, then:
 
 ```bash
 export OPENINTEL_REDDIT_CLIENT_ID=your_client_id
 export OPENINTEL_REDDIT_CLIENT_SECRET=your_secret
-openintel setup reddit                     # ✅ live-checks your credentials
-openintel analyze AAPL --enable-reddit
+openintel setup reddit   # non-interactive when piped; verifies from env
 ```
 
-Not sure where to start? Run `openintel setup reddit` with neither variable set for a guided walkthrough.
-
-Without these, `--enable-reddit` yields a `reddit enabled but not configured` note and the other sources still run. Credentials are read only from the environment, wrapped in `SecretString` (never logged or written to disk), and sent only to Reddit over TLS.
+</details>
 
 ## Enable the Bluesky source (optional)
 
-Bluesky search requires auth — a free app password (any Bluesky account, no fees). One-time setup:
+Run `openintel setup bluesky` — it walks you through creating a free app password, verifies your credentials live, and saves them to your OS keychain. Rotate by re-running it; remove with `openintel setup bluesky --forget`.
 
-1. Sign in at <https://bsky.app> → Settings → Privacy and Security → **App Passwords** → add one named `openintel` (the value is shown once).
-2. Export handle + app password, verify, then run:
+<details>
+<summary>CI / power users: environment variables instead</summary>
+
+Env vars always override the keychain. Get your handle and create an app password at <https://bsky.app/settings/app-passwords>, then:
 
 ```bash
 export OPENINTEL_BLUESKY_HANDLE=yourname.bsky.social
 export OPENINTEL_BLUESKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
-openintel setup bluesky                    # ✅ live-checks your credentials
-openintel analyze AAPL --enable-bluesky
+openintel setup bluesky   # non-interactive when piped; verifies from env
 ```
 
-Not sure where to start? Run `openintel setup bluesky` with neither variable set for a guided walkthrough.
+</details>
 
 ## Use with an AI agent (MCP)
 
@@ -149,7 +149,7 @@ Hexagonal (ports & adapters). The domain is pure and synchronous; IO and the clo
 - `config/` — env-only secrets (`secrecy`) and runtime settings.
 - `cli/` — clap args, orchestration, rendering.
 
-Secrets come only from environment variables (`OPENINTEL_REDDIT_CLIENT_ID`, `OPENINTEL_REDDIT_CLIENT_SECRET`, `OPENINTEL_BLUESKY_HANDLE`, `OPENINTEL_BLUESKY_APP_PASSWORD`, `OPENINTEL_MARKET_API_KEY`), wrapped in `SecretString` — never logged or written to disk.
+Secrets come from environment variables (`OPENINTEL_REDDIT_CLIENT_ID`, `OPENINTEL_REDDIT_CLIENT_SECRET`, `OPENINTEL_BLUESKY_HANDLE`, `OPENINTEL_BLUESKY_APP_PASSWORD`, `OPENINTEL_MARKET_API_KEY`) or the OS keychain (written only by `openintel setup` after a live verify; env always wins), wrapped in `SecretString` — plaintext never touches disk, never logged.
 
 ## Extending
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,17 @@
 
 ## Credentials & secrets
 
-openintel reads all credentials **only from environment variables** (see
-[`.env.example`](.env.example)). It never reads them from a committed file and
-never writes them to disk. Secrets are wrapped in `secrecy::SecretString`
-(redacted in debug output, zeroized on drop) and are never logged. When
-openintel runs as an MCP server, the credentials stay in its process
-environment — the connected AI agent never sees them.
+openintel reads credentials from **environment variables** (see
+[`.env.example`](.env.example)) or from your **OS keychain** (macOS Keychain /
+Windows Credential Manager / Linux secret-service). The keychain is written
+only by `openintel setup <source>` — after a successful live verification —
+and env vars always take precedence. Plaintext credentials never touch disk:
+interactive setup reads secrets with hidden input (nothing lands in shell
+history or scrollback) directly into `secrecy::SecretString` (redacted in
+debug output, zeroized on drop), and they are never logged. Remove stored
+credentials anytime with `openintel setup <source> --forget`. When openintel
+runs as an MCP server, credentials stay in its process — the connected AI
+agent never sees them.
 
 **Never commit real credentials:**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,8 +18,7 @@ agent never sees them.
 
 - Use a gitignored `.env` (already in `.gitignore`) or export the variables in
   your shell. Do **not** `git add -f` a `.env`.
-- Never hardcode a secret in source — the env-only design exists so you never
-  have to, and code review should reject any hardcoded key.
+- Never hardcode a secret in source — `openintel setup` and the env-only override path exist so you never have to, and code review should reject any hardcoded key.
 - Prefer a gitignored `.env` + `direnv` over exporting inline (which lands in
   shell history).
 

--- a/docs/superpowers/plans/2026-07-13-interactive-setup.md
+++ b/docs/superpowers/plans/2026-07-13-interactive-setup.md
@@ -1,0 +1,1001 @@
+# Interactive Setup (Prompt → Verify → Keychain) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `openintel setup <source>` becomes a one-command flow — guide → hidden-input prompts → live verify → persist to the OS keychain — with env vars always overriding.
+
+**Architecture:** A `CredentialStore` port in `config/store.rs` (real adapter = `keyring` crate; in-memory fake for tests); `Credentials::load(store)` resolves env → keychain per field; the interactive loop in `cli/setup.rs` is generic over injected I/O + probe so it is fully unit-testable. Non-TTY keeps today's exact behavior.
+
+**Tech Stack:** Rust, `keyring = "4"` (default features: macOS/Windows/Linux stores), `rpassword = "7"` (hidden input), `std::io::IsTerminal`, secrecy, tokio.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-interactive-setup-design.md` — copy verbatim from it.
+
+## Global Constraints
+
+- **Env always wins**: `Credentials::load` = env var (non-empty) → keychain → None. A store *malfunction* (not absence) warns to stderr and falls back to env — the keychain must never break `analyze` or the MCP server.
+- **Keychain written only by `setup`, only after a successful live verify.**
+- **Keychain keys = env-var names**, service `"openintel"`: `OPENINTEL_REDDIT_CLIENT_ID`, `OPENINTEL_REDDIT_CLIENT_SECRET`, `OPENINTEL_BLUESKY_HANDLE`, `OPENINTEL_BLUESKY_APP_PASSWORD`. `OPENINTEL_MARKET_API_KEY` stays env-only.
+- **New `.expose_secret()` sites in src/: exactly two** — `KeychainStore::set` (keyring takes `&str`) and the handle SecretString→String unwrap in `Credentials::load` (the handle is public info). Nowhere else; prompt input goes straight into `SecretString`.
+- **Never print or store secret values in fallback output** — the save-failure fallback prints `export` lines with placeholder values, not the typed secrets (nothing in scrollback).
+- **Non-TTY behavior byte-identical to today** (guide/partial/verify, same copy, same exit codes) except credentials come from `Credentials::load`.
+- **Interactive caps:** max 3 verify attempts; empty input re-asks; already-configured asks `Replace it? [y/N]` (default N = verify-only).
+- **keyring API** (verified from docs.rs 4.1.4): `keyring::v1::Entry::new(service, user) -> Result<Entry>`, `get_password() -> Result<String>`, `set_password(&str)`, `delete_credential()`, error enum `keyring::v1::Error` with a `NoEntry` variant. If the compiler disagrees with these exact paths (e.g. root re-exports), adapt imports only — behavior as specified.
+- **Hermetic tests:** no real keychain access in `cargo test` (one `#[ignore]`d round-trip); no network; no TTY needed (injected I/O).
+- **stdout discipline:** `println!` only in `src/cli/setup.rs` + `src/main.rs`; store warnings via `eprintln!`.
+- **Every commit green:** `cargo build --all-targets && cargo test && cargo clippy -- -D warnings && cargo fmt -- --check`.
+
+---
+
+### Task 1: The `CredentialStore` port + keychain adapter
+
+**Files:**
+- Create: `src/config/store.rs`
+- Modify: `src/config/mod.rs`, `Cargo.toml` (+`keyring = "4"`)
+
+**Interfaces:**
+- Produces: `pub trait CredentialStore { fn get(&self, key: &str) -> Result<Option<SecretString>, StoreError>; fn set(&self, key: &str, value: &SecretString) -> Result<(), StoreError>; fn delete(&self, key: &str) -> Result<(), StoreError>; }`; `pub struct KeychainStore` (+ `new()`, `Default`); `pub struct StoreError(pub String)` (Display + Error); `#[cfg(test)] pub(crate) struct InMemoryStore` with `new()`, `failing()`, and test-visible contents. Tasks 2–3 consume all of these.
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `cargo add keyring@4`
+Expected: resolves 4.x with default features (apple/windows/linux stores bundled).
+
+- [ ] **Step 2: Create `src/config/store.rs`**
+
+```rust
+//! Credential-store port: the OS keychain behind a small trait so tests can
+//! use an in-memory fake and the keychain can never break the analysis path.
+//!
+//! Written ONLY by `openintel setup` (after a successful live verify); read
+//! as a fallback by `Credentials::load` — env vars always win.
+
+use secrecy::{ExposeSecret, SecretString};
+
+/// Service name under which all openintel keys live in the OS store.
+const SERVICE: &str = "openintel";
+
+/// Store malfunction (backend unavailable, access denied, …). Absence of a
+/// key is NOT an error — `get` returns `Ok(None)` and `delete` is idempotent.
+#[derive(Debug)]
+pub struct StoreError(pub String);
+
+impl std::fmt::Display for StoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+pub trait CredentialStore {
+    /// Ok(None) = key not present.
+    fn get(&self, key: &str) -> Result<Option<SecretString>, StoreError>;
+    fn set(&self, key: &str, value: &SecretString) -> Result<(), StoreError>;
+    /// Idempotent: deleting an absent key is Ok.
+    fn delete(&self, key: &str) -> Result<(), StoreError>;
+}
+
+/// Real adapter over the OS keychain (macOS Keychain / Windows Credential
+/// Manager / Linux secret-service) via the `keyring` crate.
+#[derive(Default)]
+pub struct KeychainStore;
+
+impl KeychainStore {
+    pub fn new() -> Self {
+        KeychainStore
+    }
+
+    fn entry(key: &str) -> Result<keyring::v1::Entry, StoreError> {
+        keyring::v1::Entry::new(SERVICE, key)
+            .map_err(|e| StoreError(format!("keychain entry for {key}: {e}")))
+    }
+}
+
+impl CredentialStore for KeychainStore {
+    fn get(&self, key: &str) -> Result<Option<SecretString>, StoreError> {
+        match Self::entry(key)?.get_password() {
+            Ok(v) => Ok(Some(SecretString::new(v.into_boxed_str()))),
+            Err(keyring::v1::Error::NoEntry) => Ok(None),
+            Err(e) => Err(StoreError(format!("keychain read for {key}: {e}"))),
+        }
+    }
+
+    fn set(&self, key: &str, value: &SecretString) -> Result<(), StoreError> {
+        Self::entry(key)?
+            .set_password(value.expose_secret())
+            .map_err(|e| StoreError(format!("keychain write for {key}: {e}")))
+    }
+
+    fn delete(&self, key: &str) -> Result<(), StoreError> {
+        match Self::entry(key)?.delete_credential() {
+            Ok(()) | Err(keyring::v1::Error::NoEntry) => Ok(()),
+            Err(e) => Err(StoreError(format!("keychain delete for {key}: {e}"))),
+        }
+    }
+}
+
+/// In-memory fake for hermetic tests. `failing()` errors on every operation
+/// (simulates a broken keychain backend).
+#[cfg(test)]
+pub(crate) struct InMemoryStore {
+    pub map: std::cell::RefCell<std::collections::HashMap<String, SecretString>>,
+    fail: bool,
+}
+
+#[cfg(test)]
+impl InMemoryStore {
+    pub fn new() -> Self {
+        InMemoryStore {
+            map: std::cell::RefCell::new(std::collections::HashMap::new()),
+            fail: false,
+        }
+    }
+
+    pub fn failing() -> Self {
+        InMemoryStore {
+            map: std::cell::RefCell::new(std::collections::HashMap::new()),
+            fail: true,
+        }
+    }
+
+    pub fn seed(self, key: &str, value: &str) -> Self {
+        self.map.borrow_mut().insert(
+            key.to_string(),
+            SecretString::new(value.to_string().into_boxed_str()),
+        );
+        self
+    }
+}
+
+#[cfg(test)]
+impl CredentialStore for InMemoryStore {
+    fn get(&self, key: &str) -> Result<Option<SecretString>, StoreError> {
+        if self.fail {
+            return Err(StoreError("simulated store failure".into()));
+        }
+        Ok(self.map.borrow().get(key).cloned())
+    }
+
+    fn set(&self, key: &str, value: &SecretString) -> Result<(), StoreError> {
+        if self.fail {
+            return Err(StoreError("simulated store failure".into()));
+        }
+        self.map.borrow_mut().insert(key.to_string(), value.clone());
+        Ok(())
+    }
+
+    fn delete(&self, key: &str) -> Result<(), StoreError> {
+        if self.fail {
+            return Err(StoreError("simulated store failure".into()));
+        }
+        self.map.borrow_mut().remove(key);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secret(s: &str) -> SecretString {
+        SecretString::new(s.to_string().into_boxed_str())
+    }
+
+    #[test]
+    fn in_memory_round_trip_and_idempotent_delete() {
+        let store = InMemoryStore::new();
+        assert!(store.get("K").unwrap().is_none());
+        store.set("K", &secret("v")).unwrap();
+        assert_eq!(store.get("K").unwrap().unwrap().expose_secret(), "v");
+        store.delete("K").unwrap();
+        assert!(store.get("K").unwrap().is_none());
+        store.delete("K").unwrap(); // absent -> still Ok
+    }
+
+    #[test]
+    fn failing_store_errors_on_every_op() {
+        let store = InMemoryStore::failing();
+        assert!(store.get("K").is_err());
+        assert!(store.set("K", &secret("v")).is_err());
+        assert!(store.delete("K").is_err());
+    }
+
+    /// Touches the real OS keychain — run manually: `cargo test --ignored keychain_live`
+    #[test]
+    #[ignore = "mutates the developer's real OS keychain; run with --ignored"]
+    fn keychain_live_round_trip() {
+        let store = KeychainStore::new();
+        let key = "OPENINTEL_TEST_ROUND_TRIP";
+        store.set(key, &secret("test-value")).unwrap();
+        assert_eq!(
+            store.get(key).unwrap().unwrap().expose_secret(),
+            "test-value"
+        );
+        store.delete(key).unwrap();
+        assert!(store.get(key).unwrap().is_none());
+    }
+}
+```
+
+- [ ] **Step 3: Register the module**
+
+`src/config/mod.rs`:
+
+```rust
+pub mod secrets;
+pub mod settings;
+pub mod store;
+```
+
+- [ ] **Step 4: Run the store tests**
+
+Run: `cargo test --lib config::store`
+Expected: PASS (2 tests, 1 ignored).
+
+- [ ] **Step 5: Full verification + commit**
+
+Run: `cargo build --all-targets && cargo test && cargo clippy -- -D warnings && cargo fmt`
+Expected: green.
+
+```bash
+git add src/config/store.rs src/config/mod.rs Cargo.toml Cargo.lock
+git commit -m "feat(config): CredentialStore port + OS keychain adapter
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `Credentials::load` + composition roots
+
+**Files:**
+- Modify: `src/config/secrets.rs`, `src/main.rs:14`, `src/mcp/server.rs:112`
+
+**Interfaces:**
+- Consumes: Task 1's `CredentialStore`, `KeychainStore`, `InMemoryStore`, `StoreError`.
+- Produces: `Credentials::load(store: &dyn CredentialStore) -> Credentials` — env-over-keychain per field. Both composition roots now call it; Task 3 relies on `main.rs` having a `store` binding in scope.
+
+- [ ] **Step 1: Add `load` to `src/config/secrets.rs`**
+
+Add imports at top: `use crate::config::store::CredentialStore;` and extend the secrecy import to `use secrecy::{ExposeSecret, SecretString};`. Then inside `impl Credentials`, after `from_env`:
+
+```rust
+    /// Resolve credentials with precedence: environment variable (non-empty)
+    /// -> OS keychain -> unset. A store malfunction warns and falls back to
+    /// env-only for that field — the keychain can never break analysis.
+    pub fn load(store: &dyn CredentialStore) -> Self {
+        let mut c = Credentials::from_env();
+        c.reddit_client_id = c
+            .reddit_client_id
+            .or_else(|| store_get(store, "OPENINTEL_REDDIT_CLIENT_ID"));
+        c.reddit_client_secret = c
+            .reddit_client_secret
+            .or_else(|| store_get(store, "OPENINTEL_REDDIT_CLIENT_SECRET"));
+        // The handle is public info (kept as a plain String on Credentials);
+        // unwrap the store's SecretString wrapper at this one site.
+        c.bluesky_handle = c.bluesky_handle.or_else(|| {
+            store_get(store, "OPENINTEL_BLUESKY_HANDLE")
+                .map(|s| s.expose_secret().to_string())
+        });
+        c.bluesky_app_password = c
+            .bluesky_app_password
+            .or_else(|| store_get(store, "OPENINTEL_BLUESKY_APP_PASSWORD"));
+        c
+    }
+```
+
+And below `plain_from`:
+
+```rust
+/// Keychain read that treats malfunction as "unavailable" (with a warning)
+/// rather than fatal. Absence is a plain None.
+fn store_get(store: &dyn CredentialStore, key: &str) -> Option<SecretString> {
+    match store.get(key) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("warning: credential store unavailable for {key}: {e}");
+            None
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Precedence tests** (append to the existing `mod tests`; note env-var tests must not collide with real env — use the store-only paths without setting env, and env-over-store via a var name that IS set: instead, test precedence through `from_env`-independent construction):
+
+```rust
+    #[test]
+    fn load_falls_back_to_store_when_env_unset() {
+        use crate::config::store::{CredentialStore, InMemoryStore};
+        let store = InMemoryStore::new()
+            .seed("OPENINTEL_REDDIT_CLIENT_ID", "store-id")
+            .seed("OPENINTEL_REDDIT_CLIENT_SECRET", "store-secret")
+            .seed("OPENINTEL_BLUESKY_HANDLE", "store.bsky.social")
+            .seed("OPENINTEL_BLUESKY_APP_PASSWORD", "store-pw");
+        // Guard: these env vars must not leak into the test environment.
+        for key in [
+            "OPENINTEL_REDDIT_CLIENT_ID",
+            "OPENINTEL_REDDIT_CLIENT_SECRET",
+            "OPENINTEL_BLUESKY_HANDLE",
+            "OPENINTEL_BLUESKY_APP_PASSWORD",
+        ] {
+            if std::env::var(key).map(|v| !v.is_empty()).unwrap_or(false) {
+                eprintln!("skipping load_falls_back_to_store_when_env_unset: {key} set in env");
+                return;
+            }
+        }
+        let c = Credentials::load(&store);
+        assert_eq!(
+            c.reddit_client_id.unwrap().expose_secret(),
+            "store-id"
+        );
+        assert_eq!(
+            c.reddit_client_secret.unwrap().expose_secret(),
+            "store-secret"
+        );
+        assert_eq!(c.bluesky_handle.as_deref(), Some("store.bsky.social"));
+        assert_eq!(
+            c.bluesky_app_password.unwrap().expose_secret(),
+            "store-pw"
+        );
+        // Unrelated read never touched the store's error path
+        let _ = &store as &dyn CredentialStore;
+    }
+
+    #[test]
+    fn load_survives_a_broken_store() {
+        use crate::config::store::InMemoryStore;
+        let store = InMemoryStore::failing();
+        let c = Credentials::load(&store); // must not panic; falls back to env-only
+        // Whatever env says is what we get; a broken keychain adds nothing.
+        let env_only = Credentials::from_env();
+        assert_eq!(c.reddit_client_id.is_some(), env_only.reddit_client_id.is_some());
+        assert_eq!(c.bluesky_handle.is_some(), env_only.bluesky_handle.is_some());
+    }
+```
+
+(Env-over-store precedence is structurally guaranteed by `.or_else` on the
+`from_env` result; the skip-guard pattern above avoids mutating the process
+environment, which is unsafe under a threaded test runner.)
+
+- [ ] **Step 3: Switch the composition roots**
+
+`src/main.rs` — replace line 14 (`let credentials = Credentials::from_env();`) and its comment with:
+
+```rust
+    // Credentials resolve env-first, then the OS keychain (written by `openintel setup`).
+    let store = openintel::config::store::KeychainStore::new();
+    let credentials = Credentials::load(&store);
+```
+
+`src/mcp/server.rs` — replace line 112 (`let credentials = Credentials::from_env();`) with:
+
+```rust
+    let store = crate::config::store::KeychainStore::new();
+    let credentials = Credentials::load(&store);
+```
+
+(Check the file's existing import style; `Credentials` is already imported there.)
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `cargo build --all-targets && cargo test && cargo clippy -- -D warnings && cargo fmt`
+Expected: green.
+
+```bash
+git add src/config/secrets.rs src/main.rs src/mcp/server.rs
+git commit -m "feat(config): Credentials::load — env-first, keychain fallback, in both roots
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Interactive setup flow + `--forget`
+
+**Files:**
+- Modify: `src/cli/setup.rs`, `src/cli/args.rs`, `src/main.rs` (Setup dispatch arm), `Cargo.toml` (+`rpassword = "7"`)
+
+**Interfaces:**
+- Consumes: Task 1's `CredentialStore` (+`InMemoryStore` in tests); Task 2's `Credentials::load` (already wired in main); existing `probe_reddit`/`probe_bluesky`, `setup_reddit`/`setup_bluesky`, `verify_ok_text`/`verify_err_text`, hint consts.
+- Produces: `pub async fn run(source: SetupSource, credentials: &Credentials, store: &dyn CredentialStore, forget: bool) -> ExitCode`; `SetupArgs { source, forget: bool }`.
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `cargo add rpassword@7`
+
+- [ ] **Step 2: `src/cli/args.rs` — the `--forget` flag + test**
+
+```rust
+#[derive(clap::Args, Debug)]
+pub struct SetupArgs {
+    /// Which source to set up
+    #[arg(value_enum)]
+    pub source: SetupSource,
+
+    /// Remove this source's saved credentials from the OS keychain
+    #[arg(long)]
+    pub forget: bool,
+}
+```
+
+Test (in the existing `mod tests`):
+
+```rust
+    #[test]
+    fn parses_setup_forget_flag() {
+        let cli = Cli::try_parse_from(["openintel", "setup", "reddit", "--forget"]).unwrap();
+        let Command::Setup(args) = cli.command else {
+            panic!("expected setup command");
+        };
+        assert!(args.forget);
+    }
+```
+
+- [ ] **Step 3: Rewrite the top of `src/cli/setup.rs`** — module doc, imports, `SourceSpec`, and the new `run`:
+
+Replace the module doc comment (lines 1–6) with:
+
+```rust
+//! `openintel setup <source>` — guided credential setup + live verify.
+//!
+//! Interactive (TTY): condensed guide -> prompts (secret input hidden) ->
+//! live verify -> save to the OS keychain (only after ✅; env vars always
+//! override). Non-TTY keeps the classic guide/partial/verify behavior.
+//! This is the one CLI-leaf module that prints to stdout directly — it IS
+//! the user-facing output, and it never runs under the MCP stdio server.
+```
+
+Extend the imports:
+
+```rust
+use std::io::{BufRead, IsTerminal, Write};
+use std::process::ExitCode;
+
+use secrecy::SecretString;
+
+use crate::adapters::sources::bluesky::BlueskySource;
+use crate::adapters::sources::reddit::RedditSource;
+use crate::cli::args::SetupSource;
+use crate::config::secrets::Credentials;
+use crate::config::store::CredentialStore;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::social_data_source::SocialDataSource;
+```
+
+Add the per-source spec (below the hint consts):
+
+```rust
+/// Everything the shared interactive loop needs to know about one source.
+struct SourceSpec {
+    label: &'static str,
+    first_key: &'static str,
+    second_key: &'static str,
+    first_prompt: &'static str,
+    second_prompt: &'static str,
+    condensed_guide: &'static str,
+    unauthorized_hint: &'static str,
+    try_cmd: &'static str,
+}
+
+const REDDIT_SPEC: SourceSpec = SourceSpec {
+    label: "Reddit",
+    first_key: "OPENINTEL_REDDIT_CLIENT_ID",
+    second_key: "OPENINTEL_REDDIT_CLIENT_SECRET",
+    first_prompt: "Client id",
+    second_prompt: "Client secret",
+    condensed_guide: "\
+Reddit needs a free OAuth app — there's no keyless access. ~2 minutes:
+
+  1. Sign in to Reddit, then open:  https://www.reddit.com/prefs/apps
+  2. Scroll to the bottom and click \"create another app…\"
+     (or \"are you a developer? create an app…\").
+  3. Fill in the form:
+       • name           openintel        (anything is fine)
+       • type           select \"script\"  ← this matters
+       • redirect uri   http://localhost:8080   (unused, but required)
+     Click \"create app\".
+  4. On the app that appears:
+       • CLIENT ID  — the short string just under the app name
+                      (below \"personal use script\")
+       • SECRET     — the value labelled \"secret\"
+  5. Enter them below — they'll be verified live and saved to your OS
+     keychain (plaintext never touches disk).
+",
+    unauthorized_hint: REDDIT_UNAUTHORIZED_HINT,
+    try_cmd: "openintel analyze GME --enable-reddit",
+};
+
+const BLUESKY_SPEC: SourceSpec = SourceSpec {
+    label: "Bluesky",
+    first_key: "OPENINTEL_BLUESKY_HANDLE",
+    second_key: "OPENINTEL_BLUESKY_APP_PASSWORD",
+    first_prompt: "Handle (e.g. yourname.bsky.social)",
+    second_prompt: "App password",
+    condensed_guide: "\
+Bluesky needs a free app password — search requires auth. ~2 minutes:
+
+  1. Create a free account at https://bsky.app if you don't have one.
+  2. Sign in, then open:  https://bsky.app/settings/app-passwords
+     (Settings → Privacy and Security → App Passwords).
+  3. Click \"Add App Password\", name it  openintel , and copy the generated
+     password — it is shown only once (format: xxxx-xxxx-xxxx-xxxx).
+  4. Enter your handle and the app password below — they'll be verified live
+     and saved to your OS keychain (plaintext never touches disk).
+",
+    unauthorized_hint: BLUESKY_UNAUTHORIZED_HINT,
+    try_cmd: "openintel analyze GME --enable-bluesky",
+};
+```
+
+Replace `pub async fn run` with:
+
+```rust
+/// Entry point for `openintel setup <source>`. Exit code 0 only when the
+/// source is verified working (or `--forget` succeeded).
+pub async fn run(
+    source: SetupSource,
+    credentials: &Credentials,
+    store: &dyn CredentialStore,
+    forget: bool,
+) -> ExitCode {
+    let spec = match source {
+        SetupSource::Reddit => &REDDIT_SPEC,
+        SetupSource::Bluesky => &BLUESKY_SPEC,
+    };
+
+    if forget {
+        return forget_source(spec, store);
+    }
+
+    if !std::io::stdin().is_terminal() {
+        // Piped / CI: the classic guide/partial/verify behavior, unchanged.
+        return match source {
+            SetupSource::Reddit => setup_reddit(credentials).await,
+            SetupSource::Bluesky => setup_bluesky(credentials).await,
+        };
+    }
+
+    let configured = match source {
+        SetupSource::Reddit => {
+            credentials.reddit_client_id.is_some() && credentials.reddit_client_secret.is_some()
+        }
+        SetupSource::Bluesky => {
+            credentials.bluesky_handle.is_some() && credentials.bluesky_app_password.is_some()
+        }
+    };
+    let already = configured.then(|| provenance(spec.first_key));
+
+    let mut stdin = std::io::stdin().lock();
+    let read_secret = |prompt: &str| {
+        rpassword::prompt_password(prompt)
+            .map(|s| SecretString::new(s.into_boxed_str()))
+    };
+    let mut io = SetupIo {
+        input: &mut stdin,
+        read_secret: &read_secret,
+    };
+
+    let outcome = match source {
+        SetupSource::Reddit => {
+            run_interactive(&mut io, store, spec, already, |first, secret| {
+                probe_reddit(SecretString::new(first.into_boxed_str()), secret)
+            })
+            .await
+        }
+        SetupSource::Bluesky => {
+            run_interactive(&mut io, store, spec, already, probe_bluesky).await
+        }
+    };
+
+    match outcome {
+        InteractiveOutcome::Done(Outcome::Success) => ExitCode::SUCCESS,
+        InteractiveOutcome::Done(Outcome::Failure) => ExitCode::FAILURE,
+        InteractiveOutcome::VerifyExisting => match source {
+            SetupSource::Reddit => setup_reddit(credentials).await,
+            SetupSource::Bluesky => setup_bluesky(credentials).await,
+        },
+    }
+}
+
+/// Where the already-configured credentials came from, for the replace-ask.
+fn provenance(first_key: &str) -> &'static str {
+    if std::env::var(first_key)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+    {
+        "the environment"
+    } else {
+        "the OS keychain"
+    }
+}
+
+fn forget_source(spec: &SourceSpec, store: &dyn CredentialStore) -> ExitCode {
+    match forget_outcome(spec, store) {
+        Outcome::Success => ExitCode::SUCCESS,
+        Outcome::Failure => ExitCode::FAILURE,
+    }
+}
+
+fn forget_outcome(spec: &SourceSpec, store: &dyn CredentialStore) -> Outcome {
+    for key in [spec.first_key, spec.second_key] {
+        if let Err(e) = store.delete(key) {
+            println!("❌ could not remove {key} from the OS keychain: {e}");
+            return Outcome::Failure;
+        }
+    }
+    println!(
+        "Removed {} credentials from the OS keychain. (Env vars, if set, still apply.)",
+        spec.label
+    );
+    Outcome::Success
+}
+```
+
+- [ ] **Step 4: The interactive loop** (add below `forget_source`):
+
+```rust
+/// Injected I/O so the interactive loop is unit-testable without a TTY.
+struct SetupIo<'a> {
+    input: &'a mut dyn BufRead,
+    read_secret: &'a dyn Fn(&str) -> std::io::Result<SecretString>,
+}
+
+/// `std::process::ExitCode` has no `PartialEq`, so the loop reports this
+/// testable outcome and `run()` maps it to an exit code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Outcome {
+    Success,
+    Failure,
+}
+
+enum InteractiveOutcome {
+    Done(Outcome),
+    /// User declined to replace existing creds -> caller runs the classic verify.
+    VerifyExisting,
+}
+
+const MAX_ATTEMPTS: usize = 3;
+
+async fn run_interactive<F, Fut>(
+    io: &mut SetupIo<'_>,
+    store: &dyn CredentialStore,
+    spec: &SourceSpec,
+    already_configured_from: Option<&'static str>,
+    probe: F,
+) -> InteractiveOutcome
+where
+    F: Fn(String, SecretString) -> Fut,
+    Fut: std::future::Future<Output = Result<usize, DomainError>>,
+{
+    if let Some(source_of_truth) = already_configured_from {
+        println!(
+            "{} is already configured (from {source_of_truth}).",
+            spec.label
+        );
+        match read_visible(io, "Replace it? [y/N]: ") {
+            Ok(ans) if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") => {}
+            Ok(_) => return InteractiveOutcome::VerifyExisting,
+            Err(_) => return InteractiveOutcome::Done(Outcome::Failure),
+        }
+    }
+
+    println!("{}", spec.condensed_guide);
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        let Ok(first) = prompt_nonempty_visible(io, spec.first_prompt) else {
+            return InteractiveOutcome::Done(Outcome::Failure);
+        };
+        let Ok(secret) = prompt_nonempty_secret(io, spec.second_prompt) else {
+            return InteractiveOutcome::Done(Outcome::Failure);
+        };
+
+        println!("Checking your {} credentials…", spec.label);
+        match probe(first.clone(), secret.clone()).await {
+            Ok(count) => {
+                let first_secret = SecretString::new(first.into_boxed_str());
+                let saved = store
+                    .set(spec.first_key, &first_secret)
+                    .and_then(|()| store.set(spec.second_key, &secret));
+                return InteractiveOutcome::Done(match saved {
+                    Ok(()) => {
+                        println!("{}", verify_ok_text(spec.label, count, spec.try_cmd));
+                        println!(
+                            "   Saved to your OS keychain — you're set. (Env vars still override.)"
+                        );
+                        Outcome::Success
+                    }
+                    Err(e) => {
+                        println!("{}", verify_ok_text(spec.label, count, spec.try_cmd));
+                        println!(
+                            "⚠  Verified, but saving to the OS keychain failed: {e}\n   \
+                             Fall back to environment variables (with your real values):\n\n   \
+                             export {}=paste_your_value\n   export {}=paste_your_value",
+                            spec.first_key, spec.second_key
+                        );
+                        Outcome::Failure
+                    }
+                });
+            }
+            Err(e) => {
+                println!("{}", verify_err_text(&e, spec.unauthorized_hint));
+                if attempt < MAX_ATTEMPTS {
+                    println!("Let's try again ({} of {MAX_ATTEMPTS}).", attempt + 1);
+                }
+            }
+        }
+    }
+    println!(
+        "Still not verified after {MAX_ATTEMPTS} attempts — double-check the values and re-run `openintel setup`."
+    );
+    InteractiveOutcome::Done(Outcome::Failure)
+}
+
+/// Visible prompt (identifier-like values). Re-asks on empty input.
+fn prompt_nonempty_visible(io: &mut SetupIo<'_>, label: &str) -> std::io::Result<String> {
+    loop {
+        let ans = read_visible(io, &format!("{label}: "))?;
+        let trimmed = ans.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+        println!("Please enter a value.");
+    }
+}
+
+/// Hidden prompt (secret-like values). Re-asks on empty input.
+fn prompt_nonempty_secret(io: &mut SetupIo<'_>, label: &str) -> std::io::Result<SecretString> {
+    use secrecy::ExposeSecret as _;
+    loop {
+        let secret = (io.read_secret)(&format!("{label} (input hidden): "))?;
+        if !secret.expose_secret().trim().is_empty() {
+            return Ok(secret);
+        }
+        println!("Please enter a value.");
+    }
+}
+
+fn read_visible(io: &mut SetupIo<'_>, prompt: &str) -> std::io::Result<String> {
+    print!("{prompt}");
+    std::io::stdout().flush()?;
+    let mut line = String::new();
+    io.input.read_line(&mut line)?;
+    Ok(line)
+}
+```
+
+**Note on the one `expose_secret` here:** `prompt_nonempty_secret` peeks only
+to reject empty input and the value never leaves the function un-wrapped.
+This is a third in-src expose site beyond the two the spec names — if you can
+check emptiness without it you may, but `SecretString` offers no length API,
+so this is accepted; keep it to exactly this emptiness check.
+
+- [ ] **Step 5: Update the Setup dispatch arm in `src/main.rs`**
+
+```rust
+        Command::Setup(args) => {
+            openintel::cli::setup::run(args.source, &credentials, &store, args.forget).await
+        }
+```
+
+- [ ] **Step 6: Interactive-loop tests** (append to `src/cli/setup.rs` `mod tests`):
+
+```rust
+    use crate::config::store::{CredentialStore, InMemoryStore};
+    use secrecy::ExposeSecret;
+    use std::io::Cursor;
+
+    fn scripted<'a>(
+        input: &'a mut Cursor<&'static str>,
+        secrets: &'a dyn Fn(&str) -> std::io::Result<SecretString>,
+    ) -> SetupIo<'a> {
+        SetupIo {
+            input,
+            read_secret: secrets,
+        }
+    }
+
+    fn ok_secret(_prompt: &str) -> std::io::Result<SecretString> {
+        Ok(SecretString::new("s3cret".to_string().into_boxed_str()))
+    }
+
+    #[tokio::test]
+    async fn interactive_happy_path_saves_both_keys() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("my-id\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |_first, _secret| {
+            std::future::ready(Ok(2usize))
+        })
+        .await;
+        assert!(matches!(outcome, InteractiveOutcome::Done(Outcome::Success)));
+        let map = store.map.borrow();
+        assert_eq!(
+            map.get("OPENINTEL_REDDIT_CLIENT_ID").unwrap().expose_secret(),
+            "my-id"
+        );
+        assert_eq!(
+            map.get("OPENINTEL_REDDIT_CLIENT_SECRET")
+                .unwrap()
+                .expose_secret(),
+            "s3cret"
+        );
+    }
+
+    #[tokio::test]
+    async fn interactive_three_failures_exits_one_and_saves_nothing() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("id1\nid2\nid3\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |_f, _s| {
+            std::future::ready(Err(DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: "unauthorized — check client id/secret".into(),
+            }))
+        })
+        .await;
+        assert!(matches!(outcome, InteractiveOutcome::Done(Outcome::Failure)));
+        assert!(store.map.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn interactive_empty_input_reasks_then_succeeds() {
+        let store = InMemoryStore::new();
+        // First visible answer empty -> re-ask -> then a real id.
+        let mut input = Cursor::new("\nreal-id\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |first, _s| {
+            std::future::ready(if first == "real-id" { Ok(0) } else { Err(DomainError::NoData) })
+        })
+        .await;
+        assert!(matches!(outcome, InteractiveOutcome::Done(Outcome::Success)));
+    }
+
+    #[tokio::test]
+    async fn interactive_replace_declined_verifies_existing() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("n\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(
+            &mut io,
+            &store,
+            &REDDIT_SPEC,
+            Some("the OS keychain"),
+            |_f, _s| std::future::ready(Ok(1)),
+        )
+        .await;
+        assert!(matches!(outcome, InteractiveOutcome::VerifyExisting));
+        assert!(store.map.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn interactive_save_failure_is_exit_one_with_fallback() {
+        let store = InMemoryStore::failing();
+        let mut input = Cursor::new("my-id\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |_f, _s| {
+            std::future::ready(Ok(1usize))
+        })
+        .await;
+        assert!(matches!(outcome, InteractiveOutcome::Done(Outcome::Failure)));
+    }
+
+    #[test]
+    fn forget_is_idempotent_and_removes_keys() {
+        let store = InMemoryStore::new()
+            .seed("OPENINTEL_REDDIT_CLIENT_ID", "x")
+            .seed("OPENINTEL_REDDIT_CLIENT_SECRET", "y");
+        assert_eq!(forget_outcome(&REDDIT_SPEC, &store), Outcome::Success);
+        assert!(store.map.borrow().is_empty());
+        // Second run: nothing left to delete, still success.
+        assert_eq!(forget_outcome(&REDDIT_SPEC, &store), Outcome::Success);
+    }
+
+    #[test]
+    fn condensed_guides_have_no_export_lines() {
+        for spec in [&REDDIT_SPEC, &BLUESKY_SPEC] {
+            assert!(!spec.condensed_guide.contains("export "));
+            assert!(spec.condensed_guide.contains("keychain"));
+        }
+        assert!(REDDIT_SPEC.condensed_guide.contains("prefs/apps"));
+        assert!(BLUESKY_SPEC.condensed_guide.contains("app-passwords"));
+    }
+```
+
+- [ ] **Step 7: Full verification + smoke tests**
+
+Run: `cargo build --all-targets && cargo test && cargo clippy -- -D warnings && cargo fmt`
+Expected: green.
+
+Run: `echo "" | cargo run -q -- setup reddit; echo "exit=$?"`
+Expected: non-TTY path → classic guide (or verify if your env has creds), NOT a prompt.
+
+Run: `cargo run -q -- setup reddit --forget; echo "exit=$?"`
+Expected: `Removed Reddit credentials from the OS keychain. …`, `exit=0`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/cli/setup.rs src/cli/args.rs src/main.rs Cargo.toml Cargo.lock
+git commit -m "feat(cli): interactive setup — prompt, live verify, keychain save, --forget
+
+TTY runs the gh-auth-login flow (hidden secret input via rpassword, 3-attempt
+cap, replace-ask for rotation, save only after a successful probe). Non-TTY
+keeps the classic guide/partial/verify behavior byte-for-byte.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Docs — README, SECURITY.md, .env.example
+
+**Files:**
+- Modify: `README.md`, `SECURITY.md`, `.env.example`
+
+- [ ] **Step 1: README** (find by content, not line number):
+
+1. Quickstart: after the install lines, replace any "Enable real sentiment" pointer with:
+   > Enable real sentiment (optional, ~2 min each): run `openintel setup reddit` and `openintel setup bluesky` — each walks you through creating free credentials, verifies them live, and saves them to your OS keychain.
+2. "Enable the Reddit source (optional)" section: replace the numbered steps + export block with:
+
+```markdown
+Run `openintel setup reddit` — it walks you through creating a free script app, verifies your credentials live, and saves them to your OS keychain. Rotate by re-running it; remove with `openintel setup reddit --forget`.
+
+<details>
+<summary>CI / power users: environment variables instead</summary>
+
+Env vars always override the keychain. Create a **script** app at <https://www.reddit.com/prefs/apps>, then:
+
+```bash
+export OPENINTEL_REDDIT_CLIENT_ID=your_client_id
+export OPENINTEL_REDDIT_CLIENT_SECRET=your_secret
+openintel setup reddit   # non-interactive when piped; verifies from env
+```
+
+</details>
+```
+
+3. "Enable the Bluesky source (optional)" section: same treatment with `openintel setup bluesky`, <https://bsky.app/settings/app-passwords>, and `OPENINTEL_BLUESKY_HANDLE`/`OPENINTEL_BLUESKY_APP_PASSWORD`.
+4. The secrets sentence in Architecture: extend to "…come from environment variables (…) or the OS keychain (written only by `openintel setup` after a live verify; env always wins), wrapped in `SecretString` — plaintext never touches disk, never logged."
+
+- [ ] **Step 2: SECURITY.md** — replace the first paragraph of "Credentials & secrets" with:
+
+```markdown
+openintel reads credentials from **environment variables** (see
+[`.env.example`](.env.example)) or from your **OS keychain** (macOS Keychain /
+Windows Credential Manager / Linux secret-service). The keychain is written
+only by `openintel setup <source>` — after a successful live verification —
+and env vars always take precedence. Plaintext credentials never touch disk:
+interactive setup reads secrets with hidden input (nothing lands in shell
+history or scrollback) directly into `secrecy::SecretString` (redacted in
+debug output, zeroized on drop), and they are never logged. Remove stored
+credentials anytime with `openintel setup <source> --forget`. When openintel
+runs as an MCP server, credentials stay in its process — the connected AI
+agent never sees them.
+```
+
+(Keep the "Never commit real credentials" bullets and the rest unchanged.)
+
+- [ ] **Step 3: `.env.example`** — replace the header comment (first 6 lines) with:
+
+```bash
+# openintel credentials — env-var template (CI / power users).
+#
+# Most users don't need this file: run `openintel setup reddit` /
+# `openintel setup bluesky` for a guided flow that verifies live and saves
+# to your OS keychain. Env vars, when set, always OVERRIDE the keychain.
+# If you do use a .env: keep it gitignored, load via direnv or
+# `set -a; . ./.env; set +a`, and NEVER commit real values.
+```
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `cargo test 2>&1 | tail -3` (docs-only sanity) and `grep -n "export OPENINTEL" README.md | head` (exports now only inside the details blocks).
+
+```bash
+git add README.md SECURITY.md .env.example
+git commit -m "docs: interactive setup is the recommended flow; env demoted to CI/power users
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-07-13-interactive-setup-design.md
+++ b/docs/superpowers/specs/2026-07-13-interactive-setup-design.md
@@ -1,0 +1,189 @@
+# Interactive `openintel setup <source>` — Prompt, Verify, Keychain — Design
+
+**Date:** 2026-07-13
+**Status:** Draft — awaiting user review
+
+## Goal
+
+`openintel setup reddit` (and `bluesky`) becomes a complete, one-command flow —
+gh-auth-login style: condensed guide → prompt for credentials (secret input
+hidden) → **live verify** → persist to the **OS keychain** → done. No `export`
+dance, no `.env` required, nothing to paste twice. Driven by real first-user
+feedback: "can I just run setup and be guided to enter my id and secret?"
+
+## Security posture (SECURITY.md change)
+
+- Secrets live in the **OS keychain** (macOS Keychain / Windows Credential
+  Manager / Linux secret-service via the `keyring` crate — encrypted at rest,
+  OS-access-gated) **or** in environment variables. Plaintext never touches
+  disk.
+- **Env always wins** — keychain is a fallback. CI and power users see zero
+  behavior change; `.env`+direnv stays documented but demoted to "CI/power
+  users".
+- Hidden prompt input (rpassword) goes straight into `SecretString` — nothing
+  in shell history or scrollback. This is strictly better than the `export`
+  lines we currently teach (those land in history).
+- The keychain is written **only after a successful live verify** — it never
+  holds known-bad credentials — and only by the `setup` command.
+
+## Architecture
+
+### 1. `src/config/store.rs` (new) — the credential-store port
+
+```rust
+pub trait CredentialStore {
+    /// Ok(None) = not present. Errors are for store malfunction only.
+    fn get(&self, key: &str) -> Result<Option<SecretString>, StoreError>;
+    fn set(&self, key: &str, value: &SecretString) -> Result<(), StoreError>;
+    /// Idempotent: deleting an absent key is Ok.
+    fn delete(&self, key: &str) -> Result<(), StoreError>;
+}
+```
+
+- `StoreError(String)` — a thin wrapper; message only, never the value.
+- **`KeychainStore`** — real adapter over `keyring = "4"` (default features
+  bundle the macOS/Windows/Linux stores): `keyring::v1::Entry::new("openintel",
+  key)` then `get_password` / `set_password` / `delete_credential`. The
+  `NoEntry` error variant maps to `Ok(None)`; `delete` maps it to `Ok(())`.
+  `get_password`'s `String` is wrapped into `SecretString` immediately.
+  `.expose_secret()` is called at exactly one new site: inside
+  `KeychainStore::set` (the keyring API takes `&str`).
+- **`InMemoryStore`** (`#[cfg(test)]`) — `RefCell<HashMap<String, String>>`
+  fake for hermetic tests.
+- Keys are the env-var names, 1:1: `OPENINTEL_REDDIT_CLIENT_ID`,
+  `OPENINTEL_REDDIT_CLIENT_SECRET`, `OPENINTEL_BLUESKY_HANDLE`,
+  `OPENINTEL_BLUESKY_APP_PASSWORD`. (`OPENINTEL_MARKET_API_KEY` stays env-only
+  — it is reserved/unused; YAGNI.)
+
+### 2. `Credentials::load` — resolution with precedence
+
+`src/config/secrets.rs` gains:
+
+```rust
+pub fn load(store: &dyn CredentialStore) -> Self
+```
+
+Per field: env var if set (non-empty) → else keychain value → else `None`.
+A store **malfunction** (not absence) prints one `eprintln!` warning naming the
+key and resolves that field from env only — the keychain must never be able to
+break `analyze` or the MCP server. `from_env()` remains (pure-env; used by
+`load` internally and directly by tests).
+
+Both composition roots (`main.rs`, `mcp::server::serve`) construct a
+`KeychainStore` and switch from `Credentials::from_env()` to
+`Credentials::load(&store)` — so setup-once works for the CLI **and** the MCP
+server with zero shell configuration. (Docs note: on macOS the first keychain
+read from a new binary may show an OS permission prompt — normal.)
+
+### 3. Interactive flow — `src/cli/setup.rs`
+
+TTY detection: `std::io::stdin().is_terminal()` (`std::io::IsTerminal`, no new
+dependency).
+
+**TTY mode** (a human at the keyboard):
+
+1. If the source already resolves (env or keychain), say where from and ask
+   `Reddit is already configured (from the OS keychain). Replace it? [y/N]` —
+   `N`/enter → run today's verify against the resolved creds and exit with its
+   code (re-check without retyping); `y` → continue.
+2. Print the **condensed guide** (the existing walkthrough minus its step-5
+   export instructions — replaced by "then come back here").
+3. Prompt:
+   - identifier-like value (client id / handle): visible `read_line` prompt.
+   - secret-like value (client secret / app password): **hidden** via
+     `rpassword::prompt_password` — read directly into `SecretString`.
+   - Empty input → re-ask (same prompt, one nudge line).
+4. `Checking your Reddit credentials…` → the existing live probe.
+5. **✅** → `store.set` both keys →
+   `✅ Verified and saved to your OS keychain — you're set. (Env vars still override.)`
+   `   Try:  openintel analyze GME --enable-reddit` → exit 0.
+   If the save fails: print the verify success, the store error, and the two
+   `export` lines as a fallback → exit 1 (verified but not persisted ≠ set up).
+6. **❌** → existing `verify_err_text` hint → re-prompt from step 3, max **3**
+   attempts total → exit 1 after the third failure. Ctrl-C anytime; nothing is
+   saved before step 5.
+
+**Non-TTY mode** (piped, CI, scripts): exactly today's three-mode behavior
+(guide / partial / verify) — no prompts, same copy, same exit codes — except
+credentials come from `Credentials::load` (so a keychain-configured machine
+verifies in scripts too).
+
+**`--forget`**: `openintel setup reddit --forget` deletes that source's two
+keychain keys (idempotent), prints
+`Removed Reddit credentials from the OS keychain. (Env vars, if set, still apply.)`,
+exit 0. Added to `SetupArgs` as `#[arg(long)] forget: bool`.
+
+### 4. Prompt plumbing (testability)
+
+The prompt loop is written against injected I/O so tests never need a TTY:
+
+```rust
+struct SetupIo<'a> {
+    input: &'a mut dyn BufRead,             // visible-input reads
+    read_secret: &'a dyn Fn(&str) -> std::io::Result<SecretString>, // hidden reads
+}
+```
+
+Production wires stdin + `rpassword::prompt_password`; tests wire a
+`Cursor<&str>` script + a closure returning canned secrets. The live probe is
+injected as a closure too (`&dyn Fn(id, secret) -> Result<usize, DomainError>`
+— async wrapped at the call site), so the full interactive loop — replace-ask,
+re-prompt on empty, 3-attempt cap, save-on-success, save-failure fallback — is
+unit-tested with zero network and zero keychain.
+
+## Error handling
+
+- Keychain malfunction during `load`: warn + fall back to env, never fatal.
+- Keychain malfunction during setup save: verified-but-unsaved → export-lines
+  fallback + exit 1.
+- Probe failures: existing `verify_err_text` hints unchanged.
+- `--forget` on a machine with no stored creds: success (idempotent).
+
+## Testing (hermetic)
+
+- `KeychainStore` mapping is thin and *not* unit-tested against a real
+  keychain (would mutate the developer's OS store); one `#[ignore]`d
+  round-trip test (`set → get → delete`) for manual/live runs.
+- `InMemoryStore` used everywhere else:
+  - `Credentials::load` precedence: env-only, store-only, env-over-store,
+    empty-env-falls-to-store, store-error-warns-and-falls-back.
+  - Interactive loop (scripted I/O): happy path saves both keys; wrong creds
+    3× exits 1 and saves nothing; empty input re-asks; replace-prompt `N` runs
+    verify-only; save-failure prints export fallback.
+  - `--forget` deletes both keys; idempotent on empty store.
+- Arg parsing: `setup reddit --forget`.
+- Existing non-TTY render/mode tests unchanged.
+
+## Docs
+
+- README Quickstart: "Enable real sentiment: run `openintel setup reddit` and
+  `openintel setup bluesky` — each walks you through it and verifies live."
+  The manual `export` blocks in both "Enable the …" sections shrink to the
+  CI/power-user alternative.
+- SECURITY.md: keychain paragraph per the posture section above.
+- `.env.example` header: note it is the CI/power-user path; `openintel setup`
+  is the recommended flow.
+
+## Non-goals (YAGNI)
+
+- No `--token`-style flag input (secrets on argv leak via `ps`/history).
+- No credential expiry/rotation reminders.
+- No keychain storage for `OPENINTEL_MARKET_API_KEY` (reserved, unused).
+- No custom keychain service naming/config.
+- No Windows/Linux CI testing of the real keychain (adapter is thin; the
+  `keyring` crate owns platform correctness).
+
+## Files
+
+**Create**
+- `src/config/store.rs`
+- this spec
+
+**Modify**
+- `src/config/mod.rs` (register `store`)
+- `src/config/secrets.rs` (`Credentials::load`)
+- `src/cli/setup.rs` (interactive flow, `--forget`, SetupIo)
+- `src/cli/args.rs` (`forget` flag)
+- `src/main.rs`, `src/mcp/server.rs` (composition roots → `Credentials::load`)
+- `Cargo.toml` (`keyring = "4"`, `rpassword = "7"`)
+- `README.md`, `SECURITY.md`, `.env.example`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -21,7 +21,7 @@ pub enum Command {
     /// Run as an MCP server over stdio (for AI agents).
     Mcp,
 
-    /// Guided setup + live check for a data source (env-only; never stores credentials)
+    /// Guided setup + live verify for a data source (saves to the OS keychain; env vars override)
     Setup(SetupArgs),
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -58,6 +58,10 @@ pub struct SetupArgs {
     /// Which source to set up
     #[arg(value_enum)]
     pub source: SetupSource,
+
+    /// Remove this source's saved credentials from the OS keychain
+    #[arg(long)]
+    pub forget: bool,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -136,5 +140,14 @@ mod tests {
     #[test]
     fn rejects_unknown_setup_source() {
         assert!(Cli::try_parse_from(["openintel", "setup", "bogus"]).is_err());
+    }
+
+    #[test]
+    fn parses_setup_forget_flag() {
+        let cli = Cli::try_parse_from(["openintel", "setup", "reddit", "--forget"]).unwrap();
+        let Command::Setup(args) = cli.command else {
+            panic!("expected setup command");
+        };
+        assert!(args.forget);
     }
 }

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -384,6 +384,9 @@ where
         match probe(first.clone(), secret.clone()).await {
             Ok(count) => {
                 let first_secret = SecretString::new(first.into_boxed_str());
+                // Write order matters: identifier first, secret last — if the
+                // second write fails, only the (public) identifier can be
+                // orphaned, never the secret, and the next setup overwrites it.
                 let saved = store
                     .set(spec.first_key, &first_secret)
                     .and_then(|()| store.set(spec.second_key, &secret));
@@ -784,6 +787,22 @@ mod tests {
         let store = InMemoryStore::new();
         let mut input = Cursor::new("my-id\n");
         let mut io = scripted(&mut input, &empty_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |_f, _s| {
+            std::future::ready(Ok(1usize))
+        })
+        .await;
+        assert!(matches!(
+            outcome,
+            InteractiveOutcome::Done(Outcome::Failure)
+        ));
+        assert!(store.map.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn interactive_persistent_blank_visible_input_fails_cleanly() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("\n\n\n\n"); // blank lines, no EOF within the bound
+        let mut io = scripted(&mut input, &ok_secret);
         let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |_f, _s| {
             std::future::ready(Ok(1usize))
         })

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -421,9 +421,13 @@ where
     InteractiveOutcome::Done(Outcome::Failure)
 }
 
+/// Empty-input re-asks are bounded so a broken/EOF'd stream (or an empty
+/// string forever, e.g. rpassword at EOF) can't spin the loop unbounded.
+const MAX_EMPTY_REASKS: usize = 3;
+
 /// Visible prompt (identifier-like values). Re-asks on empty input.
 fn prompt_nonempty_visible(io: &mut SetupIo<'_>, label: &str) -> std::io::Result<String> {
-    loop {
+    for _ in 0..MAX_EMPTY_REASKS {
         let ans = read_visible(io, &format!("{label}: "))?;
         let trimmed = ans.trim();
         if !trimmed.is_empty() {
@@ -431,25 +435,38 @@ fn prompt_nonempty_visible(io: &mut SetupIo<'_>, label: &str) -> std::io::Result
         }
         println!("Please enter a value.");
     }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::UnexpectedEof,
+        "no input provided",
+    ))
 }
 
 /// Hidden prompt (secret-like values). Re-asks on empty input.
 fn prompt_nonempty_secret(io: &mut SetupIo<'_>, label: &str) -> std::io::Result<SecretString> {
     use secrecy::ExposeSecret as _;
-    loop {
+    for _ in 0..MAX_EMPTY_REASKS {
         let secret = (io.read_secret)(&format!("{label} (input hidden): "))?;
         if !secret.expose_secret().trim().is_empty() {
             return Ok(secret);
         }
         println!("Please enter a value.");
     }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::UnexpectedEof,
+        "no input provided",
+    ))
 }
 
 fn read_visible(io: &mut SetupIo<'_>, prompt: &str) -> std::io::Result<String> {
     print!("{prompt}");
     std::io::stdout().flush()?;
     let mut line = String::new();
-    io.input.read_line(&mut line)?;
+    if io.input.read_line(&mut line)? == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "input closed",
+        ));
+    }
     Ok(line)
 }
 
@@ -727,6 +744,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn interactive_replace_blank_enter_defaults_to_decline() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(
+            &mut io,
+            &store,
+            &REDDIT_SPEC,
+            Some("the OS keychain"),
+            |_f, _s| std::future::ready(Ok(1)),
+        )
+        .await;
+        assert!(matches!(outcome, InteractiveOutcome::VerifyExisting));
+        assert!(store.map.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn interactive_eof_at_prompt_fails_cleanly() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new(""); // immediate EOF
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |_f, _s| {
+            std::future::ready(Ok(1usize))
+        })
+        .await;
+        assert!(matches!(
+            outcome,
+            InteractiveOutcome::Done(Outcome::Failure)
+        ));
+        assert!(store.map.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn interactive_persistent_empty_secret_fails_cleanly() {
+        fn empty_secret(_prompt: &str) -> std::io::Result<SecretString> {
+            Ok(SecretString::new("".to_string().into_boxed_str()))
+        }
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("my-id\n");
+        let mut io = scripted(&mut input, &empty_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |_f, _s| {
+            std::future::ready(Ok(1usize))
+        })
+        .await;
+        assert!(matches!(
+            outcome,
+            InteractiveOutcome::Done(Outcome::Failure)
+        ));
+        assert!(store.map.borrow().is_empty());
+    }
+
+    #[tokio::test]
     async fn interactive_save_failure_is_exit_one_with_fallback() {
         let store = InMemoryStore::failing();
         let mut input = Cursor::new("my-id\n");
@@ -739,6 +808,12 @@ mod tests {
             outcome,
             InteractiveOutcome::Done(Outcome::Failure)
         ));
+    }
+
+    #[test]
+    fn forget_reports_failure_when_store_is_broken() {
+        let store = InMemoryStore::failing();
+        assert_eq!(forget_outcome(&REDDIT_SPEC, &store), Outcome::Failure);
     }
 
     #[test]

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -1,10 +1,12 @@
-//! `openintel setup <source>` — guided, env-only credential setup + live verify.
+//! `openintel setup <source>` — guided credential setup + live verify.
 //!
-//! Never stores or writes credentials (see SECURITY.md): it only reads
-//! `Credentials::from_env()` and tells the user what to do next. This is the
-//! one CLI-leaf module that prints to stdout directly — it IS the user-facing
-//! output, and it never runs under the MCP stdio server.
+//! Interactive (TTY): condensed guide -> prompts (secret input hidden) ->
+//! live verify -> save to the OS keychain (only after ✅; env vars always
+//! override). Non-TTY keeps the classic guide/partial/verify behavior.
+//! This is the one CLI-leaf module that prints to stdout directly — it IS
+//! the user-facing output, and it never runs under the MCP stdio server.
 
+use std::io::{BufRead, IsTerminal, Write};
 use std::process::ExitCode;
 
 use secrecy::SecretString;
@@ -13,18 +15,10 @@ use crate::adapters::sources::bluesky::BlueskySource;
 use crate::adapters::sources::reddit::RedditSource;
 use crate::cli::args::SetupSource;
 use crate::config::secrets::Credentials;
+use crate::config::store::CredentialStore;
 use crate::domain::entities::ticker::Ticker;
 use crate::domain::error::DomainError;
 use crate::domain::ports::social_data_source::SocialDataSource;
-
-/// Entry point for `openintel setup <source>`. Exit code 0 only when the
-/// source is fully configured and a live probe succeeds.
-pub async fn run(source: SetupSource, credentials: &Credentials) -> ExitCode {
-    match source {
-        SetupSource::Reddit => setup_reddit(credentials).await,
-        SetupSource::Bluesky => setup_bluesky(credentials).await,
-    }
-}
 
 /// Which of the three setup modes applies, given which env vars are set.
 /// First/second = the source's (identifier-like, secret-like) credential pair
@@ -172,6 +166,292 @@ const BLUESKY_UNAUTHORIZED_HINT: &str =
     "Your handle or app password looks wrong. Check the handle\n   \
          (e.g. yourname.bsky.social) and generate a fresh app password at\n   \
          https://bsky.app/settings/app-passwords (the value is shown only once).";
+
+/// Everything the shared interactive loop needs to know about one source.
+struct SourceSpec {
+    label: &'static str,
+    first_key: &'static str,
+    second_key: &'static str,
+    first_prompt: &'static str,
+    second_prompt: &'static str,
+    condensed_guide: &'static str,
+    unauthorized_hint: &'static str,
+    try_cmd: &'static str,
+}
+
+const REDDIT_SPEC: SourceSpec = SourceSpec {
+    label: "Reddit",
+    first_key: "OPENINTEL_REDDIT_CLIENT_ID",
+    second_key: "OPENINTEL_REDDIT_CLIENT_SECRET",
+    first_prompt: "Client id",
+    second_prompt: "Client secret",
+    condensed_guide: "\
+Reddit needs a free OAuth app — there's no keyless access. ~2 minutes:
+
+  1. Sign in to Reddit, then open:  https://www.reddit.com/prefs/apps
+  2. Scroll to the bottom and click \"create another app…\"
+     (or \"are you a developer? create an app…\").
+  3. Fill in the form:
+       • name           openintel        (anything is fine)
+       • type           select \"script\"  ← this matters
+       • redirect uri   http://localhost:8080   (unused, but required)
+     Click \"create app\".
+  4. On the app that appears:
+       • CLIENT ID  — the short string just under the app name
+                      (below \"personal use script\")
+       • SECRET     — the value labelled \"secret\"
+  5. Enter them below — they'll be verified live and saved to your OS
+     keychain (plaintext never touches disk).
+",
+    unauthorized_hint: REDDIT_UNAUTHORIZED_HINT,
+    try_cmd: "openintel analyze GME --enable-reddit",
+};
+
+const BLUESKY_SPEC: SourceSpec = SourceSpec {
+    label: "Bluesky",
+    first_key: "OPENINTEL_BLUESKY_HANDLE",
+    second_key: "OPENINTEL_BLUESKY_APP_PASSWORD",
+    first_prompt: "Handle (e.g. yourname.bsky.social)",
+    second_prompt: "App password",
+    condensed_guide: "\
+Bluesky needs a free app password — search requires auth. ~2 minutes:
+
+  1. Create a free account at https://bsky.app if you don't have one.
+  2. Sign in, then open:  https://bsky.app/settings/app-passwords
+     (Settings → Privacy and Security → App Passwords).
+  3. Click \"Add App Password\", name it  openintel , and copy the generated
+     password — it is shown only once (format: xxxx-xxxx-xxxx-xxxx).
+  4. Enter your handle and the app password below — they'll be verified live
+     and saved to your OS keychain (plaintext never touches disk).
+",
+    unauthorized_hint: BLUESKY_UNAUTHORIZED_HINT,
+    try_cmd: "openintel analyze GME --enable-bluesky",
+};
+
+/// Entry point for `openintel setup <source>`. Exit code 0 only when the
+/// source is verified working (or `--forget` succeeded).
+pub async fn run(
+    source: SetupSource,
+    credentials: &Credentials,
+    store: &dyn CredentialStore,
+    forget: bool,
+) -> ExitCode {
+    let spec = match source {
+        SetupSource::Reddit => &REDDIT_SPEC,
+        SetupSource::Bluesky => &BLUESKY_SPEC,
+    };
+
+    if forget {
+        return forget_source(spec, store);
+    }
+
+    if !std::io::stdin().is_terminal() {
+        // Piped / CI: the classic guide/partial/verify behavior, unchanged.
+        return match source {
+            SetupSource::Reddit => setup_reddit(credentials).await,
+            SetupSource::Bluesky => setup_bluesky(credentials).await,
+        };
+    }
+
+    let configured = match source {
+        SetupSource::Reddit => {
+            credentials.reddit_client_id.is_some() && credentials.reddit_client_secret.is_some()
+        }
+        SetupSource::Bluesky => {
+            credentials.bluesky_handle.is_some() && credentials.bluesky_app_password.is_some()
+        }
+    };
+    let already = configured.then(|| provenance(spec.first_key));
+
+    let mut stdin = std::io::stdin().lock();
+    let read_secret = |prompt: &str| {
+        rpassword::prompt_password(prompt).map(|s| SecretString::new(s.into_boxed_str()))
+    };
+    let mut io = SetupIo {
+        input: &mut stdin,
+        read_secret: &read_secret,
+    };
+
+    let outcome = match source {
+        SetupSource::Reddit => {
+            run_interactive(&mut io, store, spec, already, |first, secret| {
+                probe_reddit(SecretString::new(first.into_boxed_str()), secret)
+            })
+            .await
+        }
+        SetupSource::Bluesky => run_interactive(&mut io, store, spec, already, probe_bluesky).await,
+    };
+
+    match outcome {
+        InteractiveOutcome::Done(Outcome::Success) => ExitCode::SUCCESS,
+        InteractiveOutcome::Done(Outcome::Failure) => ExitCode::FAILURE,
+        InteractiveOutcome::VerifyExisting => match source {
+            SetupSource::Reddit => setup_reddit(credentials).await,
+            SetupSource::Bluesky => setup_bluesky(credentials).await,
+        },
+    }
+}
+
+/// Where the already-configured credentials came from, for the replace-ask.
+fn provenance(first_key: &str) -> &'static str {
+    if std::env::var(first_key)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+    {
+        "the environment"
+    } else {
+        "the OS keychain"
+    }
+}
+
+fn forget_source(spec: &SourceSpec, store: &dyn CredentialStore) -> ExitCode {
+    match forget_outcome(spec, store) {
+        Outcome::Success => ExitCode::SUCCESS,
+        Outcome::Failure => ExitCode::FAILURE,
+    }
+}
+
+fn forget_outcome(spec: &SourceSpec, store: &dyn CredentialStore) -> Outcome {
+    for key in [spec.first_key, spec.second_key] {
+        if let Err(e) = store.delete(key) {
+            println!("❌ could not remove {key} from the OS keychain: {e}");
+            return Outcome::Failure;
+        }
+    }
+    println!(
+        "Removed {} credentials from the OS keychain. (Env vars, if set, still apply.)",
+        spec.label
+    );
+    Outcome::Success
+}
+
+/// Injected I/O so the interactive loop is unit-testable without a TTY.
+struct SetupIo<'a> {
+    input: &'a mut dyn BufRead,
+    read_secret: &'a dyn Fn(&str) -> std::io::Result<SecretString>,
+}
+
+/// `std::process::ExitCode` has no `PartialEq`, so the loop reports this
+/// testable outcome and `run()` maps it to an exit code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Outcome {
+    Success,
+    Failure,
+}
+
+enum InteractiveOutcome {
+    Done(Outcome),
+    /// User declined to replace existing creds -> caller runs the classic verify.
+    VerifyExisting,
+}
+
+const MAX_ATTEMPTS: usize = 3;
+
+async fn run_interactive<F, Fut>(
+    io: &mut SetupIo<'_>,
+    store: &dyn CredentialStore,
+    spec: &SourceSpec,
+    already_configured_from: Option<&'static str>,
+    probe: F,
+) -> InteractiveOutcome
+where
+    F: Fn(String, SecretString) -> Fut,
+    Fut: std::future::Future<Output = Result<usize, DomainError>>,
+{
+    if let Some(source_of_truth) = already_configured_from {
+        println!(
+            "{} is already configured (from {source_of_truth}).",
+            spec.label
+        );
+        match read_visible(io, "Replace it? [y/N]: ") {
+            Ok(ans) if matches!(ans.trim().to_lowercase().as_str(), "y" | "yes") => {}
+            Ok(_) => return InteractiveOutcome::VerifyExisting,
+            Err(_) => return InteractiveOutcome::Done(Outcome::Failure),
+        }
+    }
+
+    println!("{}", spec.condensed_guide);
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        let Ok(first) = prompt_nonempty_visible(io, spec.first_prompt) else {
+            return InteractiveOutcome::Done(Outcome::Failure);
+        };
+        let Ok(secret) = prompt_nonempty_secret(io, spec.second_prompt) else {
+            return InteractiveOutcome::Done(Outcome::Failure);
+        };
+
+        println!("Checking your {} credentials…", spec.label);
+        match probe(first.clone(), secret.clone()).await {
+            Ok(count) => {
+                let first_secret = SecretString::new(first.into_boxed_str());
+                let saved = store
+                    .set(spec.first_key, &first_secret)
+                    .and_then(|()| store.set(spec.second_key, &secret));
+                return InteractiveOutcome::Done(match saved {
+                    Ok(()) => {
+                        println!("{}", verify_ok_text(spec.label, count, spec.try_cmd));
+                        println!(
+                            "   Saved to your OS keychain — you're set. (Env vars still override.)"
+                        );
+                        Outcome::Success
+                    }
+                    Err(e) => {
+                        println!("{}", verify_ok_text(spec.label, count, spec.try_cmd));
+                        println!(
+                            "⚠  Verified, but saving to the OS keychain failed: {e}\n   \
+                             Fall back to environment variables (with your real values):\n\n   \
+                             export {}=paste_your_value\n   export {}=paste_your_value",
+                            spec.first_key, spec.second_key
+                        );
+                        Outcome::Failure
+                    }
+                });
+            }
+            Err(e) => {
+                println!("{}", verify_err_text(&e, spec.unauthorized_hint));
+                if attempt < MAX_ATTEMPTS {
+                    println!("Let's try again ({} of {MAX_ATTEMPTS}).", attempt + 1);
+                }
+            }
+        }
+    }
+    println!(
+        "Still not verified after {MAX_ATTEMPTS} attempts — double-check the values and re-run `openintel setup`."
+    );
+    InteractiveOutcome::Done(Outcome::Failure)
+}
+
+/// Visible prompt (identifier-like values). Re-asks on empty input.
+fn prompt_nonempty_visible(io: &mut SetupIo<'_>, label: &str) -> std::io::Result<String> {
+    loop {
+        let ans = read_visible(io, &format!("{label}: "))?;
+        let trimmed = ans.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+        println!("Please enter a value.");
+    }
+}
+
+/// Hidden prompt (secret-like values). Re-asks on empty input.
+fn prompt_nonempty_secret(io: &mut SetupIo<'_>, label: &str) -> std::io::Result<SecretString> {
+    use secrecy::ExposeSecret as _;
+    loop {
+        let secret = (io.read_secret)(&format!("{label} (input hidden): "))?;
+        if !secret.expose_secret().trim().is_empty() {
+            return Ok(secret);
+        }
+        println!("Please enter a value.");
+    }
+}
+
+fn read_visible(io: &mut SetupIo<'_>, prompt: &str) -> std::io::Result<String> {
+    print!("{prompt}");
+    std::io::stdout().flush()?;
+    let mut line = String::new();
+    io.input.read_line(&mut line)?;
+    Ok(line)
+}
 
 async fn setup_bluesky(credentials: &Credentials) -> ExitCode {
     match plan(
@@ -342,5 +622,143 @@ mod tests {
         let text = verify_err_text(&unauthorized, BLUESKY_UNAUTHORIZED_HINT);
         assert!(text.contains("app-passwords"));
         assert!(!text.contains("prefs/apps"));
+    }
+
+    use crate::config::store::InMemoryStore;
+    use secrecy::ExposeSecret;
+    use std::io::Cursor;
+
+    fn scripted<'a>(
+        input: &'a mut Cursor<&'static str>,
+        secrets: &'a dyn Fn(&str) -> std::io::Result<SecretString>,
+    ) -> SetupIo<'a> {
+        SetupIo {
+            input,
+            read_secret: secrets,
+        }
+    }
+
+    fn ok_secret(_prompt: &str) -> std::io::Result<SecretString> {
+        Ok(SecretString::new("s3cret".to_string().into_boxed_str()))
+    }
+
+    #[tokio::test]
+    async fn interactive_happy_path_saves_both_keys() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("my-id\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |_first, _secret| {
+            std::future::ready(Ok(2usize))
+        })
+        .await;
+        assert!(matches!(
+            outcome,
+            InteractiveOutcome::Done(Outcome::Success)
+        ));
+        let map = store.map.borrow();
+        assert_eq!(
+            map.get("OPENINTEL_REDDIT_CLIENT_ID")
+                .unwrap()
+                .expose_secret(),
+            "my-id"
+        );
+        assert_eq!(
+            map.get("OPENINTEL_REDDIT_CLIENT_SECRET")
+                .unwrap()
+                .expose_secret(),
+            "s3cret"
+        );
+    }
+
+    #[tokio::test]
+    async fn interactive_three_failures_exits_one_and_saves_nothing() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("id1\nid2\nid3\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |_f, _s| {
+            std::future::ready(Err(DomainError::SourceFailure {
+                name: "reddit".into(),
+                message: "unauthorized — check client id/secret".into(),
+            }))
+        })
+        .await;
+        assert!(matches!(
+            outcome,
+            InteractiveOutcome::Done(Outcome::Failure)
+        ));
+        assert!(store.map.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn interactive_empty_input_reasks_then_succeeds() {
+        let store = InMemoryStore::new();
+        // First visible answer empty -> re-ask -> then a real id.
+        let mut input = Cursor::new("\nreal-id\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |first, _s| {
+            std::future::ready(if first == "real-id" {
+                Ok(0)
+            } else {
+                Err(DomainError::NoData)
+            })
+        })
+        .await;
+        assert!(matches!(
+            outcome,
+            InteractiveOutcome::Done(Outcome::Success)
+        ));
+    }
+
+    #[tokio::test]
+    async fn interactive_replace_declined_verifies_existing() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("n\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(
+            &mut io,
+            &store,
+            &REDDIT_SPEC,
+            Some("the OS keychain"),
+            |_f, _s| std::future::ready(Ok(1)),
+        )
+        .await;
+        assert!(matches!(outcome, InteractiveOutcome::VerifyExisting));
+        assert!(store.map.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn interactive_save_failure_is_exit_one_with_fallback() {
+        let store = InMemoryStore::failing();
+        let mut input = Cursor::new("my-id\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &REDDIT_SPEC, None, |_f, _s| {
+            std::future::ready(Ok(1usize))
+        })
+        .await;
+        assert!(matches!(
+            outcome,
+            InteractiveOutcome::Done(Outcome::Failure)
+        ));
+    }
+
+    #[test]
+    fn forget_is_idempotent_and_removes_keys() {
+        let store = InMemoryStore::new()
+            .seed("OPENINTEL_REDDIT_CLIENT_ID", "x")
+            .seed("OPENINTEL_REDDIT_CLIENT_SECRET", "y");
+        assert_eq!(forget_outcome(&REDDIT_SPEC, &store), Outcome::Success);
+        assert!(store.map.borrow().is_empty());
+        // Second run: nothing left to delete, still success.
+        assert_eq!(forget_outcome(&REDDIT_SPEC, &store), Outcome::Success);
+    }
+
+    #[test]
+    fn condensed_guides_have_no_export_lines() {
+        for spec in [&REDDIT_SPEC, &BLUESKY_SPEC] {
+            assert!(!spec.condensed_guide.contains("export "));
+            assert!(spec.condensed_guide.contains("keychain"));
+        }
+        assert!(REDDIT_SPEC.condensed_guide.contains("prefs/apps"));
+        assert!(BLUESKY_SPEC.condensed_guide.contains("app-passwords"));
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,2 +1,3 @@
 pub mod secrets;
 pub mod settings;
+pub mod store;

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -1,4 +1,6 @@
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
+
+use crate::config::store::CredentialStore;
 
 #[derive(Debug)]
 pub struct Credentials {
@@ -20,6 +22,28 @@ impl Credentials {
             market_api_key: secret_from(std::env::var("OPENINTEL_MARKET_API_KEY").ok()),
         }
     }
+
+    /// Resolve credentials with precedence: environment variable (non-empty)
+    /// -> OS keychain -> unset. A store malfunction warns and falls back to
+    /// env-only for that field — the keychain can never break analysis.
+    pub fn load(store: &dyn CredentialStore) -> Self {
+        let mut c = Credentials::from_env();
+        c.reddit_client_id = c
+            .reddit_client_id
+            .or_else(|| store_get(store, "OPENINTEL_REDDIT_CLIENT_ID"));
+        c.reddit_client_secret = c
+            .reddit_client_secret
+            .or_else(|| store_get(store, "OPENINTEL_REDDIT_CLIENT_SECRET"));
+        // The handle is public info (kept as a plain String on Credentials);
+        // unwrap the store's SecretString wrapper at this one site.
+        c.bluesky_handle = c.bluesky_handle.or_else(|| {
+            store_get(store, "OPENINTEL_BLUESKY_HANDLE").map(|s| s.expose_secret().to_string())
+        });
+        c.bluesky_app_password = c
+            .bluesky_app_password
+            .or_else(|| store_get(store, "OPENINTEL_BLUESKY_APP_PASSWORD"));
+        c
+    }
 }
 
 fn secret_from(value: Option<String>) -> Option<SecretString> {
@@ -31,6 +55,18 @@ fn secret_from(value: Option<String>) -> Option<SecretString> {
 /// Non-secret env value with the same "exported-but-empty means unset" rule.
 fn plain_from(value: Option<String>) -> Option<String> {
     value.filter(|v| !v.is_empty())
+}
+
+/// Keychain read that treats malfunction as "unavailable" (with a warning)
+/// rather than fatal. Absence of a key is NOT an error — `get` returns `Ok(None)` and `delete` is idempotent.
+fn store_get(store: &dyn CredentialStore, key: &str) -> Option<SecretString> {
+    match store.get(key) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("warning: credential store unavailable for {key}: {e}");
+            None
+        }
+    }
 }
 
 #[cfg(test)]
@@ -63,5 +99,54 @@ mod tests {
         };
         assert!(!format!("{creds:?}").contains("leak-me"));
         assert!(!format!("{creds:?}").contains("leak-me-too"));
+    }
+
+    #[test]
+    fn load_falls_back_to_store_when_env_unset() {
+        use crate::config::store::{CredentialStore, InMemoryStore};
+        let store = InMemoryStore::new()
+            .seed("OPENINTEL_REDDIT_CLIENT_ID", "store-id")
+            .seed("OPENINTEL_REDDIT_CLIENT_SECRET", "store-secret")
+            .seed("OPENINTEL_BLUESKY_HANDLE", "store.bsky.social")
+            .seed("OPENINTEL_BLUESKY_APP_PASSWORD", "store-pw");
+        // Guard: these env vars must not leak into the test environment.
+        for key in [
+            "OPENINTEL_REDDIT_CLIENT_ID",
+            "OPENINTEL_REDDIT_CLIENT_SECRET",
+            "OPENINTEL_BLUESKY_HANDLE",
+            "OPENINTEL_BLUESKY_APP_PASSWORD",
+        ] {
+            if std::env::var(key).map(|v| !v.is_empty()).unwrap_or(false) {
+                eprintln!("skipping load_falls_back_to_store_when_env_unset: {key} set in env");
+                return;
+            }
+        }
+        let c = Credentials::load(&store);
+        assert_eq!(c.reddit_client_id.unwrap().expose_secret(), "store-id");
+        assert_eq!(
+            c.reddit_client_secret.unwrap().expose_secret(),
+            "store-secret"
+        );
+        assert_eq!(c.bluesky_handle.as_deref(), Some("store.bsky.social"));
+        assert_eq!(c.bluesky_app_password.unwrap().expose_secret(), "store-pw");
+        // Unrelated read never touched the store's error path
+        let _ = &store as &dyn CredentialStore;
+    }
+
+    #[test]
+    fn load_survives_a_broken_store() {
+        use crate::config::store::InMemoryStore;
+        let store = InMemoryStore::failing();
+        let c = Credentials::load(&store); // must not panic; falls back to env-only
+                                           // Whatever env says is what we get; a broken keychain adds nothing.
+        let env_only = Credentials::from_env();
+        assert_eq!(
+            c.reddit_client_id.is_some(),
+            env_only.reddit_client_id.is_some()
+        );
+        assert_eq!(
+            c.bluesky_handle.is_some(),
+            env_only.bluesky_handle.is_some()
+        );
     }
 }

--- a/src/config/store.rs
+++ b/src/config/store.rs
@@ -1,0 +1,172 @@
+//! Credential-store port: the OS keychain behind a small trait so tests can
+//! use an in-memory fake and the keychain can never break the analysis path.
+//!
+//! Written ONLY by `openintel setup` (after a successful live verify); read
+//! as a fallback by `Credentials::load` — env vars always win.
+
+use secrecy::{ExposeSecret, SecretString};
+
+/// Service name under which all openintel keys live in the OS store.
+const SERVICE: &str = "openintel";
+
+/// Store malfunction (backend unavailable, access denied, …). Absence of a
+/// key is NOT an error — `get` returns `Ok(None)` and `delete` is idempotent.
+#[derive(Debug)]
+pub struct StoreError(pub String);
+
+impl std::fmt::Display for StoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+pub trait CredentialStore {
+    /// Ok(None) = key not present.
+    fn get(&self, key: &str) -> Result<Option<SecretString>, StoreError>;
+    fn set(&self, key: &str, value: &SecretString) -> Result<(), StoreError>;
+    /// Idempotent: deleting an absent key is Ok.
+    fn delete(&self, key: &str) -> Result<(), StoreError>;
+}
+
+/// Real adapter over the OS keychain (macOS Keychain / Windows Credential
+/// Manager / Linux secret-service) via the `keyring` crate.
+#[derive(Default)]
+pub struct KeychainStore;
+
+impl KeychainStore {
+    pub fn new() -> Self {
+        KeychainStore
+    }
+
+    fn entry(key: &str) -> Result<keyring::v1::Entry, StoreError> {
+        keyring::v1::Entry::new(SERVICE, key)
+            .map_err(|e| StoreError(format!("keychain entry for {key}: {e}")))
+    }
+}
+
+impl CredentialStore for KeychainStore {
+    fn get(&self, key: &str) -> Result<Option<SecretString>, StoreError> {
+        match Self::entry(key)?.get_password() {
+            Ok(v) => Ok(Some(SecretString::new(v.into_boxed_str()))),
+            Err(keyring::v1::Error::NoEntry) => Ok(None),
+            Err(e) => Err(StoreError(format!("keychain read for {key}: {e}"))),
+        }
+    }
+
+    fn set(&self, key: &str, value: &SecretString) -> Result<(), StoreError> {
+        Self::entry(key)?
+            .set_password(value.expose_secret())
+            .map_err(|e| StoreError(format!("keychain write for {key}: {e}")))
+    }
+
+    fn delete(&self, key: &str) -> Result<(), StoreError> {
+        match Self::entry(key)?.delete_credential() {
+            Ok(()) | Err(keyring::v1::Error::NoEntry) => Ok(()),
+            Err(e) => Err(StoreError(format!("keychain delete for {key}: {e}"))),
+        }
+    }
+}
+
+/// In-memory fake for hermetic tests. `failing()` errors on every operation
+/// (simulates a broken keychain backend).
+#[cfg(test)]
+pub(crate) struct InMemoryStore {
+    pub map: std::cell::RefCell<std::collections::HashMap<String, SecretString>>,
+    fail: bool,
+}
+
+#[cfg(test)]
+impl InMemoryStore {
+    pub fn new() -> Self {
+        InMemoryStore {
+            map: std::cell::RefCell::new(std::collections::HashMap::new()),
+            fail: false,
+        }
+    }
+
+    pub fn failing() -> Self {
+        InMemoryStore {
+            map: std::cell::RefCell::new(std::collections::HashMap::new()),
+            fail: true,
+        }
+    }
+
+    pub fn seed(self, key: &str, value: &str) -> Self {
+        self.map.borrow_mut().insert(
+            key.to_string(),
+            SecretString::new(value.to_string().into_boxed_str()),
+        );
+        self
+    }
+}
+
+#[cfg(test)]
+impl CredentialStore for InMemoryStore {
+    fn get(&self, key: &str) -> Result<Option<SecretString>, StoreError> {
+        if self.fail {
+            return Err(StoreError("simulated store failure".into()));
+        }
+        Ok(self.map.borrow().get(key).cloned())
+    }
+
+    fn set(&self, key: &str, value: &SecretString) -> Result<(), StoreError> {
+        if self.fail {
+            return Err(StoreError("simulated store failure".into()));
+        }
+        self.map.borrow_mut().insert(key.to_string(), value.clone());
+        Ok(())
+    }
+
+    fn delete(&self, key: &str) -> Result<(), StoreError> {
+        if self.fail {
+            return Err(StoreError("simulated store failure".into()));
+        }
+        self.map.borrow_mut().remove(key);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secret(s: &str) -> SecretString {
+        SecretString::new(s.to_string().into_boxed_str())
+    }
+
+    #[test]
+    fn in_memory_round_trip_and_idempotent_delete() {
+        let store = InMemoryStore::new();
+        assert!(store.get("K").unwrap().is_none());
+        store.set("K", &secret("v")).unwrap();
+        assert_eq!(store.get("K").unwrap().unwrap().expose_secret(), "v");
+        store.delete("K").unwrap();
+        assert!(store.get("K").unwrap().is_none());
+        store.delete("K").unwrap(); // absent -> still Ok
+    }
+
+    #[test]
+    fn failing_store_errors_on_every_op() {
+        let store = InMemoryStore::failing();
+        assert!(store.get("K").is_err());
+        assert!(store.set("K", &secret("v")).is_err());
+        assert!(store.delete("K").is_err());
+    }
+
+    /// Touches the real OS keychain — run manually: `cargo test --ignored keychain_live`
+    #[test]
+    #[ignore = "mutates the developer's real OS keychain; run with --ignored"]
+    fn keychain_live_round_trip() {
+        let store = KeychainStore::new();
+        let key = "OPENINTEL_TEST_ROUND_TRIP";
+        store.set(key, &secret("test-value")).unwrap();
+        assert_eq!(
+            store.get(key).unwrap().unwrap().expose_secret(),
+            "test-value"
+        );
+        store.delete(key).unwrap();
+        assert!(store.get(key).unwrap().is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,14 @@ use openintel::adapters::market::yahoo::YahooMarketSource;
 use openintel::cli::args::{to_app_config, Cli, Command};
 use openintel::cli::run::analyze;
 use openintel::config::secrets::Credentials;
+use openintel::config::store::KeychainStore;
 
 #[tokio::main]
 async fn main() -> ExitCode {
     let cli = Cli::parse();
-    // Reddit client credentials (if set) enable the real Reddit source; other sources need none.
-    let credentials = Credentials::from_env();
+    // Credentials resolve env-first, then the OS keychain (written by `openintel setup`).
+    let store = KeychainStore::new();
+    let credentials = Credentials::load(&store);
 
     match cli.command {
         Command::Analyze(args) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,8 @@ async fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
-        Command::Setup(args) => openintel::cli::setup::run(args.source, &credentials).await,
+        Command::Setup(args) => {
+            openintel::cli::setup::run(args.source, &credentials, &store, args.forget).await
+        }
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -109,7 +109,8 @@ impl ServerHandler for OpenIntelServer {
 
 /// Run the MCP server over stdio (blocks until the client disconnects).
 pub async fn serve() -> Result<(), Box<dyn std::error::Error>> {
-    let credentials = Credentials::from_env();
+    let store = crate::config::store::KeychainStore::new();
+    let credentials = Credentials::load(&store);
     let social = crate::adapters::sources::build_social_sources(&credentials);
 
     let market = YahooMarketSource::new()?;


### PR DESCRIPTION
## What

`openintel setup reddit|bluesky` is now a complete one-command flow (gh-auth-login style), driven by real first-user feedback ("can I just run setup and be guided?"):

```
$ openintel setup reddit
[condensed guide: create the free script app]
Client id: abc123
Client secret (input hidden): ********
Checking your Reddit credentials…
✅ Verified. Saved to your OS keychain — you're set. (Env vars still override.)
```

- **Prompt → live verify → persist**: hidden secret input (rpassword) straight into `SecretString`; the OS keychain (macOS Keychain / Windows Credential Manager / Linux secret-service via `keyring` 4) is written **only after a successful live probe**.
- **Env always wins**: `Credentials::load` = env → keychain → unset, per field; a broken keychain warns to stderr and can never break `analyze` or the MCP server. CI/power users see zero change.
- **Rotation & removal**: re-run to replace (asks first); `openintel setup <source> --forget` deletes stored keys (idempotent).
- **Non-TTY byte-identical**: piped/CI invocations keep the classic guide/partial/verify behavior and exit codes.
- Both composition roots (CLI + MCP server) resolve via the keychain, so setup-once works everywhere with zero shell config.

## Security posture (SECURITY.md updated)

Plaintext never touches disk: keychain (encrypted at rest, OS-gated) or env only. Hidden prompts mean nothing lands in shell history/scrollback — strictly better than the `export` dance the docs used to teach. `.expose_secret()` new sites: exactly three, each documented (keychain write, public-handle unwrap, prompt emptiness check). Save-failure fallback prints placeholder export lines, never the typed values.

## Architecture

`CredentialStore` port (hexagonal): `KeychainStore` real adapter + `InMemoryStore` test fake. The interactive loop is generic over injected I/O + probe closures — the full state machine (replace-ask, empty-input re-asks, 3-attempt cap, EOF handling, save-on-success, save-failure fallback, `--forget`) is unit-tested with zero network, zero TTY, zero real keychain.

## Review trail

Per-task reviews ×4 (one Important caught and fixed pre-merge: **stdin EOF spun the re-ask loop forever** — now bounded + `UnexpectedEof`, 4 regression tests). Opus whole-branch review: READY TO MERGE with one fix (stale "never stores credentials" help string) — applied. Known/disclosed: macOS may show a one-time keychain ACL prompt for rebuilt unsigned binaries (keyring-inherent).

## Tests

136 lib + 3 integration passing (4 `#[ignore]`d live/keychain), clippy `-D warnings` + fmt clean.

Spec: `docs/superpowers/specs/2026-07-13-interactive-setup-design.md` · Plan: `docs/superpowers/plans/2026-07-13-interactive-setup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)