### PR TITLE
feat(pulse): X Pulse — influencer catalyst feed (paid API, opt-in, cost-honest)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,9 @@ OPENINTEL_MARKET_API_KEY=
 # `openintel setup bluesky` to verify.
 OPENINTEL_BLUESKY_HANDLE=
 OPENINTEL_BLUESKY_APP_PASSWORD=
+
+# --- X Pulse (paid API — optional) ---
+# Bearer token from https://developer.x.com (Projects & Apps → Keys and Tokens).
+# Pay-per-use: ~$0.005 per post read; openintel only calls X on an explicit
+# `openintel pulse` / MCP x_pulse invocation. Prefer `openintel setup x`.
+OPENINTEL_X_BEARER=

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cargo install --path .
 openintel analyze AAPL
 ```
 
-> **Market data is live (Yahoo Finance, keyless). Reddit and Bluesky are live when configured (see below). There is no X source (paid API).** `analyze` fetches over the network — offline or unconfigured sources degrade gracefully with a note.
+> **Market data is live (Yahoo Finance, keyless). Reddit and Bluesky are live when configured (see below) — and see *X Pulse* below for paid catalyst tracking.** `analyze` fetches over the network — offline or unconfigured sources degrade gracefully with a note.
 
 ## Usage
 
@@ -74,6 +74,22 @@ openintel setup bluesky   # non-interactive when piped; verifies from env
 ```
 
 </details>
+
+## X Pulse (optional — paid X API)
+
+Catalyst posts from specific high-impact X accounts (a POTUS tariff post, a CEO
+announcement) — surfaced as **events to reason about**, never averaged into
+sentiment. X's API is pay-per-use (~$0.005 per post read, deduped over 24h), so
+the pulse is strictly opt-in: nothing calls X unless you run it.
+
+```bash
+openintel setup x                                      # guided token setup (verify reads ≈ $0.05)
+openintel pulse NVDA --accounts jensenhuang,elonmusk   # ≤ 20 reads ≈ $0.10 max
+```
+
+No `--accounts` → a small macro default list (POTUS, White House, Musk, the Fed).
+Via MCP, the `x_pulse` tool asks the agent to research which accounts matter for
+your ticker and confirm the cost with you before spending.
 
 ## Use with an AI agent (MCP)
 

--- a/docs/superpowers/plans/2026-07-16-x-pulse.md
+++ b/docs/superpowers/plans/2026-07-16-x-pulse.md
@@ -1,0 +1,1456 @@
+# X Pulse Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `openintel pulse <TICKER>` + MCP `x_pulse`: author-filtered X search surfacing catalyst posts from high-impact accounts, credit-aware and opt-in — never part of analyze/fusion.
+
+**Architecture:** New pulse vertical mirroring house patterns: pure domain (`PulsePost`/`PulseReport` + `InfluencerFeed` port) → application orchestration (clamps, normalization, cost math, clock at the edge) → `XPulseSource` adapter (bearer auth, pure `build_query` + `parse_posts`) → CLI leaf renderer + MCP tool. Setup gains its first single-credential source.
+
+**Tech Stack:** Rust, reqwest 0.13.4 (`default-features=false, features=["rustls"]` — `.query()/.form()/.json()` unavailable), X API v2 `GET /2/tweets/search/recent`, existing keychain/secrecy machinery.
+
+**Spec:** `docs/superpowers/specs/2026-07-16-x-pulse-design.md` — copy verbatim from it.
+
+## Global Constraints
+
+- **Opt-in only:** nothing calls X except an explicit `pulse` invocation; `analyze`/`scan`/`compare`/fusion are untouched; `SourceKind::X` does NOT return.
+- **Cost transparency:** `X_COST_PER_READ_USD = 0.005` (docs.x.com pay-per-use, 2026-02); every `PulseReport` carries `posts_read` + `estimated_cost_usd`; the table renders the cost line verbatim: `cost: {N} posts read (≈ ${X.XX} at $0.005/read; X dedupes re-reads for 24h)`.
+- **Error substrings** (`name: "x"`): 401 → `"unauthorized — check bearer token"`; 403 → `"forbidden — check API access and credit balance"`; 429 → `"rate limited (HTTP 429) — resets at {RFC3339 UTC}"` when the `x-rate-limit-reset` header (unix seconds) is present, else `"rate limited (HTTP 429)"`. Other non-2xx → `"search HTTP {status}"`. Response bodies never echoed.
+- **Query:** `` ${TICKER} (from:a OR from:b) -is:retweet `` from pure `build_query`; `start_time` = now − hours_back (RFC 3339, seconds precision, Z); `max_results = limit.clamp(10, 100)` (API minimum 10) and the parser truncates to `limit`.
+- **Clamps (application layer):** `hours_back.clamp(1, 168)`, `limit.clamp(1, 100)`; accounts `@`-stripped/trimmed, empties dropped, empty list → `DEFAULT_PULSE_ACCOUNTS = ["realDonaldTrump", "WhiteHouse", "elonmusk", "federalreserve"]`.
+- **Secrets:** bearer is `SecretString` end-to-end; `.expose_secret()` in new adapter code at exactly one site (`bearer_auth`). Keychain key `OPENINTEL_X_BEARER`.
+- **stdout discipline:** `println!` only in `main.rs` + `cli/setup.rs`; `cli/pulse.rs` returns rendered `String`s (main prints), like `cli/run.rs`.
+- **Zero posts = success** (exit 0); X unconfigured → hint `run: openintel setup x`, exit 1 (CLI) / invalid-request error (MCP).
+- **Reddit/Bluesky setup flows byte-identical** after the single-credential generalization.
+- **Hermetic tests:** no network/TTY/keychain; one new `#[ignore]`d live test.
+- **Every commit green:** `cargo build --all-targets && cargo test && cargo clippy -- -D warnings && cargo fmt -- --check`.
+
+---
+
+### Task 1: Pulse core — domain entities, port, application
+
+**Files:**
+- Create: `src/domain/entities/pulse.rs`, `src/domain/ports/influencer_feed.rs`, `src/application/pulse.rs`
+- Modify: `src/domain/entities/mod.rs`, `src/domain/ports/mod.rs`, `src/application/mod.rs`
+
+**Interfaces:**
+- Consumes: existing `PostText`, `Ticker`, `DomainError`.
+- Produces (later tasks rely on exactly these):
+  - `PulsePost { id: String, author: String, text: PostText, created_at: DateTime<Utc>, engagement: u32 }`
+  - `PulseReport { ticker: String, accounts: Vec<String>, hours_back: u32, posts: Vec<PulsePost>, posts_read: u32, estimated_cost_usd: f64, generated_at: DateTime<Utc> }` (all `Serialize`)
+  - `#[async_trait] pub trait InfluencerFeed: Send + Sync { async fn pulse(&self, ticker: &Ticker, accounts: &[String], hours_back: u32, limit: usize) -> Result<Vec<PulsePost>, DomainError>; }`
+  - `pub async fn pulse(ticker_raw: &str, accounts_raw: &[String], hours_back: u32, limit: usize, feed: &dyn InfluencerFeed, now: DateTime<Utc>) -> Result<PulseReport, DomainError>`
+  - `pub const X_COST_PER_READ_USD: f64 = 0.005;`, `pub const DEFAULT_PULSE_ACCOUNTS: [&str; 4]`, `pub fn normalize_accounts(raw: &[String]) -> Vec<String>` — all in `application::pulse`.
+
+- [ ] **Step 1: `src/domain/entities/pulse.rs`**
+
+```rust
+//! Pulse posts: catalyst events from specific high-impact X accounts.
+//! Deliberately NOT `SocialPost` — pulse posts never enter the fusion
+//! engine's sentiment averaging (see the 2026-07-16 spec).
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::domain::entities::social_post::PostText;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PulsePost {
+    pub id: String,
+    pub author: String,
+    pub text: PostText,
+    pub created_at: DateTime<Utc>,
+    pub engagement: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PulseReport {
+    pub ticker: String,
+    pub accounts: Vec<String>,
+    pub hours_back: u32,
+    pub posts: Vec<PulsePost>,
+    pub posts_read: u32,
+    pub estimated_cost_usd: f64,
+    pub generated_at: DateTime<Utc>,
+}
+```
+
+- [ ] **Step 2: `src/domain/ports/influencer_feed.rs`**
+
+```rust
+use async_trait::async_trait;
+
+use crate::domain::entities::pulse::PulsePost;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+
+/// Author-filtered event feed (the X Pulse port). Paid upstream — callers
+/// invoke it only on explicit user opt-in.
+#[async_trait]
+pub trait InfluencerFeed: Send + Sync {
+    async fn pulse(
+        &self,
+        ticker: &Ticker,
+        accounts: &[String],
+        hours_back: u32,
+        limit: usize,
+    ) -> Result<Vec<PulsePost>, DomainError>;
+}
+```
+
+Register both: append `pub mod pulse;` to `src/domain/entities/mod.rs` and `pub mod influencer_feed;` to `src/domain/ports/mod.rs` (keep alphabetical order).
+
+- [ ] **Step 3: `src/application/pulse.rs`**
+
+```rust
+use chrono::{DateTime, Utc};
+
+use crate::domain::entities::pulse::PulseReport;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::influencer_feed::InfluencerFeed;
+
+/// X pay-per-use price per post read (docs.x.com pricing, 2026-02 launch).
+pub const X_COST_PER_READ_USD: f64 = 0.005;
+
+/// No-arguments fallback: market-moving macro accounts. Per-call account
+/// lists are the primary path — the consuming agent curates per ticker.
+pub const DEFAULT_PULSE_ACCOUNTS: [&str; 4] =
+    ["realDonaldTrump", "WhiteHouse", "elonmusk", "federalreserve"];
+
+pub const MAX_HOURS_BACK: u32 = 168;
+pub const MAX_PULSE_LIMIT: usize = 100;
+
+/// Trim, strip a leading `@`, drop empties; empty result -> the default list.
+pub fn normalize_accounts(raw: &[String]) -> Vec<String> {
+    let cleaned: Vec<String> = raw
+        .iter()
+        .map(|a| a.trim().trim_start_matches('@').to_string())
+        .filter(|a| !a.is_empty())
+        .collect();
+    if cleaned.is_empty() {
+        DEFAULT_PULSE_ACCOUNTS.iter().map(|s| s.to_string()).collect()
+    } else {
+        cleaned
+    }
+}
+
+pub async fn pulse(
+    ticker_raw: &str,
+    accounts_raw: &[String],
+    hours_back: u32,
+    limit: usize,
+    feed: &dyn InfluencerFeed,
+    now: DateTime<Utc>,
+) -> Result<PulseReport, DomainError> {
+    let ticker = Ticker::parse(ticker_raw)?;
+    let accounts = normalize_accounts(accounts_raw);
+    let hours_back = hours_back.clamp(1, MAX_HOURS_BACK);
+    let limit = limit.clamp(1, MAX_PULSE_LIMIT);
+    let posts = feed.pulse(&ticker, &accounts, hours_back, limit).await?;
+    let posts_read = posts.len() as u32;
+    Ok(PulseReport {
+        ticker: ticker.as_str().to_string(),
+        accounts,
+        hours_back,
+        posts,
+        posts_read,
+        estimated_cost_usd: f64::from(posts_read) * X_COST_PER_READ_USD,
+        generated_at: now,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::entities::pulse::PulsePost;
+    use crate::domain::entities::social_post::PostText;
+    use async_trait::async_trait;
+    use chrono::TimeZone;
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap()
+    }
+
+    /// Records what it was called with; returns `n` canned posts.
+    struct FakeFeed {
+        n: usize,
+        seen: std::cell::RefCell<Option<(String, Vec<String>, u32, usize)>>,
+    }
+
+    #[async_trait]
+    impl InfluencerFeed for FakeFeed {
+        async fn pulse(
+            &self,
+            ticker: &Ticker,
+            accounts: &[String],
+            hours_back: u32,
+            limit: usize,
+        ) -> Result<Vec<PulsePost>, DomainError> {
+            *self.seen.borrow_mut() = Some((
+                ticker.as_str().to_string(),
+                accounts.to_vec(),
+                hours_back,
+                limit,
+            ));
+            Ok((0..self.n)
+                .map(|i| PulsePost {
+                    id: format!("p{i}"),
+                    author: "someone".into(),
+                    text: PostText::parse("hello market").unwrap(),
+                    created_at: at(),
+                    engagement: 1,
+                })
+                .collect())
+        }
+    }
+
+    fn fake(n: usize) -> FakeFeed {
+        FakeFeed {
+            n,
+            seen: std::cell::RefCell::new(None),
+        }
+    }
+
+    #[test]
+    fn normalize_strips_at_and_falls_back_to_defaults() {
+        let raw = vec!["@jensenhuang".to_string(), "  elonmusk ".to_string(), "".to_string()];
+        assert_eq!(normalize_accounts(&raw), vec!["jensenhuang", "elonmusk"]);
+        let empty: Vec<String> = vec!["@".to_string(), "  ".to_string()];
+        assert_eq!(normalize_accounts(&empty), DEFAULT_PULSE_ACCOUNTS.to_vec());
+        assert_eq!(normalize_accounts(&[]), DEFAULT_PULSE_ACCOUNTS.to_vec());
+    }
+
+    #[tokio::test]
+    async fn pulse_clamps_and_computes_cost() {
+        let feed = fake(3);
+        let report = pulse("nvda", &[], 500, 900, &feed, at()).await.unwrap();
+        let (ticker, accounts, hours, limit) = feed.seen.borrow().clone().unwrap();
+        assert_eq!(ticker, "NVDA"); // Ticker::parse normalizes
+        assert_eq!(accounts, DEFAULT_PULSE_ACCOUNTS.to_vec());
+        assert_eq!(hours, 168);
+        assert_eq!(limit, 100);
+        assert_eq!(report.posts_read, 3);
+        assert!((report.estimated_cost_usd - 0.015).abs() < 1e-9);
+        assert_eq!(report.generated_at, at());
+    }
+
+    #[tokio::test]
+    async fn pulse_clamps_low_bounds_and_zero_posts_is_ok() {
+        let feed = fake(0);
+        let report = pulse("AAPL", &["a".into()], 0, 0, &feed, at()).await.unwrap();
+        let (_, _, hours, limit) = feed.seen.borrow().clone().unwrap();
+        assert_eq!(hours, 1);
+        assert_eq!(limit, 1);
+        assert_eq!(report.posts_read, 0);
+        assert_eq!(report.estimated_cost_usd, 0.0);
+    }
+
+    #[tokio::test]
+    async fn pulse_rejects_bad_ticker() {
+        let feed = fake(0);
+        assert!(pulse("$$$", &[], 24, 20, &feed, at()).await.is_err());
+    }
+}
+```
+
+Register: append `pub mod pulse;` to `src/application/mod.rs`.
+
+Note: if `Ticker::parse("nvda")` does NOT uppercase (check `ticker.rs`), change the assertion to the actual normalization behavior — do not change `Ticker`.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `cargo build --all-targets && cargo test && cargo clippy -- -D warnings && cargo fmt`
+Expected: green (4 new tests).
+
+```bash
+git add src/domain/entities/pulse.rs src/domain/ports/influencer_feed.rs src/application/pulse.rs src/domain/entities/mod.rs src/domain/ports/mod.rs src/application/mod.rs
+git commit -m "feat(pulse): domain entities, InfluencerFeed port, application orchestration
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: X adapter + `x_bearer` credential
+
+**Files:**
+- Create: `src/adapters/sources/x/mod.rs`, `src/adapters/sources/x/response.rs`
+- Modify: `src/adapters/sources/mod.rs` (module list), `src/config/secrets.rs` (+`x_bearer`)
+
+**Interfaces:**
+- Consumes: Task 1's `PulsePost`, `InfluencerFeed`; existing `Ticker`, `DomainError`, `CredentialStore` machinery.
+- Produces: `pub struct XPulseSource` with `pub fn new(bearer: SecretString) -> Result<Self, DomainError>` + `impl InfluencerFeed`; `Credentials.x_bearer: Option<SecretString>` (env/keychain key `OPENINTEL_X_BEARER`).
+
+- [ ] **Step 1: `src/adapters/sources/x/response.rs`** — pure parser
+
+```rust
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::domain::entities::pulse::PulsePost;
+use crate::domain::entities::social_post::PostText;
+use crate::domain::error::DomainError;
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    data: Vec<Tweet>,
+    #[serde(default)]
+    includes: Includes,
+}
+
+#[derive(Debug, Deserialize)]
+struct Tweet {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    author_id: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    public_metrics: Option<Metrics>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct Metrics {
+    #[serde(default)]
+    like_count: Option<i64>,
+    #[serde(default)]
+    retweet_count: Option<i64>,
+    #[serde(default)]
+    reply_count: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct Includes {
+    #[serde(default)]
+    users: Vec<User>,
+}
+
+#[derive(Debug, Deserialize)]
+struct User {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "x".into(),
+        message: message.into(),
+    }
+}
+
+fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+pub(crate) fn parse_posts(
+    body: &str,
+    limit: usize,
+    fetched_at: DateTime<Utc>,
+) -> Result<Vec<PulsePost>, DomainError> {
+    let resp: SearchResponse =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
+
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    // author_id -> username join table from `includes.users`.
+    let users: std::collections::HashMap<String, String> = resp
+        .includes
+        .users
+        .into_iter()
+        .filter_map(|u| Some((u.id?, u.username?)))
+        .collect();
+
+    let mut posts = Vec::new();
+    for tweet in resp.data {
+        let id = match tweet.id {
+            Some(i) if !i.is_empty() => i,
+            _ => continue,
+        };
+        let text = match PostText::parse(&tweet.text.unwrap_or_default()) {
+            Ok(t) => t,
+            Err(_) => continue, // empty text -> skip, not fatal
+        };
+        let author = tweet
+            .author_id
+            .and_then(|aid| users.get(&aid).cloned())
+            .unwrap_or_else(|| "[unknown]".to_string());
+        let created_at = tweet
+            .created_at
+            .as_deref()
+            .and_then(parse_rfc3339)
+            .unwrap_or(fetched_at);
+        let m = tweet.public_metrics.unwrap_or_default();
+        let engagement = [m.like_count, m.retweet_count, m.reply_count]
+            .iter()
+            .map(|c| c.unwrap_or(0).max(0) as u64)
+            .sum::<u64>()
+            .min(u32::MAX as u64) as u32;
+
+        posts.push(PulsePost {
+            id,
+            author,
+            text,
+            created_at,
+            engagement,
+        });
+        if posts.len() >= limit {
+            break;
+        }
+    }
+    Ok(posts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap()
+    }
+
+    const HAPPY: &str = r#"{
+        "data":[
+            {"id":"1","text":"Chips made in America will be TAXED at ZERO","author_id":"u1",
+             "created_at":"2026-07-16T09:00:00.000Z",
+             "public_metrics":{"like_count":100,"retweet_count":40,"reply_count":10}},
+            {"id":"2","text":"Blackwell Ultra shipping at scale","author_id":"u2"}
+        ],
+        "includes":{"users":[
+            {"id":"u1","username":"realDonaldTrump"},
+            {"id":"u2","username":"jensenhuang"}
+        ]}
+    }"#;
+
+    #[test]
+    fn happy_joins_authors_and_sums_engagement() {
+        let posts = parse_posts(HAPPY, 50, at()).unwrap();
+        assert_eq!(posts.len(), 2);
+        assert_eq!(posts[0].author, "realDonaldTrump");
+        assert_eq!(posts[0].engagement, 150);
+        assert_eq!(
+            posts[0].created_at,
+            Utc.with_ymd_and_hms(2026, 7, 16, 9, 0, 0).unwrap()
+        );
+        assert_eq!(posts[1].author, "jensenhuang");
+        assert_eq!(posts[1].engagement, 0); // no public_metrics
+        assert_eq!(posts[1].created_at, at()); // no created_at -> fetched_at
+    }
+
+    #[test]
+    fn unknown_author_and_skips() {
+        let body = r#"{"data":[
+            {"id":"1","text":"no author id"},
+            {"id":"2","text":"   "},
+            {"text":"no id"}
+        ]}"#;
+        let posts = parse_posts(body, 50, at()).unwrap();
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].author, "[unknown]");
+    }
+
+    #[test]
+    fn limit_truncates_and_zero_is_empty() {
+        assert_eq!(parse_posts(HAPPY, 1, at()).unwrap().len(), 1);
+        assert!(parse_posts(HAPPY, 0, at()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_data_and_malformed() {
+        assert!(parse_posts(r#"{"data":[]}"#, 50, at()).unwrap().is_empty());
+        assert!(parse_posts(r#"{}"#, 50, at()).unwrap().is_empty()); // data defaults
+        assert!(parse_posts("nope", 50, at()).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: `src/adapters/sources/x/mod.rs`**
+
+```rust
+mod response;
+
+use std::time::Duration as StdDuration;
+
+use async_trait::async_trait;
+use chrono::{Duration, SecondsFormat, TimeZone, Utc};
+use secrecy::{ExposeSecret, SecretString};
+
+use crate::domain::entities::pulse::PulsePost;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::influencer_feed::InfluencerFeed;
+
+const SEARCH_URL: &str = "https://api.x.com/2/tweets/search/recent";
+const TIMEOUT_SECS: u64 = 10;
+
+/// Build the author-filtered search query.
+/// Contingency (spec): if pay-per-use rejects the `$` cashtag operator
+/// (HTTP 400 naming the operator in the live test), drop the `$` prefix here.
+pub(crate) fn build_query(ticker: &Ticker, accounts: &[String]) -> String {
+    let from = accounts
+        .iter()
+        .map(|a| format!("from:{a}"))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    format!("${} ({from}) -is:retweet", ticker.as_str())
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "x".into(),
+        message: message.into(),
+    }
+}
+
+pub struct XPulseSource {
+    client: reqwest::Client,
+    bearer: SecretString,
+    user_agent: String,
+}
+
+impl XPulseSource {
+    pub fn new(bearer: SecretString) -> Result<Self, DomainError> {
+        let user_agent = format!("rust:openintel:v{}", env!("CARGO_PKG_VERSION"));
+        let client = reqwest::Client::builder()
+            .timeout(StdDuration::from_secs(TIMEOUT_SECS))
+            .user_agent(&user_agent)
+            .build()
+            .map_err(|e| fail(format!("client build failed: {e}")))?;
+        Ok(Self {
+            client,
+            bearer,
+            user_agent,
+        })
+    }
+}
+
+#[async_trait]
+impl InfluencerFeed for XPulseSource {
+    async fn pulse(
+        &self,
+        ticker: &Ticker,
+        accounts: &[String],
+        hours_back: u32,
+        limit: usize,
+    ) -> Result<Vec<PulsePost>, DomainError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let fetched_at = Utc::now();
+        let start_time = (fetched_at - Duration::hours(i64::from(hours_back)))
+            .to_rfc3339_opts(SecondsFormat::Secs, true);
+        let max_results = limit.clamp(10, 100).to_string(); // API minimum is 10
+
+        // `.query()` is behind reqwest's un-enabled `query` feature; build manually.
+        let mut url = reqwest::Url::parse(SEARCH_URL).map_err(|e| fail(format!("bad url: {e}")))?;
+        url.query_pairs_mut()
+            .append_pair("query", &build_query(ticker, accounts))
+            .append_pair("start_time", &start_time)
+            .append_pair("max_results", &max_results)
+            .append_pair("tweet.fields", "created_at,public_metrics")
+            .append_pair("expansions", "author_id")
+            .append_pair("user.fields", "username");
+
+        let resp = self
+            .client
+            .get(url)
+            .bearer_auth(self.bearer.expose_secret())
+            .header(reqwest::header::USER_AGENT, &self.user_agent)
+            .send()
+            .await
+            .map_err(|e| fail(format!("search request failed: {e}")))?;
+        let status = resp.status();
+        let reset_hint = resp
+            .headers()
+            .get("x-rate-limit-reset")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<i64>().ok())
+            .and_then(|secs| Utc.timestamp_opt(secs, 0).single());
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| fail(format!("search body failed (HTTP {status}): {e}")))?;
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(match reset_hint {
+                Some(t) => fail(format!(
+                    "rate limited (HTTP 429) — resets at {}",
+                    t.to_rfc3339_opts(SecondsFormat::Secs, true)
+                )),
+                None => fail("rate limited (HTTP 429)"),
+            });
+        }
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(fail("unauthorized — check bearer token"));
+        }
+        if status == reqwest::StatusCode::FORBIDDEN {
+            return Err(fail("forbidden — check API access and credit balance"));
+        }
+        if !status.is_success() {
+            return Err(fail(format!("search HTTP {status}")));
+        }
+        response::parse_posts(&body, limit, fetched_at)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secret(s: &str) -> SecretString {
+        SecretString::new(s.to_string().into_boxed_str())
+    }
+
+    #[test]
+    fn build_query_shapes_cashtag_from_chain_and_retweet_filter() {
+        let t = Ticker::parse("NVDA").unwrap();
+        let accounts = vec!["jensenhuang".to_string(), "elonmusk".to_string()];
+        assert_eq!(
+            build_query(&t, &accounts),
+            "$NVDA (from:jensenhuang OR from:elonmusk) -is:retweet"
+        );
+        let one = vec!["WhiteHouse".to_string()];
+        assert_eq!(build_query(&t, &one), "$NVDA (from:WhiteHouse) -is:retweet");
+    }
+
+    #[test]
+    fn new_builds() {
+        assert!(XPulseSource::new(secret("token")).is_ok());
+    }
+
+    #[tokio::test]
+    #[ignore = "hits live X (paid: ~10 post reads ≈ $0.05); needs OPENINTEL_X_BEARER; run with --ignored"]
+    async fn x_live_pulse() {
+        let bearer = std::env::var("OPENINTEL_X_BEARER").unwrap();
+        let src = XPulseSource::new(SecretString::new(bearer.into_boxed_str())).unwrap();
+        let accounts: Vec<String> = crate::application::pulse::DEFAULT_PULSE_ACCOUNTS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let posts = src
+            .pulse(&Ticker::parse("AAPL").unwrap(), &accounts, 168, 10)
+            .await
+            .unwrap(); // cashtag-operator contingency check: a 400 here means switch build_query to bare keyword
+        for p in &posts {
+            assert!(!p.id.is_empty());
+            assert!(!p.text.as_str().is_empty());
+        }
+    }
+}
+```
+
+Register: add `pub mod x;` to the module list in `src/adapters/sources/mod.rs` (alphabetical: after `reddit`).
+
+- [ ] **Step 3: `x_bearer` credential in `src/config/secrets.rs`**
+
+Add to the struct (after `bluesky_app_password`):
+
+```rust
+    /// X API bearer token (paid pay-per-use API — pulse only, never analyze).
+    pub x_bearer: Option<SecretString>,
+```
+
+In `from_env()`: `x_bearer: secret_from(std::env::var("OPENINTEL_X_BEARER").ok()),`
+In `load()`: `c.x_bearer = c.x_bearer.or_else(|| store_get(store, "OPENINTEL_X_BEARER"));`
+Update every `Credentials { … }` literal in tests (this file's `debug_does_not_leak_secret`, `src/adapters/sources/mod.rs`'s `creds` helper): add `x_bearer: None,`.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `cargo build --all-targets && cargo test && cargo clippy -- -D warnings && cargo fmt`
+Expected: green (7 new tests + 1 ignored).
+
+```bash
+git add src/adapters/sources/x/ src/adapters/sources/mod.rs src/config/secrets.rs
+git commit -m "feat(x): XPulseSource — bearer-auth author-filtered search + x_bearer credential
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: CLI — `openintel pulse`
+
+**Files:**
+- Create: `src/cli/pulse.rs`
+- Modify: `src/cli/args.rs`, `src/cli/mod.rs`, `src/main.rs`
+
+**Interfaces:**
+- Consumes: Task 1's `application::pulse` + `PulseReport`; Task 2's `XPulseSource`; existing `Credentials`, `FormatArg`, `DISCLAIMER`.
+- Produces: `Command::Pulse(PulseArgs)`; `pub async fn run(args: &PulseArgs, credentials: &Credentials) -> Result<String, DomainError>` in `cli::pulse`; `pub fn not_configured_text() -> String`.
+
+- [ ] **Step 1: `src/cli/args.rs`** — add after the `Setup` variant:
+
+```rust
+    /// Catalyst posts from specific high-impact X accounts (paid X API — opt-in)
+    Pulse(PulseArgs),
+```
+
+and below `SetupArgs`:
+
+```rust
+#[derive(clap::Args, Debug)]
+pub struct PulseArgs {
+    /// Ticker symbol, e.g. NVDA
+    pub ticker: String,
+
+    /// X handles to listen to, comma-separated (no @). Default: the macro list.
+    #[arg(long, value_delimiter = ',')]
+    pub accounts: Vec<String>,
+
+    /// Lookback window in hours (1-168)
+    #[arg(long, default_value_t = 24)]
+    pub hours: u32,
+
+    /// Max posts to read — each read costs ~$0.005 (1-100)
+    #[arg(long, default_value_t = 20)]
+    pub limit: usize,
+
+    #[arg(long, value_enum, default_value_t = FormatArg::Table)]
+    pub format: FormatArg,
+}
+```
+
+Tests (existing `mod tests`):
+
+```rust
+    #[test]
+    fn parses_pulse_with_accounts() {
+        let cli = Cli::try_parse_from([
+            "openintel", "pulse", "NVDA", "--accounts", "jensenhuang,elonmusk", "--hours", "48",
+        ])
+        .unwrap();
+        let Command::Pulse(args) = cli.command else {
+            panic!("expected pulse command");
+        };
+        assert_eq!(args.ticker, "NVDA");
+        assert_eq!(args.accounts, vec!["jensenhuang", "elonmusk"]);
+        assert_eq!(args.hours, 48);
+        assert_eq!(args.limit, 20);
+    }
+
+    #[test]
+    fn pulse_defaults_have_empty_accounts() {
+        let cli = Cli::try_parse_from(["openintel", "pulse", "GME"]).unwrap();
+        let Command::Pulse(args) = cli.command else {
+            panic!("expected pulse command");
+        };
+        assert!(args.accounts.is_empty());
+        assert_eq!(args.hours, 24);
+    }
+```
+
+- [ ] **Step 2: `src/cli/pulse.rs`**
+
+```rust
+//! CLI leaf for `openintel pulse` — orchestrates the pulse and renders it.
+//! Returns strings; `main.rs` prints (stdout discipline).
+
+use chrono::{DateTime, Utc};
+
+use crate::adapters::sources::x::XPulseSource;
+use crate::application::pulse::X_COST_PER_READ_USD;
+use crate::application::DISCLAIMER;
+use crate::cli::args::{FormatArg, PulseArgs};
+use crate::config::secrets::Credentials;
+use crate::domain::entities::pulse::PulseReport;
+use crate::domain::error::DomainError;
+
+pub fn not_configured_text() -> String {
+    "x is not configured — the pulse needs an X API bearer token (paid API).\n\
+     Run:  openintel setup x"
+        .to_string()
+}
+
+pub async fn run(args: &PulseArgs, credentials: &Credentials) -> Result<String, DomainError> {
+    let bearer = credentials
+        .x_bearer
+        .clone()
+        .ok_or_else(|| DomainError::SourceFailure {
+            name: "x".into(),
+            message: "not configured".into(),
+        })?;
+    let feed = XPulseSource::new(bearer)?;
+    let report = crate::application::pulse::pulse(
+        &args.ticker,
+        &args.accounts,
+        args.hours,
+        args.limit,
+        &feed,
+        Utc::now(),
+    )
+    .await?;
+    Ok(match args.format {
+        FormatArg::Table => render_table(&report, Utc::now()),
+        FormatArg::Json => render_json(&report)?,
+    })
+}
+
+fn render_json(report: &PulseReport) -> Result<String, DomainError> {
+    #[derive(serde::Serialize)]
+    struct Out<'a> {
+        report: &'a PulseReport,
+        disclaimer: &'static str,
+    }
+    serde_json::to_string_pretty(&Out {
+        report,
+        disclaimer: DISCLAIMER,
+    })
+    .map_err(|e| DomainError::SourceFailure {
+        name: "x".into(),
+        message: format!("render failed: {e}"),
+    })
+}
+
+/// "3h ago" / "45m ago" / "2d ago"
+fn age(now: DateTime<Utc>, created_at: DateTime<Utc>) -> String {
+    let mins = (now - created_at).num_minutes().max(0);
+    if mins < 60 {
+        format!("{mins}m ago")
+    } else if mins < 48 * 60 {
+        format!("{}h ago", mins / 60)
+    } else {
+        format!("{}d ago", mins / (24 * 60))
+    }
+}
+
+fn render_table(report: &PulseReport, now: DateTime<Utc>) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "=== OpenIntel X Pulse — {} ===", report.ticker);
+    let _ = writeln!(
+        out,
+        "window: last {}h · accounts: {}",
+        report.hours_back,
+        report.accounts.join(", ")
+    );
+    let _ = writeln!(
+        out,
+        "generated: {}\n",
+        report.generated_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    );
+
+    if report.posts.is_empty() {
+        let _ = writeln!(out, "⚡ no posts from these accounts in the window");
+    } else {
+        let _ = writeln!(out, "⚡ {} post(s)\n", report.posts.len());
+        for p in &report.posts {
+            let _ = writeln!(
+                out,
+                "  [{}] @{} (eng {})",
+                age(now, p.created_at),
+                p.author,
+                p.engagement
+            );
+            let _ = writeln!(out, "    {}\n", p.text.as_str());
+        }
+    }
+
+    let _ = writeln!(
+        out,
+        "cost: {} posts read (≈ ${:.2} at ${}/read; X dedupes re-reads for 24h)",
+        report.posts_read, report.estimated_cost_usd, X_COST_PER_READ_USD
+    );
+    let _ = writeln!(out, "\n{DISCLAIMER}");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::entities::pulse::PulsePost;
+    use crate::domain::entities::social_post::PostText;
+    use chrono::TimeZone;
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap()
+    }
+
+    fn report(posts: Vec<PulsePost>) -> PulseReport {
+        let posts_read = posts.len() as u32;
+        PulseReport {
+            ticker: "NVDA".into(),
+            accounts: vec!["jensenhuang".into(), "elonmusk".into()],
+            hours_back: 24,
+            posts,
+            posts_read,
+            estimated_cost_usd: f64::from(posts_read) * X_COST_PER_READ_USD,
+            generated_at: at(),
+        }
+    }
+
+    fn post(hours_old: i64) -> PulsePost {
+        PulsePost {
+            id: "1".into(),
+            author: "jensenhuang".into(),
+            text: PostText::parse("Blackwell Ultra shipping at scale").unwrap(),
+            created_at: at() - chrono::Duration::hours(hours_old),
+            engagement: 48210,
+        }
+    }
+
+    #[test]
+    fn table_renders_posts_cost_and_disclaimer() {
+        let rendered = render_table(&report(vec![post(3)]), at());
+        assert!(rendered.contains("=== OpenIntel X Pulse — NVDA ==="));
+        assert!(rendered.contains("window: last 24h · accounts: jensenhuang, elonmusk"));
+        assert!(rendered.contains("[3h ago] @jensenhuang (eng 48210)"));
+        assert!(rendered.contains("Blackwell Ultra shipping at scale"));
+        assert!(rendered.contains("cost: 1 posts read (≈ $0.01 at $0.005/read"));
+        assert!(rendered.contains("Not financial advice"));
+    }
+
+    #[test]
+    fn table_zero_posts_is_quiet_not_error() {
+        let rendered = render_table(&report(vec![]), at());
+        assert!(rendered.contains("no posts from these accounts in the window"));
+        assert!(rendered.contains("cost: 0 posts read"));
+    }
+
+    #[test]
+    fn age_buckets() {
+        assert_eq!(age(at(), at() - chrono::Duration::minutes(45)), "45m ago");
+        assert_eq!(age(at(), at() - chrono::Duration::hours(3)), "3h ago");
+        assert_eq!(age(at(), at() - chrono::Duration::days(3)), "3d ago");
+        assert_eq!(age(at(), at() + chrono::Duration::minutes(5)), "0m ago"); // clock skew clamps
+    }
+
+    #[test]
+    fn json_contains_report_and_disclaimer() {
+        let json = render_json(&report(vec![post(1)])).unwrap();
+        assert!(json.contains("\"posts_read\": 1"));
+        assert!(json.contains("\"estimated_cost_usd\""));
+        assert!(json.contains("Not financial advice"));
+    }
+}
+```
+
+Register: `pub mod pulse;` in `src/cli/mod.rs`.
+
+- [ ] **Step 3: `src/main.rs` dispatch arm** (after the Setup arm):
+
+```rust
+        Command::Pulse(args) => match openintel::cli::pulse::run(&args, &credentials).await {
+            Ok(rendered) => {
+                println!("{rendered}");
+                ExitCode::SUCCESS
+            }
+            Err(e) if e.to_string().contains("not configured") => {
+                println!("{}", openintel::cli::pulse::not_configured_text());
+                ExitCode::FAILURE
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                ExitCode::FAILURE
+            }
+        },
+```
+
+- [ ] **Step 4: Verify, smoke-test, commit**
+
+Run: `cargo build --all-targets && cargo test && cargo clippy -- -D warnings && cargo fmt`
+Run: `env -u OPENINTEL_X_BEARER cargo run -q -- pulse NVDA; echo "exit=$?"` — expected: the not-configured hint (`openintel setup x`), `exit=1`. (Note: if a keychain `OPENINTEL_X_BEARER` exists on this machine the hint won't show; that's correct behavior — say so in the report rather than fighting it.)
+
+```bash
+git add src/cli/pulse.rs src/cli/args.rs src/cli/mod.rs src/main.rs
+git commit -m "feat(cli): openintel pulse — catalyst posts from curated X accounts
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: MCP — `x_pulse` tool
+
+**Files:**
+- Modify: `src/mcp/tools.rs`, `src/mcp/server.rs`
+
+**Interfaces:**
+- Consumes: Tasks 1–2 (`application::pulse`, `XPulseSource`, `InfluencerFeed`).
+- Produces: `tools::PulseToolArgs`, `tools::PulseOutput`, `pub async fn run_pulse(args, feed: &dyn InfluencerFeed) -> Result<PulseOutput, DomainError>`; server field `pulse_feed: Option<Arc<XPulseSource>>` + `x_pulse` tool.
+
+- [ ] **Step 1: `src/mcp/tools.rs`** — add (imports: `crate::application::pulse as pulse_app`, `crate::domain::entities::pulse::PulseReport`, `crate::domain::ports::influencer_feed::InfluencerFeed`, `chrono::Utc`):
+
+```rust
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PulseToolArgs {
+    /// Ticker symbol, e.g. "NVDA".
+    pub ticker: String,
+    /// X handles to listen to (no @). Curate per ticker: CEO/founder, major
+    /// holders or activist funds, sector journalists, macro figures. Omit only
+    /// if the user asked for the default macro list.
+    pub accounts: Option<Vec<String>>,
+    /// Lookback window in hours (default 24, max 168).
+    pub hours_back: Option<u32>,
+    /// Max posts to read — each read costs ~$0.005 (default 20, max 100).
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PulseOutput {
+    pub summary: String,
+    pub report: PulseReport,
+    pub disclaimer: &'static str,
+}
+
+pub async fn run_pulse(
+    args: PulseToolArgs,
+    feed: &dyn InfluencerFeed,
+) -> Result<PulseOutput, DomainError> {
+    let accounts = args.accounts.unwrap_or_default();
+    let report = pulse_app::pulse(
+        &args.ticker,
+        &accounts,
+        args.hours_back.unwrap_or(24),
+        args.limit.unwrap_or(20),
+        feed,
+        Utc::now(),
+    )
+    .await?;
+    let summary = format!(
+        "{} — ⚡ {} high-impact post(s) in last {}h from {} account(s) · {} posts read ≈ ${:.2}",
+        report.ticker,
+        report.posts.len(),
+        report.hours_back,
+        report.accounts.len(),
+        report.posts_read,
+        report.estimated_cost_usd
+    );
+    Ok(PulseOutput {
+        summary,
+        report,
+        disclaimer: DISCLAIMER,
+    })
+}
+```
+
+Test (in the tools test module — a fake feed, no network):
+
+```rust
+    #[tokio::test]
+    async fn run_pulse_summarizes_and_costs() {
+        use crate::domain::entities::pulse::PulsePost;
+        use crate::domain::entities::social_post::PostText;
+        use crate::domain::entities::ticker::Ticker;
+        use crate::domain::ports::influencer_feed::InfluencerFeed;
+        use async_trait::async_trait;
+
+        struct OnePost;
+        #[async_trait]
+        impl InfluencerFeed for OnePost {
+            async fn pulse(
+                &self,
+                _t: &Ticker,
+                _a: &[String],
+                _h: u32,
+                _l: usize,
+            ) -> Result<Vec<PulsePost>, DomainError> {
+                Ok(vec![PulsePost {
+                    id: "1".into(),
+                    author: "jensenhuang".into(),
+                    text: PostText::parse("shipping").unwrap(),
+                    created_at: chrono::Utc::now(),
+                    engagement: 5,
+                }])
+            }
+        }
+
+        let out = run_pulse(
+            PulseToolArgs {
+                ticker: "NVDA".into(),
+                accounts: Some(vec!["@jensenhuang".into()]),
+                hours_back: None,
+                limit: None,
+            },
+            &OnePost,
+        )
+        .await
+        .unwrap();
+        assert!(out.summary.contains("⚡ 1 high-impact post(s)"));
+        assert_eq!(out.report.accounts, vec!["jensenhuang"]); // @-stripped
+        assert!(out.disclaimer.contains("Not financial advice"));
+    }
+```
+
+- [ ] **Step 2: `src/mcp/server.rs`** — field, constructor, wiring, tool:
+
+Struct gains `pulse_feed: Option<Arc<crate::adapters::sources::x::XPulseSource>>`; `new()` gains the parameter:
+
+```rust
+    pub fn new(
+        social: Vec<Box<dyn SocialDataSource>>,
+        market: YahooMarketSource,
+        pulse_feed: Option<crate::adapters::sources::x::XPulseSource>,
+    ) -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            social: Arc::new(social),
+            market,
+            pulse_feed: pulse_feed.map(Arc::new),
+        }
+    }
+```
+
+In `serve()`:
+
+```rust
+    let pulse_feed = match credentials.x_bearer.clone() {
+        Some(bearer) => match crate::adapters::sources::x::XPulseSource::new(bearer) {
+            Ok(src) => Some(src),
+            Err(e) => {
+                eprintln!("warning: x pulse disabled: {e}");
+                None
+            }
+        },
+        None => None,
+    };
+    let service = OpenIntelServer::new(social, market, pulse_feed)
+        .serve(stdio())
+        .await?;
+```
+
+New tool in the `#[tool_router]` block (description is the spec's curation contract, verbatim):
+
+```rust
+    #[tool(
+        description = "Fetch recent posts about a ticker from specific high-impact X accounts \
+                       (paid API: ~$0.005 per post read). Before calling: research which accounts \
+                       actually matter for this ticker — CEO/founder, major institutional holders \
+                       or activist funds, respected sector journalists, and market-moving macro \
+                       figures — then propose the account list and estimated max cost \
+                       (limit × $0.005) to the user and get their confirmation. Omit `accounts` \
+                       only if the user asks for the default macro list. Returned posts are \
+                       catalyst events — reason about them directly; do not treat them as a \
+                       sentiment sample. Read-only — does not trade."
+    )]
+    async fn x_pulse(
+        &self,
+        Parameters(args): Parameters<tools::PulseToolArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let Some(feed) = self.pulse_feed.as_deref() else {
+            return Err(ErrorData::invalid_request(
+                "x is not configured — set OPENINTEL_X_BEARER or run `openintel setup x`".to_string(),
+                None,
+            ));
+        };
+        let out = tools::run_pulse(args, feed)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let json = serde_json::to_string_pretty(&out)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    }
+```
+
+(If `ErrorData::invalid_request`'s signature differs in rmcp 2, use the closest constructor that produces a client-visible invalid-request error — adapt call only, message verbatim.)
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `cargo build --all-targets && cargo test && cargo clippy -- -D warnings && cargo fmt`
+Expected: green.
+
+```bash
+git add src/mcp/tools.rs src/mcp/server.rs
+git commit -m "feat(mcp): x_pulse tool — agent-curated catalyst feed with cost contract
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `openintel setup x` — first single-credential source
+
+**Files:**
+- Modify: `src/cli/setup.rs`, `src/cli/args.rs`
+
+**Interfaces:**
+- Consumes: Task 2's `XPulseSource` + `x_bearer`; Task 1's `DEFAULT_PULSE_ACCOUNTS`; existing setup plumbing (`SourceSpec`, `run_interactive`, `Outcome`, store).
+- Produces: `SetupSource::X`; `SourceSpec.second_key/second_prompt: Option<&'static str>`; single-credential interactive path with a cost-confirm before the probe.
+
+- [ ] **Step 1: `src/cli/args.rs`** — `SetupSource` gains `X`; parse test:
+
+```rust
+    #[test]
+    fn parses_setup_x() {
+        let cli = Cli::try_parse_from(["openintel", "setup", "x"]).unwrap();
+        let Command::Setup(args) = cli.command else {
+            panic!("expected setup command");
+        };
+        assert_eq!(args.source, SetupSource::X);
+    }
+```
+
+- [ ] **Step 2: `src/cli/setup.rs`** — generalize `SourceSpec`:
+
+Change `second_key: &'static str` → `second_key: Option<&'static str>` and `second_prompt: &'static str` → `second_prompt: Option<&'static str>`. Reddit/Bluesky specs wrap theirs in `Some(…)`. Every existing use of `spec.second_key`/`spec.second_prompt` in the PAIR path unwraps via the pair branch (see Step 3). `forget_outcome` iterates `[Some(spec.first_key), spec.second_key].into_iter().flatten()`.
+
+Add the X spec:
+
+```rust
+const X_UNAUTHORIZED_HINT: &str =
+    "Your bearer token looks wrong or lacks access. In the X developer console\n   \
+     (https://developer.x.com → Projects & Apps → your app → Keys and Tokens),\n   \
+     regenerate the Bearer Token, and make sure API credits are loaded.";
+
+const X_SPEC: SourceSpec = SourceSpec {
+    label: "X",
+    first_key: "OPENINTEL_X_BEARER",
+    second_key: None,
+    first_prompt: "Bearer token",
+    second_prompt: None,
+    condensed_guide: "\
+X Pulse needs an X API bearer token — the API is PAID (pay-per-use,
+about $0.005 per post read; you buy credits up front). ~3 minutes:
+
+  1. Sign in at https://developer.x.com and open the developer console.
+  2. Projects & Apps → your app (create one if needed) → Keys and Tokens.
+  3. Under \"Bearer Token\", generate/reveal it and copy it.
+  4. Make sure your account has API credits loaded (Billing → Credits).
+  5. Enter the token below — verification reads up to 10 posts (≈ $0.05).
+",
+    unauthorized_hint: X_UNAUTHORIZED_HINT,
+    try_cmd: "openintel pulse NVDA --accounts jensenhuang",
+    pre_probe_confirm: Some("Verifying will read up to 10 posts from X (≈ $0.05). Proceed? [Y/n]: "),
+};
+```
+
+(`pre_probe_confirm: Option<&'static str>` is the new `SourceSpec` field introduced in Step 4 — add it to the struct together with the `second_*` Option changes in this step, with `pre_probe_confirm: None` on `REDDIT_SPEC` and `BLUESKY_SPEC`.)
+
+- [ ] **Step 3: single-credential branch in `run_interactive`**
+
+In the prompt section, branch on `spec.second_key`:
+
+- **Pair sources (Some)** — exactly today's behavior: visible first prompt, hidden second prompt (this is the current code path, unchanged).
+- **Single-credential (None)** — the one value IS the secret:
+
+```rust
+        let (first, secret) = if let Some(second_prompt) = spec.second_prompt {
+            let Ok(first) = prompt_nonempty_visible(io, spec.first_prompt) else {
+                return InteractiveOutcome::Done(Outcome::Failure);
+            };
+            let Ok(secret) = prompt_nonempty_secret(io, second_prompt) else {
+                return InteractiveOutcome::Done(Outcome::Failure);
+            };
+            (first, secret)
+        } else {
+            // Single-credential source: read the one (secret) value hidden.
+            let Ok(secret) = prompt_nonempty_secret(io, spec.first_prompt) else {
+                return InteractiveOutcome::Done(Outcome::Failure);
+            };
+            (String::new(), secret)
+        };
+```
+
+Saving: for single-credential sources save ONLY `first_key` with the secret:
+
+```rust
+                let saved = if spec.second_key.is_some() {
+                    let first_secret = SecretString::new(first.into_boxed_str());
+                    store
+                        .set(spec.first_key, &first_secret)
+                        .and_then(|()| store.set(spec.second_key.expect("pair source"), &secret))
+                } else {
+                    store.set(spec.first_key, &secret)
+                };
+```
+
+(Adjust the save-failure fallback export lines to print only the keys that exist: `[Some(spec.first_key), spec.second_key].into_iter().flatten()`.)
+
+- [ ] **Step 4: cost-confirm + probe + non-TTY for X**
+
+Add a `pre_probe_confirm: Option<&'static str>` field to `SourceSpec` (`None` for Reddit/Bluesky; for X:
+`Some("Verifying will read up to 10 posts from X (≈ $0.05). Proceed? [Y/n]: ")`).
+In `run_interactive`, after collecting credentials and before `println!("Checking…")`:
+
+```rust
+        if let Some(confirm) = spec.pre_probe_confirm {
+            match read_visible(io, confirm) {
+                Ok(ans) if matches!(ans.trim().to_lowercase().as_str(), "" | "y" | "yes") => {}
+                Ok(_) => {
+                    println!("Aborted — nothing was saved.");
+                    return InteractiveOutcome::Done(Outcome::Failure);
+                }
+                Err(_) => return InteractiveOutcome::Done(Outcome::Failure),
+            }
+        }
+```
+
+Probe + dispatch in `run()`:
+
+```rust
+        SetupSource::X => {
+            run_interactive(&mut io, store, &X_SPEC, already, |_first, secret| {
+                probe_x(secret)
+            })
+            .await
+        }
+```
+
+with `already = credentials.x_bearer.is_some().then(|| provenance("OPENINTEL_X_BEARER"))` and:
+
+```rust
+/// One paid round trip: search the default macro accounts for AAPL (max 10 reads ≈ $0.05).
+async fn probe_x(bearer: SecretString) -> Result<usize, DomainError> {
+    let feed = XPulseSource::new(bearer)?;
+    let ticker = Ticker::parse("AAPL")?;
+    let accounts: Vec<String> = crate::application::pulse::DEFAULT_PULSE_ACCOUNTS
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let posts = feed.pulse(&ticker, &accounts, 24, 10).await?;
+    Ok(posts.len())
+}
+```
+
+Import `use crate::adapters::sources::x::XPulseSource;` and `use crate::domain::ports::influencer_feed::InfluencerFeed;`.
+
+Non-TTY: add `setup_x(credentials)` with two modes only (single credential):
+
+```rust
+async fn setup_x(credentials: &Credentials) -> ExitCode {
+    match credentials.x_bearer.clone() {
+        None => {
+            println!("{}", X_SPEC.condensed_guide);
+            println!(
+                "Set OPENINTEL_X_BEARER (or run `openintel setup x` in a terminal), then re-run."
+            );
+            ExitCode::FAILURE
+        }
+        Some(bearer) => {
+            println!("Checking your X credentials… (reads up to 10 posts ≈ $0.05)");
+            match probe_x(bearer).await {
+                Ok(count) => {
+                    println!("{}", verify_ok_text("X", count, X_SPEC.try_cmd));
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    println!("{}", verify_err_text(&e, X_UNAUTHORIZED_HINT));
+                    ExitCode::FAILURE
+                }
+            }
+        }
+    }
+}
+```
+
+and route it in `run()`'s non-TTY match. `verify_ok_text("X", 0, …)`'s "no recent posts" copy already fits a quiet pulse.
+
+- [ ] **Step 5: Tests** (extend the setup test module):
+
+```rust
+    #[test]
+    fn x_guide_contains_cost_and_console_steps() {
+        assert!(X_SPEC.condensed_guide.contains("developer.x.com"));
+        assert!(X_SPEC.condensed_guide.contains("$0.005"));
+        assert!(X_SPEC.condensed_guide.contains("Bearer Token"));
+        assert!(X_SPEC.second_key.is_none());
+    }
+
+    #[tokio::test]
+    async fn single_cred_happy_path_saves_one_key() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("\n"); // cost-confirm: blank = Yes
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &X_SPEC, None, |_f, _s| {
+            std::future::ready(Ok(2usize))
+        })
+        .await;
+        assert!(matches!(outcome, InteractiveOutcome::Done(Outcome::Success)));
+        let map = store.map.borrow();
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get("OPENINTEL_X_BEARER").unwrap().expose_secret(), "s3cret");
+    }
+
+    #[tokio::test]
+    async fn single_cred_cost_confirm_decline_saves_nothing() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("n\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &X_SPEC, None, |_f, _s| {
+            std::future::ready(Ok(2usize))
+        })
+        .await;
+        assert!(matches!(outcome, InteractiveOutcome::Done(Outcome::Failure)));
+        assert!(store.map.borrow().is_empty());
+    }
+
+    #[test]
+    fn forget_x_removes_single_key() {
+        let store = InMemoryStore::new().seed("OPENINTEL_X_BEARER", "tok");
+        assert_eq!(forget_outcome(&X_SPEC, &store), Outcome::Success);
+        assert!(store.map.borrow().is_empty());
+    }
+```
+
+Existing reddit/bluesky tests: update `SourceSpec` literals only where the plan changed field types (`Some(…)` wraps, `pre_probe_confirm: None`) — assertions unchanged (non-TTY byte-identity).
+
+- [ ] **Step 6: Verify, smoke, commit**
+
+Run: `cargo build --all-targets && cargo test && cargo clippy -- -D warnings && cargo fmt`
+Run: `echo "" | env -u OPENINTEL_X_BEARER cargo run -q -- setup x; echo "exit=$?"` — expected: X guide + env hint, `exit=1` (same keychain caveat as Task 3).
+
+```bash
+git add src/cli/setup.rs src/cli/args.rs
+git commit -m "feat(cli): openintel setup x — single-credential flow with cost-confirmed verify
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Docs
+
+**Files:**
+- Modify: `README.md`, `.env.example`
+
+- [ ] **Step 1: README** — after the "Enable the Bluesky source" section add:
+
+```markdown
+## X Pulse (optional — paid X API)
+
+Catalyst posts from specific high-impact X accounts (a POTUS tariff post, a CEO
+announcement) — surfaced as **events to reason about**, never averaged into
+sentiment. X's API is pay-per-use (~$0.005 per post read, deduped over 24h), so
+the pulse is strictly opt-in: nothing calls X unless you run it.
+
+```bash
+openintel setup x                                      # guided token setup (verify reads ≈ $0.05)
+openintel pulse NVDA --accounts jensenhuang,elonmusk   # ≤ 20 reads ≈ $0.10 max
+```
+
+No `--accounts` → a small macro default list (POTUS, White House, Musk, the Fed).
+Via MCP, the `x_pulse` tool asks the agent to research which accounts matter for
+your ticker and confirm the cost with you before spending.
+```
+
+Also: the flags table gains nothing (pulse has its own subcommand); the Quickstart's "Enable real sentiment" line gains "— and see *X Pulse* below for paid catalyst tracking."
+
+- [ ] **Step 2: `.env.example`** — after the Bluesky block:
+
+```bash
+# --- X Pulse (paid API — optional) ---
+# Bearer token from https://developer.x.com (Projects & Apps → Keys and Tokens).
+# Pay-per-use: ~$0.005 per post read; openintel only calls X on an explicit
+# `openintel pulse` / MCP x_pulse invocation. Prefer `openintel setup x`.
+OPENINTEL_X_BEARER=
+```
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `cargo test 2>&1 | tail -3`; `grep -n "pulse\|X_BEARER" README.md .env.example | head`
+
+```bash
+git add README.md .env.example
+git commit -m "docs: X Pulse section — paid catalyst feed, cost math, opt-in posture
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-07-16-x-pulse-design.md
+++ b/docs/superpowers/specs/2026-07-16-x-pulse-design.md
@@ -1,0 +1,244 @@
+# X Pulse — Influencer Event Feed (Credit-Aware, Opt-In) — Design
+
+**Date:** 2026-07-16
+**Status:** Draft — awaiting user review
+
+## Goal
+
+Surface posts from **specific high-impact X accounts** about a ticker — market-moving
+events (a POTUS tariff post, a CEO announcement, an activist thread), not another
+sentiment average. X's pay-per-use API ($0.005/post read, verified 2026-07 from
+docs.x.com) makes commodity mention-scanning bad value (Bluesky covers that free);
+the differentiated, cheap, high-signal query is **author-filtered search** —
+typically 0–5 posts, costing pennies, each one a catalyst candidate.
+
+**Explicitly a new surface, not a fifth sentiment source**: pulse posts are events
+for the consuming agent (or human) to reason about. They never enter the fusion
+engine's averaging. `SourceKind::X` does **not** return.
+
+## Product shape
+
+### CLI
+
+```text
+openintel pulse NVDA --accounts jensenhuang,elonmusk --hours 24 --limit 20
+```
+
+- `--accounts a,b,c` — X handles to listen to (no `@`). Omitted → the shipped
+  default macro list.
+- `--hours N` — lookback window, default 24, clamped 1..=168.
+- `--limit N` — max posts, default 20, clamped 1..=100.
+- `--format table|json` — like `analyze`.
+
+Table output:
+
+```text
+=== OpenIntel X Pulse — NVDA ===
+window: last 24h · accounts: jensenhuang, elonmusk, realDonaldTrump, WhiteHouse
+generated: 2026-07-16T22:40:00Z
+
+⚡ 2 post(s)
+
+  [3h ago] @jensenhuang (eng 48210)
+    Blackwell Ultra is now shipping at scale. The next decade of computing…
+
+  [11h ago] @realDonaldTrump (eng 191034)
+    Chips made in America will be TAXED at ZERO. Foreign chips, big tariffs!
+
+cost: 2 posts read (≈ $0.01 at $0.005/read; X dedupes re-reads for 24h)
+
+Not financial advice. …existing disclaimer…
+```
+
+Zero posts is a **successful quiet result** (exit 0, "no posts from these accounts
+in the window"). Unconfigured X → clear error + `run: openintel setup x`, exit 1.
+
+### MCP tool: `x_pulse`
+
+Input `{ ticker, accounts?: string[], hours_back?: u32 (default 24), limit?: usize (default 20) }`
+→ the `PulseReport` as JSON plus the disclaimer.
+
+**The curation contract lives in the tool description** (this is the guided UX —
+the agent does the research, the human approves the spend):
+
+> Fetch recent posts about `ticker` from specific high-impact X accounts (paid
+> API: ~$0.005 per post read). Before calling: research which accounts actually
+> matter for this ticker — CEO/founder, major institutional holders or activist
+> funds, respected sector journalists, and market-moving macro figures — then
+> propose the account list and estimated max cost (`limit × $0.005`) to the user
+> and get their confirmation. Omit `accounts` only if the user asks for the
+> default macro list. Returned posts are catalyst events — reason about them
+> directly; do not treat them as a sentiment sample.
+
+### Default macro accounts
+
+```rust
+pub const DEFAULT_PULSE_ACCOUNTS: [&str; 4] =
+    ["realDonaldTrump", "WhiteHouse", "elonmusk", "federalreserve"];
+```
+
+Small and defensible: heads of state/government move indices and sectors; Musk
+moves specific tickers; the Fed moves everything. Per-call override is the primary
+path — this list is only the no-arguments fallback.
+
+## Architecture (hexagonal, mirrors existing patterns)
+
+### Domain
+
+- `domain/entities/pulse.rs` (new):
+  - `PulsePost { id: String, author: String, text: PostText, created_at: DateTime<Utc>, engagement: u32 }`
+    (reuses `PostText`; deliberately NOT `SocialPost` — no `SourceKind`).
+  - `PulseReport { ticker: String, accounts: Vec<String>, hours_back: u32, posts: Vec<PulsePost>, posts_read: u32, estimated_cost_usd: f64, generated_at: DateTime<Utc> }`
+    — all `Serialize`.
+- `domain/ports/influencer_feed.rs` (new):
+
+```rust
+#[async_trait]
+pub trait InfluencerFeed: Send + Sync {
+    async fn pulse(
+        &self,
+        ticker: &Ticker,
+        accounts: &[String],
+        hours_back: u32,
+        limit: usize,
+    ) -> Result<Vec<PulsePost>, DomainError>;
+}
+```
+
+### Application
+
+- `application/pulse.rs` (new): validate ticker (`Ticker::parse`), clamp
+  `hours_back` 1..=168 and `limit` 1..=100, normalize accounts (strip leading `@`,
+  drop empties; empty list after normalize → `DEFAULT_PULSE_ACCOUNTS`), call the
+  feed, assemble `PulseReport` (`posts_read = posts.len()`,
+  `estimated_cost_usd = posts_read as f64 * X_COST_PER_READ_USD`). Clock injected
+  at the edge per house pattern.
+- `pub const X_COST_PER_READ_USD: f64 = 0.005;` — one constant, commented with
+  source + as-of date (docs.x.com pricing, 2026-02 pay-per-use launch).
+
+### Adapter — `adapters/sources/x/` (mod.rs + response.rs)
+
+- `XPulseSource::new(bearer: SecretString) -> Result<Self, DomainError>` — reqwest
+  client, 10 s timeout, `rust:openintel:v{version}` UA. Implements `InfluencerFeed`.
+- Request: `GET https://api.x.com/2/tweets/search/recent` with
+  `Authorization: Bearer` (`.expose_secret()` at that one site) and query params
+  via `Url::query_pairs_mut()` (reqwest 0.13.4 gating, as everywhere):
+  - `query` = `` $TICKER (from:a OR from:b …) -is:retweet `` — built by a pure,
+    unit-tested `build_query(ticker, accounts)`.
+    *Contingency (decided at live test with the user's token):* if pay-per-use
+    rejects the `$` cashtag operator (HTTP 400 naming the operator), switch to
+    the bare ticker keyword — one-line change in `build_query`, tests updated.
+  - `start_time` = now − hours_back, RFC 3339.
+  - `max_results` = `clamp(limit, 10, 100)` (API minimum is 10; parser truncates
+    to the requested `limit` so the report never over-shows).
+  - `tweet.fields=created_at,public_metrics`, `expansions=author_id`,
+    `user.fields=username`.
+- `response.rs` — pure `parse_posts(body, limit, fetched_at)`: join
+  `includes.users` by `author_id` for the handle (fallback `"[unknown]"`);
+  `created_at` RFC 3339 → fallback `fetched_at`; engagement =
+  like + retweet + reply counts (defaults 0, saturating, per Bluesky precedent);
+  skip empty text / missing id; `#[serde(default)]` throughout; malformed JSON →
+  `SourceFailure`.
+- Error mapping (`name: "x"`):
+  - 401 → `"unauthorized — check bearer token"`
+  - 403 → `"forbidden — check API access and credit balance"`
+  - 429 → `"rate limited (HTTP 429) — resets at {UTC time}"`, reset parsed from
+    the `x-rate-limit-reset` header (unix seconds) when present, else the plain
+    429 message. **Fail fast** — a pulse is one request; no wait/retry in v1.
+  - other non-2xx → `"search HTTP {status}"`. Response bodies never echoed.
+
+### Credentials & setup
+
+- `Credentials.x_bearer: Option<SecretString>` returns — env `OPENINTEL_X_BEARER`,
+  keychain key `OPENINTEL_X_BEARER`, resolved by `Credentials::load` like the rest.
+- `openintel setup x` — the interactive flow gets its first **single-credential**
+  source. `SourceSpec.second_*` fields become `Option`s (Reddit/Bluesky pass
+  `Some`, X passes `None`); `plan()`'s pair logic applies only to pair sources —
+  single-credential mode selection is just set/unset (Guide / Verify; Partial
+  cannot occur). Non-TTY behavior for reddit/bluesky is byte-identical.
+- **Verification costs money and says so first**: after the guide + hidden bearer
+  prompt, before probing:
+  `Verifying will read up to 10 posts from X (≈ $0.05). Proceed? [Y/n]` —
+  decline → nothing saved, exit 1. Probe = `pulse(AAPL, DEFAULT_PULSE_ACCOUNTS,
+  24h, limit 10)`. A 0-post result still verifies (auth + query succeeded).
+  Non-TTY with `OPENINTEL_X_BEARER` set verifies directly (cost documented in
+  README; CI users know what they're doing).
+
+### Composition & wiring
+
+- `main.rs`: `Command::Pulse(args)` arm — builds `XPulseSource` from resolved
+  creds (error + setup hint when absent), calls `application::pulse`, renders.
+- `mcp/server.rs` / `mcp/tools.rs`: server holds `Option<Arc<XPulseSource>>`
+  (None when unconfigured → tool returns the setup-hint error); `x_pulse` tool
+  as above. `analyze`/`scan`/`compare`/`list_sources` are untouched.
+- `list_sources` gains nothing in v1 — pulse is not a `SocialDataSource`
+  (revisit if the tool inventory grows).
+
+## Cost & rate-limit posture (the user-set requirements)
+
+- **Opt-in only**: nothing calls X except an explicit `pulse` invocation. No
+  default-run spend, ever.
+- **Cost transparency**: every report carries `posts_read` + `estimated_cost_usd`
+  and the table renders the cost line; the MCP description forces a pre-call
+  estimate + user confirmation; setup states its probe cost.
+- **Rate limits**: header-aware fail-fast with reset time surfaced.
+  `--wait-for-rate-limit` is deliberately deferred (a pulse is a single request;
+  waiting matters when multi-request features arrive).
+
+## Testing (hermetic)
+
+- `build_query`: single/multi accounts, `@`-stripping, cashtag + `-is:retweet`
+  presence, OR-chain shape.
+- Parser: happy path with `includes.users` join, missing author → `[unknown]`,
+  missing `created_at` → `fetched_at`, engagement summing/saturation, empty-text
+  skip, limit truncation below `max_results`, malformed JSON, empty `data`.
+- Application: clamps (hours 0→1, 200→168; limit 0→1, 500→100), `@`-normalize,
+  empty accounts → defaults, cost math (`3 posts → 0.015`).
+- Setup: single-credential mode selection, X guide copy invariants (developer
+  console URL, cost warning, "never stores"), cost-confirm decline saves nothing.
+- Args: `pulse` parsing (accounts comma-split, defaults), setup x parses.
+- One `#[ignore]`d live test (`x_live_pulse`) — run manually with the user's
+  bearer; also the cashtag-operator contingency check.
+- Render: table contains window, accounts, per-post lines, cost line, disclaimer.
+
+## Docs
+
+- README: new "X Pulse (optional, paid)" section — what it is (catalyst feed,
+  not sentiment), the cost math ($0.005/read; default limit 20 → ≤ 10¢/call;
+  24 h dedup), `setup x`, curation philosophy (the agent researches accounts,
+  you approve). Quickstart line mentions it after the free sources.
+- `.env.example`: `OPENINTEL_X_BEARER` returns with a "paid API — see README
+  cost notes" comment.
+- SECURITY.md: no changes needed (bearer is a `SecretString` through the
+  existing env/keychain machinery).
+
+## Non-goals (YAGNI)
+
+- No `SourceKind::X`, no fusion/`analyze` integration, no sentiment averaging of
+  pulse posts (the consuming agent reasons about events; a future fusion note is
+  a separate decision).
+- No mention-scan mode (commodity X scanning is bad value; additive later).
+- No `--wait-for-rate-limit`, no pagination, no streaming/webhooks, no scheduled
+  monitoring.
+- No account-list persistence (config files) — per-call + defaults only; the
+  agent is the curator.
+- No options/risk math (that's the next feature, `risk_frame`).
+
+## Files
+
+**Create**
+- `src/domain/entities/pulse.rs`, `src/domain/ports/influencer_feed.rs`
+- `src/application/pulse.rs`
+- `src/adapters/sources/x/{mod.rs,response.rs}`
+- `src/cli/pulse.rs` — the CLI leaf: table/json render + orchestration
+  (mirrors how `setup.rs` is a leaf; `cli/run.rs` stays analyze-only)
+- this spec
+
+**Modify**
+- `src/domain/{entities,ports}/mod.rs`-equivalents (module registrations)
+- `src/application/mod.rs`
+- `src/config/secrets.rs` (+`x_bearer`)
+- `src/cli/args.rs` (`Pulse(PulseArgs)`, `SetupSource::X`), `src/cli/setup.rs`
+  (single-credential flow)
+- `src/main.rs`, `src/mcp/server.rs`, `src/mcp/tools.rs`
+- `README.md`, `.env.example`

--- a/src/adapters/sources/mod.rs
+++ b/src/adapters/sources/mod.rs
@@ -1,5 +1,6 @@
 pub mod bluesky;
 pub mod reddit;
+pub mod x;
 
 #[cfg(test)]
 pub(crate) mod test_fixtures;
@@ -60,6 +61,7 @@ mod tests {
             },
             bluesky_app_password: if bluesky { s("pw") } else { None },
             market_api_key: None,
+            x_bearer: None,
         }
     }
 

--- a/src/adapters/sources/x/mod.rs
+++ b/src/adapters/sources/x/mod.rs
@@ -1,0 +1,170 @@
+mod response;
+
+use std::time::Duration as StdDuration;
+
+use async_trait::async_trait;
+use chrono::{Duration, SecondsFormat, TimeZone, Utc};
+use secrecy::{ExposeSecret, SecretString};
+
+use crate::domain::entities::pulse::PulsePost;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::influencer_feed::InfluencerFeed;
+
+const SEARCH_URL: &str = "https://api.x.com/2/tweets/search/recent";
+const TIMEOUT_SECS: u64 = 10;
+
+/// Build the author-filtered search query.
+/// Contingency (spec): if pay-per-use rejects the `$` cashtag operator
+/// (HTTP 400 naming the operator in the live test), drop the `$` prefix here.
+pub(crate) fn build_query(ticker: &Ticker, accounts: &[String]) -> String {
+    let from = accounts
+        .iter()
+        .map(|a| format!("from:{a}"))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    format!("${} ({from}) -is:retweet", ticker.as_str())
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "x".into(),
+        message: message.into(),
+    }
+}
+
+pub struct XPulseSource {
+    client: reqwest::Client,
+    bearer: SecretString,
+    user_agent: String,
+}
+
+impl XPulseSource {
+    pub fn new(bearer: SecretString) -> Result<Self, DomainError> {
+        let user_agent = format!("rust:openintel:v{}", env!("CARGO_PKG_VERSION"));
+        let client = reqwest::Client::builder()
+            .timeout(StdDuration::from_secs(TIMEOUT_SECS))
+            .user_agent(&user_agent)
+            .build()
+            .map_err(|e| fail(format!("client build failed: {e}")))?;
+        Ok(Self {
+            client,
+            bearer,
+            user_agent,
+        })
+    }
+}
+
+#[async_trait]
+impl InfluencerFeed for XPulseSource {
+    async fn pulse(
+        &self,
+        ticker: &Ticker,
+        accounts: &[String],
+        hours_back: u32,
+        limit: usize,
+    ) -> Result<Vec<PulsePost>, DomainError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let fetched_at = Utc::now();
+        let start_time = (fetched_at - Duration::hours(i64::from(hours_back)))
+            .to_rfc3339_opts(SecondsFormat::Secs, true);
+        let max_results = limit.clamp(10, 100).to_string(); // API minimum is 10
+
+        // `.query()` is behind reqwest's un-enabled `query` feature; build manually.
+        let mut url = reqwest::Url::parse(SEARCH_URL).map_err(|e| fail(format!("bad url: {e}")))?;
+        url.query_pairs_mut()
+            .append_pair("query", &build_query(ticker, accounts))
+            .append_pair("start_time", &start_time)
+            .append_pair("max_results", &max_results)
+            .append_pair("tweet.fields", "created_at,public_metrics")
+            .append_pair("expansions", "author_id")
+            .append_pair("user.fields", "username");
+
+        let resp = self
+            .client
+            .get(url)
+            .bearer_auth(self.bearer.expose_secret())
+            .header(reqwest::header::USER_AGENT, &self.user_agent)
+            .send()
+            .await
+            .map_err(|e| fail(format!("search request failed: {e}")))?;
+        let status = resp.status();
+        let reset_hint = resp
+            .headers()
+            .get("x-rate-limit-reset")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<i64>().ok())
+            .and_then(|secs| Utc.timestamp_opt(secs, 0).single());
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| fail(format!("search body failed (HTTP {status}): {e}")))?;
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(match reset_hint {
+                Some(t) => fail(format!(
+                    "rate limited (HTTP 429) — resets at {}",
+                    t.to_rfc3339_opts(SecondsFormat::Secs, true)
+                )),
+                None => fail("rate limited (HTTP 429)"),
+            });
+        }
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(fail("unauthorized — check bearer token"));
+        }
+        if status == reqwest::StatusCode::FORBIDDEN {
+            return Err(fail("forbidden — check API access and credit balance"));
+        }
+        if !status.is_success() {
+            return Err(fail(format!("search HTTP {status}")));
+        }
+        response::parse_posts(&body, limit, fetched_at)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secret(s: &str) -> SecretString {
+        SecretString::new(s.to_string().into_boxed_str())
+    }
+
+    #[test]
+    fn build_query_shapes_cashtag_from_chain_and_retweet_filter() {
+        let t = Ticker::parse("NVDA").unwrap();
+        let accounts = vec!["jensenhuang".to_string(), "elonmusk".to_string()];
+        assert_eq!(
+            build_query(&t, &accounts),
+            "$NVDA (from:jensenhuang OR from:elonmusk) -is:retweet"
+        );
+        let one = vec!["WhiteHouse".to_string()];
+        assert_eq!(build_query(&t, &one), "$NVDA (from:WhiteHouse) -is:retweet");
+    }
+
+    #[test]
+    fn new_builds() {
+        assert!(XPulseSource::new(secret("token")).is_ok());
+    }
+
+    #[tokio::test]
+    #[ignore = "hits live X (paid: ~10 post reads ≈ $0.05); needs OPENINTEL_X_BEARER; run with --ignored"]
+    async fn x_live_pulse() {
+        let bearer = std::env::var("OPENINTEL_X_BEARER").unwrap();
+        let src = XPulseSource::new(SecretString::new(bearer.into_boxed_str())).unwrap();
+        let accounts: Vec<String> = crate::application::pulse::DEFAULT_PULSE_ACCOUNTS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let posts = src
+            .pulse(&Ticker::parse("AAPL").unwrap(), &accounts, 168, 10)
+            .await
+            .unwrap(); // cashtag-operator contingency check: a 400 here means switch build_query to bare keyword
+        for p in &posts {
+            assert!(!p.id.is_empty());
+            assert!(!p.text.as_str().is_empty());
+        }
+    }
+}

--- a/src/adapters/sources/x/mod.rs
+++ b/src/adapters/sources/x/mod.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use chrono::{Duration, SecondsFormat, TimeZone, Utc};
 use secrecy::{ExposeSecret, SecretString};
 
-use crate::domain::entities::pulse::PulsePost;
+use crate::domain::entities::pulse::PulseFetch;
 use crate::domain::entities::ticker::Ticker;
 use crate::domain::error::DomainError;
 use crate::domain::ports::influencer_feed::InfluencerFeed;
@@ -63,9 +63,13 @@ impl InfluencerFeed for XPulseSource {
         accounts: &[String],
         hours_back: u32,
         limit: usize,
-    ) -> Result<Vec<PulsePost>, DomainError> {
+    ) -> Result<PulseFetch, DomainError> {
         if limit == 0 {
-            return Ok(Vec::new());
+            // No request made, nothing billed.
+            return Ok(PulseFetch {
+                posts: Vec::new(),
+                posts_returned: 0,
+            });
         }
         let fetched_at = Utc::now();
         let start_time = (fetched_at - Duration::hours(i64::from(hours_back)))
@@ -158,11 +162,11 @@ mod tests {
             .iter()
             .map(|s| s.to_string())
             .collect();
-        let posts = src
+        let fetch = src
             .pulse(&Ticker::parse("AAPL").unwrap(), &accounts, 168, 10)
             .await
             .unwrap(); // cashtag-operator contingency check: a 400 here means switch build_query to bare keyword
-        for p in &posts {
+        for p in &fetch.posts {
             assert!(!p.id.is_empty());
             assert!(!p.text.as_str().is_empty());
         }

--- a/src/adapters/sources/x/response.rs
+++ b/src/adapters/sources/x/response.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
-use crate::domain::entities::pulse::PulsePost;
+use crate::domain::entities::pulse::{PulseFetch, PulsePost};
 use crate::domain::entities::social_post::PostText;
 use crate::domain::error::DomainError;
 
@@ -68,12 +68,18 @@ pub(crate) fn parse_posts(
     body: &str,
     limit: usize,
     fetched_at: DateTime<Utc>,
-) -> Result<Vec<PulsePost>, DomainError> {
+) -> Result<PulseFetch, DomainError> {
     let resp: SearchResponse =
         serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
+    // What X actually returned (= what it bills), counted before client-side
+    // truncation/skips below.
+    let posts_returned = resp.data.len() as u32;
 
     if limit == 0 {
-        return Ok(Vec::new());
+        return Ok(PulseFetch {
+            posts: Vec::new(),
+            posts_returned,
+        });
     }
 
     // author_id -> username join table from `includes.users`.
@@ -121,7 +127,10 @@ pub(crate) fn parse_posts(
             break;
         }
     }
-    Ok(posts)
+    Ok(PulseFetch {
+        posts,
+        posts_returned,
+    })
 }
 
 #[cfg(test)]
@@ -148,17 +157,18 @@ mod tests {
 
     #[test]
     fn happy_joins_authors_and_sums_engagement() {
-        let posts = parse_posts(HAPPY, 50, at()).unwrap();
-        assert_eq!(posts.len(), 2);
-        assert_eq!(posts[0].author, "realDonaldTrump");
-        assert_eq!(posts[0].engagement, 150);
+        let fetch = parse_posts(HAPPY, 50, at()).unwrap();
+        assert_eq!(fetch.posts.len(), 2);
+        assert_eq!(fetch.posts_returned, 2);
+        assert_eq!(fetch.posts[0].author, "realDonaldTrump");
+        assert_eq!(fetch.posts[0].engagement, 150);
         assert_eq!(
-            posts[0].created_at,
+            fetch.posts[0].created_at,
             Utc.with_ymd_and_hms(2026, 7, 16, 9, 0, 0).unwrap()
         );
-        assert_eq!(posts[1].author, "jensenhuang");
-        assert_eq!(posts[1].engagement, 0); // no public_metrics
-        assert_eq!(posts[1].created_at, at()); // no created_at -> fetched_at
+        assert_eq!(fetch.posts[1].author, "jensenhuang");
+        assert_eq!(fetch.posts[1].engagement, 0); // no public_metrics
+        assert_eq!(fetch.posts[1].created_at, at()); // no created_at -> fetched_at
     }
 
     #[test]
@@ -168,21 +178,30 @@ mod tests {
             {"id":"2","text":"   "},
             {"text":"no id"}
         ]}"#;
-        let posts = parse_posts(body, 50, at()).unwrap();
-        assert_eq!(posts.len(), 1);
-        assert_eq!(posts[0].author, "[unknown]");
+        let fetch = parse_posts(body, 50, at()).unwrap();
+        assert_eq!(fetch.posts.len(), 1);
+        assert_eq!(fetch.posts_returned, 3); // billed for all 3 X returned, even the 2 we skipped
+        assert_eq!(fetch.posts[0].author, "[unknown]");
     }
 
     #[test]
     fn limit_truncates_and_zero_is_empty() {
-        assert_eq!(parse_posts(HAPPY, 1, at()).unwrap().len(), 1);
-        assert!(parse_posts(HAPPY, 0, at()).unwrap().is_empty());
+        let truncated = parse_posts(HAPPY, 1, at()).unwrap();
+        assert_eq!(truncated.posts.len(), 1);
+        assert_eq!(truncated.posts_returned, 2); // billed for both, kept only 1
+
+        let zero = parse_posts(HAPPY, 0, at()).unwrap();
+        assert!(zero.posts.is_empty());
+        assert_eq!(zero.posts_returned, 2); // envelope still counted before the limit==0 short-circuit
     }
 
     #[test]
     fn empty_data_and_malformed() {
-        assert!(parse_posts(r#"{"data":[]}"#, 50, at()).unwrap().is_empty());
-        assert!(parse_posts(r#"{}"#, 50, at()).unwrap().is_empty()); // data defaults
+        assert!(parse_posts(r#"{"data":[]}"#, 50, at())
+            .unwrap()
+            .posts
+            .is_empty());
+        assert!(parse_posts(r#"{}"#, 50, at()).unwrap().posts.is_empty()); // data defaults
         assert!(parse_posts("nope", 50, at()).is_err());
     }
 }

--- a/src/adapters/sources/x/response.rs
+++ b/src/adapters/sources/x/response.rs
@@ -1,0 +1,188 @@
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::domain::entities::pulse::PulsePost;
+use crate::domain::entities::social_post::PostText;
+use crate::domain::error::DomainError;
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    data: Vec<Tweet>,
+    #[serde(default)]
+    includes: Includes,
+}
+
+#[derive(Debug, Deserialize)]
+struct Tweet {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    author_id: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    public_metrics: Option<Metrics>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct Metrics {
+    #[serde(default)]
+    like_count: Option<i64>,
+    #[serde(default)]
+    retweet_count: Option<i64>,
+    #[serde(default)]
+    reply_count: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct Includes {
+    #[serde(default)]
+    users: Vec<User>,
+}
+
+#[derive(Debug, Deserialize)]
+struct User {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "x".into(),
+        message: message.into(),
+    }
+}
+
+fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+pub(crate) fn parse_posts(
+    body: &str,
+    limit: usize,
+    fetched_at: DateTime<Utc>,
+) -> Result<Vec<PulsePost>, DomainError> {
+    let resp: SearchResponse =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
+
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    // author_id -> username join table from `includes.users`.
+    let users: std::collections::HashMap<String, String> = resp
+        .includes
+        .users
+        .into_iter()
+        .filter_map(|u| Some((u.id?, u.username?)))
+        .collect();
+
+    let mut posts = Vec::new();
+    for tweet in resp.data {
+        let id = match tweet.id {
+            Some(i) if !i.is_empty() => i,
+            _ => continue,
+        };
+        let text = match PostText::parse(&tweet.text.unwrap_or_default()) {
+            Ok(t) => t,
+            Err(_) => continue, // empty text -> skip, not fatal
+        };
+        let author = tweet
+            .author_id
+            .and_then(|aid| users.get(&aid).cloned())
+            .unwrap_or_else(|| "[unknown]".to_string());
+        let created_at = tweet
+            .created_at
+            .as_deref()
+            .and_then(parse_rfc3339)
+            .unwrap_or(fetched_at);
+        let m = tweet.public_metrics.unwrap_or_default();
+        let engagement = [m.like_count, m.retweet_count, m.reply_count]
+            .iter()
+            .map(|c| c.unwrap_or(0).max(0) as u64)
+            .sum::<u64>()
+            .min(u32::MAX as u64) as u32;
+
+        posts.push(PulsePost {
+            id,
+            author,
+            text,
+            created_at,
+            engagement,
+        });
+        if posts.len() >= limit {
+            break;
+        }
+    }
+    Ok(posts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap()
+    }
+
+    const HAPPY: &str = r#"{
+        "data":[
+            {"id":"1","text":"Chips made in America will be TAXED at ZERO","author_id":"u1",
+             "created_at":"2026-07-16T09:00:00.000Z",
+             "public_metrics":{"like_count":100,"retweet_count":40,"reply_count":10}},
+            {"id":"2","text":"Blackwell Ultra shipping at scale","author_id":"u2"}
+        ],
+        "includes":{"users":[
+            {"id":"u1","username":"realDonaldTrump"},
+            {"id":"u2","username":"jensenhuang"}
+        ]}
+    }"#;
+
+    #[test]
+    fn happy_joins_authors_and_sums_engagement() {
+        let posts = parse_posts(HAPPY, 50, at()).unwrap();
+        assert_eq!(posts.len(), 2);
+        assert_eq!(posts[0].author, "realDonaldTrump");
+        assert_eq!(posts[0].engagement, 150);
+        assert_eq!(
+            posts[0].created_at,
+            Utc.with_ymd_and_hms(2026, 7, 16, 9, 0, 0).unwrap()
+        );
+        assert_eq!(posts[1].author, "jensenhuang");
+        assert_eq!(posts[1].engagement, 0); // no public_metrics
+        assert_eq!(posts[1].created_at, at()); // no created_at -> fetched_at
+    }
+
+    #[test]
+    fn unknown_author_and_skips() {
+        let body = r#"{"data":[
+            {"id":"1","text":"no author id"},
+            {"id":"2","text":"   "},
+            {"text":"no id"}
+        ]}"#;
+        let posts = parse_posts(body, 50, at()).unwrap();
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].author, "[unknown]");
+    }
+
+    #[test]
+    fn limit_truncates_and_zero_is_empty() {
+        assert_eq!(parse_posts(HAPPY, 1, at()).unwrap().len(), 1);
+        assert!(parse_posts(HAPPY, 0, at()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_data_and_malformed() {
+        assert!(parse_posts(r#"{"data":[]}"#, 50, at()).unwrap().is_empty());
+        assert!(parse_posts(r#"{}"#, 50, at()).unwrap().is_empty()); // data defaults
+        assert!(parse_posts("nope", 50, at()).is_err());
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,4 +1,5 @@
 pub mod analyze;
+pub mod pulse;
 pub mod request;
 
 pub use analyze::analyze;

--- a/src/application/pulse.rs
+++ b/src/application/pulse.rs
@@ -5,6 +5,11 @@ use crate::domain::entities::ticker::Ticker;
 use crate::domain::error::DomainError;
 use crate::domain::ports::influencer_feed::InfluencerFeed;
 
+/// X username charset: letters, digits, underscore, max 15 chars.
+fn is_valid_handle(a: &str) -> bool {
+    !a.is_empty() && a.len() <= 15 && a.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 /// X pay-per-use price per post read (docs.x.com pricing, 2026-02 launch).
 pub const X_COST_PER_READ_USD: f64 = 0.005;
 
@@ -20,21 +25,32 @@ pub const DEFAULT_PULSE_ACCOUNTS: [&str; 4] = [
 pub const MAX_HOURS_BACK: u32 = 168;
 pub const MAX_PULSE_LIMIT: usize = 100;
 
-/// Trim, strip a leading `@`, drop empties; empty result -> the default list.
-pub fn normalize_accounts(raw: &[String]) -> Vec<String> {
+/// Trim, strip a leading `@`, drop invalid handles (X username charset:
+/// letters, digits, underscore, max 15 chars); empty raw input -> the default
+/// list. If raw was non-empty but every handle was invalid, error rather than
+/// silently falling back to defaults — that would spend money on accounts the
+/// user didn't choose.
+pub fn normalize_accounts(raw: &[String]) -> Result<Vec<String>, DomainError> {
+    if raw.is_empty() {
+        return Ok(DEFAULT_PULSE_ACCOUNTS
+            .iter()
+            .map(|s| s.to_string())
+            .collect());
+    }
     let cleaned: Vec<String> = raw
         .iter()
         .map(|a| a.trim().trim_start_matches('@').to_string())
-        .filter(|a| !a.is_empty())
+        .filter(|a| is_valid_handle(a))
         .collect();
     if cleaned.is_empty() {
-        DEFAULT_PULSE_ACCOUNTS
-            .iter()
-            .map(|s| s.to_string())
-            .collect()
-    } else {
-        cleaned
+        return Err(DomainError::SourceFailure {
+            name: "x".into(),
+            message: format!(
+                "no valid X handles in {raw:?} (letters, digits, underscore, max 15 chars)"
+            ),
+        });
     }
+    Ok(cleaned)
 }
 
 pub async fn pulse(
@@ -46,11 +62,12 @@ pub async fn pulse(
     now: DateTime<Utc>,
 ) -> Result<PulseReport, DomainError> {
     let ticker = Ticker::parse(ticker_raw)?;
-    let accounts = normalize_accounts(accounts_raw);
+    let accounts = normalize_accounts(accounts_raw)?;
     let hours_back = hours_back.clamp(1, MAX_HOURS_BACK);
     let limit = limit.clamp(1, MAX_PULSE_LIMIT);
-    let posts = feed.pulse(&ticker, &accounts, hours_back, limit).await?;
-    let posts_read = posts.len() as u32;
+    let fetch = feed.pulse(&ticker, &accounts, hours_back, limit).await?;
+    let posts = fetch.posts;
+    let posts_read = fetch.posts_returned;
     Ok(PulseReport {
         ticker: ticker.as_str().to_string(),
         accounts,
@@ -65,7 +82,7 @@ pub async fn pulse(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::entities::pulse::PulsePost;
+    use crate::domain::entities::pulse::{PulseFetch, PulsePost};
     use crate::domain::entities::social_post::PostText;
     use async_trait::async_trait;
     use chrono::TimeZone;
@@ -74,10 +91,16 @@ mod tests {
         Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap()
     }
 
-    /// Records what it was called with; returns `n` canned posts.
+    /// (ticker, accounts, hours_back, limit) the fake was called with.
+    type SeenCall = (String, Vec<String>, u32, usize);
+
+    /// Records what it was called with; returns `n` canned posts and
+    /// `posts_returned` (defaults to `n` via `fake()`, overridable via
+    /// `fake_with_returned()` to simulate billing > kept posts).
     struct FakeFeed {
         n: usize,
-        seen: std::sync::Mutex<Option<(String, Vec<String>, u32, usize)>>,
+        posts_returned: u32,
+        seen: std::sync::Mutex<Option<SeenCall>>,
     }
 
     #[async_trait]
@@ -88,28 +111,36 @@ mod tests {
             accounts: &[String],
             hours_back: u32,
             limit: usize,
-        ) -> Result<Vec<PulsePost>, DomainError> {
+        ) -> Result<PulseFetch, DomainError> {
             *self.seen.lock().unwrap() = Some((
                 ticker.as_str().to_string(),
                 accounts.to_vec(),
                 hours_back,
                 limit,
             ));
-            Ok((0..self.n)
-                .map(|i| PulsePost {
-                    id: format!("p{i}"),
-                    author: "someone".into(),
-                    text: PostText::parse("hello market").unwrap(),
-                    created_at: at(),
-                    engagement: 1,
-                })
-                .collect())
+            Ok(PulseFetch {
+                posts: (0..self.n)
+                    .map(|i| PulsePost {
+                        id: format!("p{i}"),
+                        author: "someone".into(),
+                        text: PostText::parse("hello market").unwrap(),
+                        created_at: at(),
+                        engagement: 1,
+                    })
+                    .collect(),
+                posts_returned: self.posts_returned,
+            })
         }
     }
 
     fn fake(n: usize) -> FakeFeed {
+        fake_with_returned(n, n as u32)
+    }
+
+    fn fake_with_returned(n: usize, posts_returned: u32) -> FakeFeed {
         FakeFeed {
             n,
+            posts_returned,
             seen: std::sync::Mutex::new(None),
         }
     }
@@ -121,10 +152,37 @@ mod tests {
             "  elonmusk ".to_string(),
             "".to_string(),
         ];
-        assert_eq!(normalize_accounts(&raw), vec!["jensenhuang", "elonmusk"]);
-        let empty: Vec<String> = vec!["@".to_string(), "  ".to_string()];
-        assert_eq!(normalize_accounts(&empty), DEFAULT_PULSE_ACCOUNTS.to_vec());
-        assert_eq!(normalize_accounts(&[]), DEFAULT_PULSE_ACCOUNTS.to_vec());
+        assert_eq!(
+            normalize_accounts(&raw).unwrap(),
+            vec!["jensenhuang", "elonmusk"]
+        );
+        assert_eq!(
+            normalize_accounts(&[]).unwrap(),
+            DEFAULT_PULSE_ACCOUNTS.to_vec()
+        );
+    }
+
+    #[test]
+    fn normalize_mixed_valid_invalid_keeps_valid() {
+        let raw = vec![
+            "jensenhuang".to_string(),
+            "jensen huang".to_string(), // space -> invalid
+            "way_too_long_a_handle_over_15".to_string(), // > 15 chars -> invalid
+            "elon-musk".to_string(),    // hyphen -> invalid
+            "elonmusk".to_string(),
+        ];
+        assert_eq!(
+            normalize_accounts(&raw).unwrap(),
+            vec!["jensenhuang", "elonmusk"]
+        );
+    }
+
+    #[test]
+    fn normalize_all_invalid_nonempty_errors() {
+        let raw = vec!["@".to_string(), "  ".to_string(), "bad handle".to_string()];
+        let err = normalize_accounts(&raw).unwrap_err();
+        assert!(matches!(err, DomainError::SourceFailure { ref name, .. } if name == "x"));
+        assert!(err.to_string().contains("no valid X handles"));
     }
 
     #[tokio::test]
@@ -142,6 +200,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pulse_bills_what_x_returned_not_what_we_kept() {
+        // Client-side truncation/skips kept 2 posts, but X returned (and
+        // billed) 10 — e.g. the max_results floor of 10 with a low limit.
+        let feed = fake_with_returned(2, 10);
+        let report = pulse("AAPL", &[], 24, 2, &feed, at()).await.unwrap();
+        assert_eq!(report.posts.len(), 2);
+        assert_eq!(report.posts_read, 10);
+        assert!((report.estimated_cost_usd - 0.05).abs() < 1e-9);
+    }
+
+    #[tokio::test]
     async fn pulse_clamps_low_bounds_and_zero_posts_is_ok() {
         let feed = fake(0);
         let report = pulse("AAPL", &["a".into()], 0, 0, &feed, at())
@@ -152,6 +221,16 @@ mod tests {
         assert_eq!(limit, 1);
         assert_eq!(report.posts_read, 0);
         assert_eq!(report.estimated_cost_usd, 0.0);
+    }
+
+    #[tokio::test]
+    async fn pulse_rejects_all_invalid_handles_without_falling_back_to_defaults() {
+        let feed = fake(0);
+        let err = pulse("AAPL", &["bad handle".into()], 24, 20, &feed, at())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("no valid X handles"));
+        assert!(feed.seen.lock().unwrap().is_none()); // never reached the paid call
     }
 
     #[tokio::test]

--- a/src/application/pulse.rs
+++ b/src/application/pulse.rs
@@ -1,0 +1,162 @@
+use chrono::{DateTime, Utc};
+
+use crate::domain::entities::pulse::PulseReport;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::influencer_feed::InfluencerFeed;
+
+/// X pay-per-use price per post read (docs.x.com pricing, 2026-02 launch).
+pub const X_COST_PER_READ_USD: f64 = 0.005;
+
+/// No-arguments fallback: market-moving macro accounts. Per-call account
+/// lists are the primary path — the consuming agent curates per ticker.
+pub const DEFAULT_PULSE_ACCOUNTS: [&str; 4] = [
+    "realDonaldTrump",
+    "WhiteHouse",
+    "elonmusk",
+    "federalreserve",
+];
+
+pub const MAX_HOURS_BACK: u32 = 168;
+pub const MAX_PULSE_LIMIT: usize = 100;
+
+/// Trim, strip a leading `@`, drop empties; empty result -> the default list.
+pub fn normalize_accounts(raw: &[String]) -> Vec<String> {
+    let cleaned: Vec<String> = raw
+        .iter()
+        .map(|a| a.trim().trim_start_matches('@').to_string())
+        .filter(|a| !a.is_empty())
+        .collect();
+    if cleaned.is_empty() {
+        DEFAULT_PULSE_ACCOUNTS
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    } else {
+        cleaned
+    }
+}
+
+pub async fn pulse(
+    ticker_raw: &str,
+    accounts_raw: &[String],
+    hours_back: u32,
+    limit: usize,
+    feed: &dyn InfluencerFeed,
+    now: DateTime<Utc>,
+) -> Result<PulseReport, DomainError> {
+    let ticker = Ticker::parse(ticker_raw)?;
+    let accounts = normalize_accounts(accounts_raw);
+    let hours_back = hours_back.clamp(1, MAX_HOURS_BACK);
+    let limit = limit.clamp(1, MAX_PULSE_LIMIT);
+    let posts = feed.pulse(&ticker, &accounts, hours_back, limit).await?;
+    let posts_read = posts.len() as u32;
+    Ok(PulseReport {
+        ticker: ticker.as_str().to_string(),
+        accounts,
+        hours_back,
+        posts,
+        posts_read,
+        estimated_cost_usd: f64::from(posts_read) * X_COST_PER_READ_USD,
+        generated_at: now,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::entities::pulse::PulsePost;
+    use crate::domain::entities::social_post::PostText;
+    use async_trait::async_trait;
+    use chrono::TimeZone;
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap()
+    }
+
+    /// Records what it was called with; returns `n` canned posts.
+    struct FakeFeed {
+        n: usize,
+        seen: std::sync::Mutex<Option<(String, Vec<String>, u32, usize)>>,
+    }
+
+    #[async_trait]
+    impl InfluencerFeed for FakeFeed {
+        async fn pulse(
+            &self,
+            ticker: &Ticker,
+            accounts: &[String],
+            hours_back: u32,
+            limit: usize,
+        ) -> Result<Vec<PulsePost>, DomainError> {
+            *self.seen.lock().unwrap() = Some((
+                ticker.as_str().to_string(),
+                accounts.to_vec(),
+                hours_back,
+                limit,
+            ));
+            Ok((0..self.n)
+                .map(|i| PulsePost {
+                    id: format!("p{i}"),
+                    author: "someone".into(),
+                    text: PostText::parse("hello market").unwrap(),
+                    created_at: at(),
+                    engagement: 1,
+                })
+                .collect())
+        }
+    }
+
+    fn fake(n: usize) -> FakeFeed {
+        FakeFeed {
+            n,
+            seen: std::sync::Mutex::new(None),
+        }
+    }
+
+    #[test]
+    fn normalize_strips_at_and_falls_back_to_defaults() {
+        let raw = vec![
+            "@jensenhuang".to_string(),
+            "  elonmusk ".to_string(),
+            "".to_string(),
+        ];
+        assert_eq!(normalize_accounts(&raw), vec!["jensenhuang", "elonmusk"]);
+        let empty: Vec<String> = vec!["@".to_string(), "  ".to_string()];
+        assert_eq!(normalize_accounts(&empty), DEFAULT_PULSE_ACCOUNTS.to_vec());
+        assert_eq!(normalize_accounts(&[]), DEFAULT_PULSE_ACCOUNTS.to_vec());
+    }
+
+    #[tokio::test]
+    async fn pulse_clamps_and_computes_cost() {
+        let feed = fake(3);
+        let report = pulse("nvda", &[], 500, 900, &feed, at()).await.unwrap();
+        let (ticker, accounts, hours, limit) = feed.seen.lock().unwrap().clone().unwrap();
+        assert_eq!(ticker, "NVDA"); // Ticker::parse normalizes
+        assert_eq!(accounts, DEFAULT_PULSE_ACCOUNTS.to_vec());
+        assert_eq!(hours, 168);
+        assert_eq!(limit, 100);
+        assert_eq!(report.posts_read, 3);
+        assert!((report.estimated_cost_usd - 0.015).abs() < 1e-9);
+        assert_eq!(report.generated_at, at());
+    }
+
+    #[tokio::test]
+    async fn pulse_clamps_low_bounds_and_zero_posts_is_ok() {
+        let feed = fake(0);
+        let report = pulse("AAPL", &["a".into()], 0, 0, &feed, at())
+            .await
+            .unwrap();
+        let (_, _, hours, limit) = feed.seen.lock().unwrap().clone().unwrap();
+        assert_eq!(hours, 1);
+        assert_eq!(limit, 1);
+        assert_eq!(report.posts_read, 0);
+        assert_eq!(report.estimated_cost_usd, 0.0);
+    }
+
+    #[tokio::test]
+    async fn pulse_rejects_bad_ticker() {
+        let feed = fake(0);
+        assert!(pulse("$$$", &[], 24, 20, &feed, at()).await.is_err());
+    }
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -71,6 +71,7 @@ pub struct SetupArgs {
 pub enum SetupSource {
     Reddit,
     Bluesky,
+    X,
 }
 
 #[derive(clap::Args, Debug)]
@@ -159,6 +160,15 @@ mod tests {
             panic!("expected setup command");
         };
         assert_eq!(args.source, SetupSource::Bluesky);
+    }
+
+    #[test]
+    fn parses_setup_x() {
+        let cli = Cli::try_parse_from(["openintel", "setup", "x"]).unwrap();
+        let Command::Setup(args) = cli.command else {
+            panic!("expected setup command");
+        };
+        assert_eq!(args.source, SetupSource::X);
     }
 
     #[test]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -23,6 +23,9 @@ pub enum Command {
 
     /// Guided setup + live verify for a data source (saves to the OS keychain; env vars override)
     Setup(SetupArgs),
+
+    /// Catalyst posts from specific high-impact X accounts (paid X API — opt-in)
+    Pulse(PulseArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -68,6 +71,27 @@ pub struct SetupArgs {
 pub enum SetupSource {
     Reddit,
     Bluesky,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct PulseArgs {
+    /// Ticker symbol, e.g. NVDA
+    pub ticker: String,
+
+    /// X handles to listen to, comma-separated (no @). Default: the macro list.
+    #[arg(long, value_delimiter = ',')]
+    pub accounts: Vec<String>,
+
+    /// Lookback window in hours (1-168)
+    #[arg(long, default_value_t = 24)]
+    pub hours: u32,
+
+    /// Max posts to read — each read costs ~$0.005 (1-100)
+    #[arg(long, default_value_t = 20)]
+    pub limit: usize,
+
+    #[arg(long, value_enum, default_value_t = FormatArg::Table)]
+    pub format: FormatArg,
 }
 
 pub fn to_app_config(args: &AnalyzeArgs) -> AppConfig {
@@ -149,5 +173,36 @@ mod tests {
             panic!("expected setup command");
         };
         assert!(args.forget);
+    }
+
+    #[test]
+    fn parses_pulse_with_accounts() {
+        let cli = Cli::try_parse_from([
+            "openintel",
+            "pulse",
+            "NVDA",
+            "--accounts",
+            "jensenhuang,elonmusk",
+            "--hours",
+            "48",
+        ])
+        .unwrap();
+        let Command::Pulse(args) = cli.command else {
+            panic!("expected pulse command");
+        };
+        assert_eq!(args.ticker, "NVDA");
+        assert_eq!(args.accounts, vec!["jensenhuang", "elonmusk"]);
+        assert_eq!(args.hours, 48);
+        assert_eq!(args.limit, 20);
+    }
+
+    #[test]
+    fn pulse_defaults_have_empty_accounts() {
+        let cli = Cli::try_parse_from(["openintel", "pulse", "GME"]).unwrap();
+        let Command::Pulse(args) = cli.command else {
+            panic!("expected pulse command");
+        };
+        assert!(args.accounts.is_empty());
+        assert_eq!(args.hours, 24);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
 pub mod args;
+pub mod pulse;
 pub mod run;
 pub mod setup;

--- a/src/cli/pulse.rs
+++ b/src/cli/pulse.rs
@@ -1,0 +1,182 @@
+//! CLI leaf for `openintel pulse` — orchestrates the pulse and renders it.
+//! Returns strings; `main.rs` prints (stdout discipline).
+
+use chrono::{DateTime, Utc};
+
+use crate::adapters::sources::x::XPulseSource;
+use crate::application::pulse::X_COST_PER_READ_USD;
+use crate::application::DISCLAIMER;
+use crate::cli::args::{FormatArg, PulseArgs};
+use crate::config::secrets::Credentials;
+use crate::domain::entities::pulse::PulseReport;
+use crate::domain::error::DomainError;
+
+pub fn not_configured_text() -> String {
+    "x is not configured — the pulse needs an X API bearer token (paid API).\n\
+     Run:  openintel setup x"
+        .to_string()
+}
+
+pub async fn run(args: &PulseArgs, credentials: &Credentials) -> Result<String, DomainError> {
+    let bearer = credentials
+        .x_bearer
+        .clone()
+        .ok_or_else(|| DomainError::SourceFailure {
+            name: "x".into(),
+            message: "not configured".into(),
+        })?;
+    let feed = XPulseSource::new(bearer)?;
+    let report = crate::application::pulse::pulse(
+        &args.ticker,
+        &args.accounts,
+        args.hours,
+        args.limit,
+        &feed,
+        Utc::now(),
+    )
+    .await?;
+    Ok(match args.format {
+        FormatArg::Table => render_table(&report, Utc::now()),
+        FormatArg::Json => render_json(&report)?,
+    })
+}
+
+fn render_json(report: &PulseReport) -> Result<String, DomainError> {
+    #[derive(serde::Serialize)]
+    struct Out<'a> {
+        report: &'a PulseReport,
+        disclaimer: &'static str,
+    }
+    serde_json::to_string_pretty(&Out {
+        report,
+        disclaimer: DISCLAIMER,
+    })
+    .map_err(|e| DomainError::SourceFailure {
+        name: "x".into(),
+        message: format!("render failed: {e}"),
+    })
+}
+
+/// "3h ago" / "45m ago" / "2d ago"
+fn age(now: DateTime<Utc>, created_at: DateTime<Utc>) -> String {
+    let mins = (now - created_at).num_minutes().max(0);
+    if mins < 60 {
+        format!("{mins}m ago")
+    } else if mins < 48 * 60 {
+        format!("{}h ago", mins / 60)
+    } else {
+        format!("{}d ago", mins / (24 * 60))
+    }
+}
+
+fn render_table(report: &PulseReport, now: DateTime<Utc>) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "=== OpenIntel X Pulse — {} ===", report.ticker);
+    let _ = writeln!(
+        out,
+        "window: last {}h · accounts: {}",
+        report.hours_back,
+        report.accounts.join(", ")
+    );
+    let _ = writeln!(
+        out,
+        "generated: {}\n",
+        report
+            .generated_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    );
+
+    if report.posts.is_empty() {
+        let _ = writeln!(out, "⚡ no posts from these accounts in the window");
+    } else {
+        let _ = writeln!(out, "⚡ {} post(s)\n", report.posts.len());
+        for p in &report.posts {
+            let _ = writeln!(
+                out,
+                "  [{}] @{} (eng {})",
+                age(now, p.created_at),
+                p.author,
+                p.engagement
+            );
+            let _ = writeln!(out, "    {}\n", p.text.as_str());
+        }
+    }
+
+    let _ = writeln!(
+        out,
+        "cost: {} posts read (≈ ${:.2} at ${}/read; X dedupes re-reads for 24h)",
+        report.posts_read, report.estimated_cost_usd, X_COST_PER_READ_USD
+    );
+    let _ = writeln!(out, "\n{DISCLAIMER}");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::entities::pulse::PulsePost;
+    use crate::domain::entities::social_post::PostText;
+    use chrono::TimeZone;
+
+    fn at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap()
+    }
+
+    fn report(posts: Vec<PulsePost>) -> PulseReport {
+        let posts_read = posts.len() as u32;
+        PulseReport {
+            ticker: "NVDA".into(),
+            accounts: vec!["jensenhuang".into(), "elonmusk".into()],
+            hours_back: 24,
+            posts,
+            posts_read,
+            estimated_cost_usd: f64::from(posts_read) * X_COST_PER_READ_USD,
+            generated_at: at(),
+        }
+    }
+
+    fn post(hours_old: i64) -> PulsePost {
+        PulsePost {
+            id: "1".into(),
+            author: "jensenhuang".into(),
+            text: PostText::parse("Blackwell Ultra shipping at scale").unwrap(),
+            created_at: at() - chrono::Duration::hours(hours_old),
+            engagement: 48210,
+        }
+    }
+
+    #[test]
+    fn table_renders_posts_cost_and_disclaimer() {
+        let rendered = render_table(&report(vec![post(3)]), at());
+        assert!(rendered.contains("=== OpenIntel X Pulse — NVDA ==="));
+        assert!(rendered.contains("window: last 24h · accounts: jensenhuang, elonmusk"));
+        assert!(rendered.contains("[3h ago] @jensenhuang (eng 48210)"));
+        assert!(rendered.contains("Blackwell Ultra shipping at scale"));
+        assert!(rendered.contains("cost: 1 posts read (≈ $0.01 at $0.005/read"));
+        assert!(rendered.contains("Not financial advice"));
+    }
+
+    #[test]
+    fn table_zero_posts_is_quiet_not_error() {
+        let rendered = render_table(&report(vec![]), at());
+        assert!(rendered.contains("no posts from these accounts in the window"));
+        assert!(rendered.contains("cost: 0 posts read"));
+    }
+
+    #[test]
+    fn age_buckets() {
+        assert_eq!(age(at(), at() - chrono::Duration::minutes(45)), "45m ago");
+        assert_eq!(age(at(), at() - chrono::Duration::hours(3)), "3h ago");
+        assert_eq!(age(at(), at() - chrono::Duration::days(3)), "3d ago");
+        assert_eq!(age(at(), at() + chrono::Duration::minutes(5)), "0m ago"); // clock skew clamps
+    }
+
+    #[test]
+    fn json_contains_report_and_disclaimer() {
+        let json = render_json(&report(vec![post(1)])).unwrap();
+        assert!(json.contains("\"posts_read\": 1"));
+        assert!(json.contains("\"estimated_cost_usd\""));
+        assert!(json.contains("Not financial advice"));
+    }
+}

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -153,6 +153,9 @@ fn verify_err_text(err: &DomainError, unauthorized_hint: &str) -> String {
         unauthorized_hint
     } else if msg.contains("rate limited") {
         "You're being rate-limited right now — wait a minute and re-run."
+    } else if msg.contains("forbidden") {
+        "Your token authenticated but access was refused — most often exhausted\n   \
+         API credits. Check Billing → Credits in the X developer console."
     } else {
         "Check your internet connection and try again."
     };
@@ -454,11 +457,11 @@ where
                 // Write order matters: identifier first, secret last — if the
                 // second write fails, only the (public) identifier can be
                 // orphaned, never the secret, and the next setup overwrites it.
-                let saved = if spec.second_key.is_some() {
+                let saved = if let Some(second_key) = spec.second_key {
                     let first_secret = SecretString::new(first.into_boxed_str());
                     store
                         .set(spec.first_key, &first_secret)
-                        .and_then(|()| store.set(spec.second_key.expect("pair source"), &secret))
+                        .and_then(|()| store.set(second_key, &secret))
                 } else {
                     store.set(spec.first_key, &secret)
                 };
@@ -635,8 +638,8 @@ async fn probe_x(bearer: SecretString) -> Result<usize, DomainError> {
         .iter()
         .map(|s| s.to_string())
         .collect();
-    let posts = feed.pulse(&ticker, &accounts, 24, 10).await?;
-    Ok(posts.len())
+    let fetch = feed.pulse(&ticker, &accounts, 24, 10).await?;
+    Ok(fetch.posts.len()) // display count for the "pulled N posts" message, not billing count
 }
 
 async fn setup_x(credentials: &Credentials) -> ExitCode {
@@ -727,6 +730,16 @@ mod tests {
         let text = verify_err_text(&other, REDDIT_UNAUTHORIZED_HINT);
         assert!(text.contains("connection refused")); // raw error preserved
         assert!(text.contains("Check your internet connection"));
+    }
+
+    #[test]
+    fn verify_err_text_maps_forbidden_to_credits_hint() {
+        let forbidden = DomainError::SourceFailure {
+            name: "x".into(),
+            message: "forbidden — check API access and credit balance".into(),
+        };
+        let text = verify_err_text(&forbidden, X_UNAUTHORIZED_HINT);
+        assert!(text.contains("credits"));
     }
 
     #[test]

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -13,11 +13,13 @@ use secrecy::SecretString;
 
 use crate::adapters::sources::bluesky::BlueskySource;
 use crate::adapters::sources::reddit::RedditSource;
+use crate::adapters::sources::x::XPulseSource;
 use crate::cli::args::SetupSource;
 use crate::config::secrets::Credentials;
 use crate::config::store::CredentialStore;
 use crate::domain::entities::ticker::Ticker;
 use crate::domain::error::DomainError;
+use crate::domain::ports::influencer_feed::InfluencerFeed;
 use crate::domain::ports::social_data_source::SocialDataSource;
 
 /// Which of the three setup modes applies, given which env vars are set.
@@ -171,20 +173,24 @@ const BLUESKY_UNAUTHORIZED_HINT: &str =
 struct SourceSpec {
     label: &'static str,
     first_key: &'static str,
-    second_key: &'static str,
+    second_key: Option<&'static str>,
     first_prompt: &'static str,
-    second_prompt: &'static str,
+    second_prompt: Option<&'static str>,
     condensed_guide: &'static str,
     unauthorized_hint: &'static str,
     try_cmd: &'static str,
+    /// Shown (and requires y/blank to proceed) right before the live probe —
+    /// for paid sources where verification itself costs money.
+    pre_probe_confirm: Option<&'static str>,
 }
 
 const REDDIT_SPEC: SourceSpec = SourceSpec {
     label: "Reddit",
     first_key: "OPENINTEL_REDDIT_CLIENT_ID",
-    second_key: "OPENINTEL_REDDIT_CLIENT_SECRET",
+    second_key: Some("OPENINTEL_REDDIT_CLIENT_SECRET"),
     first_prompt: "Client id",
-    second_prompt: "Client secret",
+    second_prompt: Some("Client secret"),
+    pre_probe_confirm: None,
     condensed_guide: "\
 Reddit needs a free OAuth app — there's no keyless access. ~2 minutes:
 
@@ -210,9 +216,10 @@ Reddit needs a free OAuth app — there's no keyless access. ~2 minutes:
 const BLUESKY_SPEC: SourceSpec = SourceSpec {
     label: "Bluesky",
     first_key: "OPENINTEL_BLUESKY_HANDLE",
-    second_key: "OPENINTEL_BLUESKY_APP_PASSWORD",
+    second_key: Some("OPENINTEL_BLUESKY_APP_PASSWORD"),
     first_prompt: "Handle (e.g. yourname.bsky.social)",
-    second_prompt: "App password",
+    second_prompt: Some("App password"),
+    pre_probe_confirm: None,
     condensed_guide: "\
 Bluesky needs a free app password — search requires auth. ~2 minutes:
 
@@ -228,6 +235,34 @@ Bluesky needs a free app password — search requires auth. ~2 minutes:
     try_cmd: "openintel analyze GME --enable-bluesky",
 };
 
+const X_UNAUTHORIZED_HINT: &str =
+    "Your bearer token looks wrong or lacks access. In the X developer console\n   \
+     (https://developer.x.com → Projects & Apps → your app → Keys and Tokens),\n   \
+     regenerate the Bearer Token, and make sure API credits are loaded.";
+
+const X_SPEC: SourceSpec = SourceSpec {
+    label: "X",
+    first_key: "OPENINTEL_X_BEARER",
+    second_key: None,
+    first_prompt: "Bearer token",
+    second_prompt: None,
+    condensed_guide: "\
+X Pulse needs an X API bearer token — the API is PAID (pay-per-use,
+about $0.005 per post read; you buy credits up front). ~3 minutes:
+
+  1. Sign in at https://developer.x.com and open the developer console.
+  2. Projects & Apps → your app (create one if needed) → Keys and Tokens.
+  3. Under \"Bearer Token\", generate/reveal it and copy it.
+  4. Make sure your account has API credits loaded (Billing → Credits).
+  5. Enter the token below — verification reads up to 10 posts (≈ $0.05).
+",
+    unauthorized_hint: X_UNAUTHORIZED_HINT,
+    try_cmd: "openintel pulse NVDA --accounts jensenhuang",
+    pre_probe_confirm: Some(
+        "Verifying will read up to 10 posts from X (≈ $0.05). Proceed? [Y/n]: ",
+    ),
+};
+
 /// Entry point for `openintel setup <source>`. Exit code 0 only when the
 /// source is verified working (or `--forget` succeeded).
 pub async fn run(
@@ -239,6 +274,7 @@ pub async fn run(
     let spec = match source {
         SetupSource::Reddit => &REDDIT_SPEC,
         SetupSource::Bluesky => &BLUESKY_SPEC,
+        SetupSource::X => &X_SPEC,
     };
 
     if forget {
@@ -250,6 +286,7 @@ pub async fn run(
         return match source {
             SetupSource::Reddit => setup_reddit(credentials).await,
             SetupSource::Bluesky => setup_bluesky(credentials).await,
+            SetupSource::X => setup_x(credentials).await,
         };
     }
 
@@ -260,6 +297,7 @@ pub async fn run(
         SetupSource::Bluesky => {
             credentials.bluesky_handle.is_some() && credentials.bluesky_app_password.is_some()
         }
+        SetupSource::X => credentials.x_bearer.is_some(),
     };
     let already = configured.then(|| provenance(spec.first_key));
 
@@ -280,6 +318,12 @@ pub async fn run(
             .await
         }
         SetupSource::Bluesky => run_interactive(&mut io, store, spec, already, probe_bluesky).await,
+        SetupSource::X => {
+            run_interactive(&mut io, store, spec, already, |_first, secret| {
+                probe_x(secret)
+            })
+            .await
+        }
     };
 
     match outcome {
@@ -288,6 +332,7 @@ pub async fn run(
         InteractiveOutcome::VerifyExisting => match source {
             SetupSource::Reddit => setup_reddit(credentials).await,
             SetupSource::Bluesky => setup_bluesky(credentials).await,
+            SetupSource::X => setup_x(credentials).await,
         },
     }
 }
@@ -312,7 +357,10 @@ fn forget_source(spec: &SourceSpec, store: &dyn CredentialStore) -> ExitCode {
 }
 
 fn forget_outcome(spec: &SourceSpec, store: &dyn CredentialStore) -> Outcome {
-    for key in [spec.first_key, spec.second_key] {
+    for key in [Some(spec.first_key), spec.second_key]
+        .into_iter()
+        .flatten()
+    {
         if let Err(e) = store.delete(key) {
             println!("❌ could not remove {key} from the OS keychain: {e}");
             return Outcome::Failure;
@@ -373,23 +421,47 @@ where
     println!("{}", spec.condensed_guide);
 
     for attempt in 1..=MAX_ATTEMPTS {
-        let Ok(first) = prompt_nonempty_visible(io, spec.first_prompt) else {
-            return InteractiveOutcome::Done(Outcome::Failure);
+        let (first, secret) = if let Some(second_prompt) = spec.second_prompt {
+            let Ok(first) = prompt_nonempty_visible(io, spec.first_prompt) else {
+                return InteractiveOutcome::Done(Outcome::Failure);
+            };
+            let Ok(secret) = prompt_nonempty_secret(io, second_prompt) else {
+                return InteractiveOutcome::Done(Outcome::Failure);
+            };
+            (first, secret)
+        } else {
+            // Single-credential source: read the one (secret) value hidden.
+            let Ok(secret) = prompt_nonempty_secret(io, spec.first_prompt) else {
+                return InteractiveOutcome::Done(Outcome::Failure);
+            };
+            (String::new(), secret)
         };
-        let Ok(secret) = prompt_nonempty_secret(io, spec.second_prompt) else {
-            return InteractiveOutcome::Done(Outcome::Failure);
-        };
+
+        if let Some(confirm) = spec.pre_probe_confirm {
+            match read_visible(io, confirm) {
+                Ok(ans) if matches!(ans.trim().to_lowercase().as_str(), "" | "y" | "yes") => {}
+                Ok(_) => {
+                    println!("Aborted — nothing was saved.");
+                    return InteractiveOutcome::Done(Outcome::Failure);
+                }
+                Err(_) => return InteractiveOutcome::Done(Outcome::Failure),
+            }
+        }
 
         println!("Checking your {} credentials…", spec.label);
         match probe(first.clone(), secret.clone()).await {
             Ok(count) => {
-                let first_secret = SecretString::new(first.into_boxed_str());
                 // Write order matters: identifier first, secret last — if the
                 // second write fails, only the (public) identifier can be
                 // orphaned, never the secret, and the next setup overwrites it.
-                let saved = store
-                    .set(spec.first_key, &first_secret)
-                    .and_then(|()| store.set(spec.second_key, &secret));
+                let saved = if spec.second_key.is_some() {
+                    let first_secret = SecretString::new(first.into_boxed_str());
+                    store
+                        .set(spec.first_key, &first_secret)
+                        .and_then(|()| store.set(spec.second_key.expect("pair source"), &secret))
+                } else {
+                    store.set(spec.first_key, &secret)
+                };
                 return InteractiveOutcome::Done(match saved {
                     Ok(()) => {
                         println!("{}", verify_ok_text(spec.label, count, spec.try_cmd));
@@ -400,11 +472,16 @@ where
                     }
                     Err(e) => {
                         println!("{}", verify_ok_text(spec.label, count, spec.try_cmd));
+                        let export_lines = [Some(spec.first_key), spec.second_key]
+                            .into_iter()
+                            .flatten()
+                            .map(|key| format!("export {key}=paste_your_value"))
+                            .collect::<Vec<_>>()
+                            .join("\n   ");
                         println!(
                             "⚠  Verified, but saving to the OS keychain failed: {e}\n   \
                              Fall back to environment variables (with your real values):\n\n   \
-                             export {}=paste_your_value\n   export {}=paste_your_value",
-                            spec.first_key, spec.second_key
+                             {export_lines}"
                         );
                         Outcome::Failure
                     }
@@ -548,6 +625,43 @@ Bluesky needs a free app password — search requires auth. ~2 minutes:
 openintel reads these only from your environment — it never stores or writes
 your credentials to disk."
         .to_string()
+}
+
+/// One paid round trip: search the default macro accounts for AAPL (max 10 reads ≈ $0.05).
+async fn probe_x(bearer: SecretString) -> Result<usize, DomainError> {
+    let feed = XPulseSource::new(bearer)?;
+    let ticker = Ticker::parse("AAPL")?;
+    let accounts: Vec<String> = crate::application::pulse::DEFAULT_PULSE_ACCOUNTS
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let posts = feed.pulse(&ticker, &accounts, 24, 10).await?;
+    Ok(posts.len())
+}
+
+async fn setup_x(credentials: &Credentials) -> ExitCode {
+    match credentials.x_bearer.clone() {
+        None => {
+            println!("{}", X_SPEC.condensed_guide);
+            println!(
+                "Set OPENINTEL_X_BEARER (or run `openintel setup x` in a terminal), then re-run."
+            );
+            ExitCode::FAILURE
+        }
+        Some(bearer) => {
+            println!("Checking your X credentials… (reads up to 10 posts ≈ $0.05)");
+            match probe_x(bearer).await {
+                Ok(count) => {
+                    println!("{}", verify_ok_text("X", count, X_SPEC.try_cmd));
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    println!("{}", verify_err_text(&e, X_UNAUTHORIZED_HINT));
+                    ExitCode::FAILURE
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -854,5 +968,57 @@ mod tests {
         }
         assert!(REDDIT_SPEC.condensed_guide.contains("prefs/apps"));
         assert!(BLUESKY_SPEC.condensed_guide.contains("app-passwords"));
+    }
+
+    #[test]
+    fn x_guide_contains_cost_and_console_steps() {
+        assert!(X_SPEC.condensed_guide.contains("developer.x.com"));
+        assert!(X_SPEC.condensed_guide.contains("$0.005"));
+        assert!(X_SPEC.condensed_guide.contains("Bearer Token"));
+        assert!(X_SPEC.second_key.is_none());
+    }
+
+    #[tokio::test]
+    async fn single_cred_happy_path_saves_one_key() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("\n"); // cost-confirm: blank = Yes
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &X_SPEC, None, |_f, _s| {
+            std::future::ready(Ok(2usize))
+        })
+        .await;
+        assert!(matches!(
+            outcome,
+            InteractiveOutcome::Done(Outcome::Success)
+        ));
+        let map = store.map.borrow();
+        assert_eq!(map.len(), 1);
+        assert_eq!(
+            map.get("OPENINTEL_X_BEARER").unwrap().expose_secret(),
+            "s3cret"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_cred_cost_confirm_decline_saves_nothing() {
+        let store = InMemoryStore::new();
+        let mut input = Cursor::new("n\n");
+        let mut io = scripted(&mut input, &ok_secret);
+        let outcome = run_interactive(&mut io, &store, &X_SPEC, None, |_f, _s| {
+            std::future::ready(Ok(2usize))
+        })
+        .await;
+        assert!(matches!(
+            outcome,
+            InteractiveOutcome::Done(Outcome::Failure)
+        ));
+        assert!(store.map.borrow().is_empty());
+    }
+
+    #[test]
+    fn forget_x_removes_single_key() {
+        let store = InMemoryStore::new().seed("OPENINTEL_X_BEARER", "tok");
+        assert_eq!(forget_outcome(&X_SPEC, &store), Outcome::Success);
+        assert!(store.map.borrow().is_empty());
     }
 }

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -10,6 +10,8 @@ pub struct Credentials {
     pub bluesky_handle: Option<String>,
     pub bluesky_app_password: Option<SecretString>,
     pub market_api_key: Option<SecretString>,
+    /// X API bearer token (paid pay-per-use API — pulse only, never analyze).
+    pub x_bearer: Option<SecretString>,
 }
 
 impl Credentials {
@@ -20,6 +22,7 @@ impl Credentials {
             bluesky_handle: plain_from(std::env::var("OPENINTEL_BLUESKY_HANDLE").ok()),
             bluesky_app_password: secret_from(std::env::var("OPENINTEL_BLUESKY_APP_PASSWORD").ok()),
             market_api_key: secret_from(std::env::var("OPENINTEL_MARKET_API_KEY").ok()),
+            x_bearer: secret_from(std::env::var("OPENINTEL_X_BEARER").ok()),
         }
     }
 
@@ -42,6 +45,9 @@ impl Credentials {
         c.bluesky_app_password = c
             .bluesky_app_password
             .or_else(|| store_get(store, "OPENINTEL_BLUESKY_APP_PASSWORD"));
+        c.x_bearer = c
+            .x_bearer
+            .or_else(|| store_get(store, "OPENINTEL_X_BEARER"));
         c
     }
 }
@@ -96,6 +102,7 @@ mod tests {
             bluesky_handle: Some("public.bsky.social".into()),
             bluesky_app_password: secret_from(Some("leak-me-too".to_string())),
             market_api_key: None,
+            x_bearer: None,
         };
         assert!(!format!("{creds:?}").contains("leak-me"));
         assert!(!format!("{creds:?}").contains("leak-me-too"));

--- a/src/domain/entities/mod.rs
+++ b/src/domain/entities/mod.rs
@@ -1,4 +1,5 @@
 pub mod market_snapshot;
+pub mod pulse;
 pub mod social_post;
 pub mod speculation_report;
 pub mod ticker;

--- a/src/domain/entities/pulse.rs
+++ b/src/domain/entities/pulse.rs
@@ -16,6 +16,15 @@ pub struct PulsePost {
     pub engagement: u32,
 }
 
+/// What one feed call yielded: the kept posts plus how many the upstream API
+/// actually returned (= what a pay-per-read API bills), which can exceed
+/// `posts.len()` due to client-side truncation and skips.
+#[derive(Debug, Clone)]
+pub struct PulseFetch {
+    pub posts: Vec<PulsePost>,
+    pub posts_returned: u32,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct PulseReport {
     pub ticker: String,

--- a/src/domain/entities/pulse.rs
+++ b/src/domain/entities/pulse.rs
@@ -1,0 +1,28 @@
+//! Pulse posts: catalyst events from specific high-impact X accounts.
+//! Deliberately NOT `SocialPost` — pulse posts never enter the fusion
+//! engine's sentiment averaging (see the 2026-07-16 spec).
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::domain::entities::social_post::PostText;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PulsePost {
+    pub id: String,
+    pub author: String,
+    pub text: PostText,
+    pub created_at: DateTime<Utc>,
+    pub engagement: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PulseReport {
+    pub ticker: String,
+    pub accounts: Vec<String>,
+    pub hours_back: u32,
+    pub posts: Vec<PulsePost>,
+    pub posts_read: u32,
+    pub estimated_cost_usd: f64,
+    pub generated_at: DateTime<Utc>,
+}

--- a/src/domain/ports/influencer_feed.rs
+++ b/src/domain/ports/influencer_feed.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::domain::entities::pulse::PulsePost;
+use crate::domain::entities::pulse::PulseFetch;
 use crate::domain::entities::ticker::Ticker;
 use crate::domain::error::DomainError;
 
@@ -8,11 +8,13 @@ use crate::domain::error::DomainError;
 /// invoke it only on explicit user opt-in.
 #[async_trait]
 pub trait InfluencerFeed: Send + Sync {
+    /// `posts_returned` on the result drives cost accounting — it's what the
+    /// upstream API billed, not necessarily `posts.len()`.
     async fn pulse(
         &self,
         ticker: &Ticker,
         accounts: &[String],
         hours_back: u32,
         limit: usize,
-    ) -> Result<Vec<PulsePost>, DomainError>;
+    ) -> Result<PulseFetch, DomainError>;
 }

--- a/src/domain/ports/influencer_feed.rs
+++ b/src/domain/ports/influencer_feed.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+
+use crate::domain::entities::pulse::PulsePost;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+
+/// Author-filtered event feed (the X Pulse port). Paid upstream — callers
+/// invoke it only on explicit user opt-in.
+#[async_trait]
+pub trait InfluencerFeed: Send + Sync {
+    async fn pulse(
+        &self,
+        ticker: &Ticker,
+        accounts: &[String],
+        hours_back: u32,
+        limit: usize,
+    ) -> Result<Vec<PulsePost>, DomainError>;
+}

--- a/src/domain/ports/mod.rs
+++ b/src/domain/ports/mod.rs
@@ -1,3 +1,4 @@
+pub mod influencer_feed;
 pub mod market_data_source;
 pub mod post_analyzer;
 pub mod social_data_source;

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,5 +54,19 @@ async fn main() -> ExitCode {
         Command::Setup(args) => {
             openintel::cli::setup::run(args.source, &credentials, &store, args.forget).await
         }
+        Command::Pulse(args) => match openintel::cli::pulse::run(&args, &credentials).await {
+            Ok(rendered) => {
+                println!("{rendered}");
+                ExitCode::SUCCESS
+            }
+            Err(e) if e.to_string().contains("not configured") => {
+                println!("{}", openintel::cli::pulse::not_configured_text());
+                ExitCode::FAILURE
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                ExitCode::FAILURE
+            }
+        },
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -16,14 +16,20 @@ pub struct OpenIntelServer {
     tool_router: ToolRouter<OpenIntelServer>,
     social: Arc<Vec<Box<dyn SocialDataSource>>>,
     market: YahooMarketSource,
+    pulse_feed: Option<Arc<crate::adapters::sources::x::XPulseSource>>,
 }
 
 impl OpenIntelServer {
-    pub fn new(social: Vec<Box<dyn SocialDataSource>>, market: YahooMarketSource) -> Self {
+    pub fn new(
+        social: Vec<Box<dyn SocialDataSource>>,
+        market: YahooMarketSource,
+        pulse_feed: Option<crate::adapters::sources::x::XPulseSource>,
+    ) -> Self {
         Self {
             tool_router: Self::tool_router(),
             social: Arc::new(social),
             market,
+            pulse_feed: pulse_feed.map(Arc::new),
         }
     }
 }
@@ -86,6 +92,36 @@ impl OpenIntelServer {
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
     }
+
+    #[tool(
+        description = "Fetch recent posts about a ticker from specific high-impact X accounts \
+                       (paid API: ~$0.005 per post read). Before calling: research which accounts \
+                       actually matter for this ticker — CEO/founder, major institutional holders \
+                       or activist funds, respected sector journalists, and market-moving macro \
+                       figures — then propose the account list and estimated max cost \
+                       (limit × $0.005) to the user and get their confirmation. Omit `accounts` \
+                       only if the user asks for the default macro list. Returned posts are \
+                       catalyst events — reason about them directly; do not treat them as a \
+                       sentiment sample. Read-only — does not trade."
+    )]
+    async fn x_pulse(
+        &self,
+        Parameters(args): Parameters<tools::PulseToolArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let Some(feed) = self.pulse_feed.as_deref() else {
+            return Err(ErrorData::invalid_request(
+                "x is not configured — set OPENINTEL_X_BEARER or run `openintel setup x`"
+                    .to_string(),
+                None,
+            ));
+        };
+        let out = tools::run_pulse(args, feed)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let json = serde_json::to_string_pretty(&out)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    }
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -114,7 +150,19 @@ pub async fn serve() -> Result<(), Box<dyn std::error::Error>> {
     let social = crate::adapters::sources::build_social_sources(&credentials);
 
     let market = YahooMarketSource::new()?;
-    let service = OpenIntelServer::new(social, market).serve(stdio()).await?;
+    let pulse_feed = match credentials.x_bearer.clone() {
+        Some(bearer) => match crate::adapters::sources::x::XPulseSource::new(bearer) {
+            Ok(src) => Some(src),
+            Err(e) => {
+                eprintln!("warning: x pulse disabled: {e}");
+                None
+            }
+        },
+        None => None,
+    };
+    let service = OpenIntelServer::new(social, market, pulse_feed)
+        .serve(stdio())
+        .await?;
     service.waiting().await?;
     Ok(())
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -524,7 +524,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_pulse_summarizes_and_costs() {
-        use crate::domain::entities::pulse::PulsePost;
+        use crate::domain::entities::pulse::{PulseFetch, PulsePost};
         use crate::domain::entities::social_post::PostText;
         use crate::domain::entities::ticker::Ticker;
         use crate::domain::ports::influencer_feed::InfluencerFeed;
@@ -539,14 +539,17 @@ mod tests {
                 _a: &[String],
                 _h: u32,
                 _l: usize,
-            ) -> Result<Vec<PulsePost>, DomainError> {
-                Ok(vec![PulsePost {
-                    id: "1".into(),
-                    author: "jensenhuang".into(),
-                    text: PostText::parse("shipping").unwrap(),
-                    created_at: chrono::Utc::now(),
-                    engagement: 5,
-                }])
+            ) -> Result<PulseFetch, DomainError> {
+                Ok(PulseFetch {
+                    posts: vec![PulsePost {
+                        id: "1".into(),
+                        author: "jensenhuang".into(),
+                        text: PostText::parse("shipping").unwrap(),
+                        created_at: chrono::Utc::now(),
+                        engagement: 5,
+                    }],
+                    posts_returned: 1,
+                })
             }
         }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,14 +1,17 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::application::{self, request::AnalysisRequest, DISCLAIMER};
+use crate::application::{self, pulse as pulse_app, request::AnalysisRequest, DISCLAIMER};
 use crate::domain::engine::config::EngineConfig;
+use crate::domain::entities::pulse::PulseReport;
 use crate::domain::entities::speculation_report::SpeculationReport;
 use crate::domain::error::DomainError;
+use crate::domain::ports::influencer_feed::InfluencerFeed;
 use crate::domain::ports::market_data_source::MarketDataSource;
 use crate::domain::ports::social_data_source::SocialDataSource;
 use crate::domain::values::source_kind::SourceKind;
 use crate::domain::values::speculation::Alignment;
+use chrono::Utc;
 
 #[derive(Debug, Serialize)]
 pub struct SourcesOutput {
@@ -299,6 +302,57 @@ pub async fn run_compare(
     }
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PulseToolArgs {
+    /// Ticker symbol, e.g. "NVDA".
+    pub ticker: String,
+    /// X handles to listen to (no @). Curate per ticker: CEO/founder, major
+    /// holders or activist funds, sector journalists, macro figures. Omit only
+    /// if the user asked for the default macro list.
+    pub accounts: Option<Vec<String>>,
+    /// Lookback window in hours (default 24, max 168).
+    pub hours_back: Option<u32>,
+    /// Max posts to read — each read costs ~$0.005 (default 20, max 100).
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PulseOutput {
+    pub summary: String,
+    pub report: PulseReport,
+    pub disclaimer: &'static str,
+}
+
+pub async fn run_pulse(
+    args: PulseToolArgs,
+    feed: &dyn InfluencerFeed,
+) -> Result<PulseOutput, DomainError> {
+    let accounts = args.accounts.unwrap_or_default();
+    let report = pulse_app::pulse(
+        &args.ticker,
+        &accounts,
+        args.hours_back.unwrap_or(24),
+        args.limit.unwrap_or(20),
+        feed,
+        Utc::now(),
+    )
+    .await?;
+    let summary = format!(
+        "{} — ⚡ {} high-impact post(s) in last {}h from {} account(s) · {} posts read ≈ ${:.2}",
+        report.ticker,
+        report.posts.len(),
+        report.hours_back,
+        report.accounts.len(),
+        report.posts_read,
+        report.estimated_cost_usd
+    );
+    Ok(PulseOutput {
+        summary,
+        report,
+        disclaimer: DISCLAIMER,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -466,5 +520,49 @@ mod tests {
         assert_eq!(out.errors.len(), 1);
         assert_eq!(out.errors[0].ticker, "$$$");
         assert!(out.ranked[0].rank_metric.is_finite());
+    }
+
+    #[tokio::test]
+    async fn run_pulse_summarizes_and_costs() {
+        use crate::domain::entities::pulse::PulsePost;
+        use crate::domain::entities::social_post::PostText;
+        use crate::domain::entities::ticker::Ticker;
+        use crate::domain::ports::influencer_feed::InfluencerFeed;
+        use async_trait::async_trait;
+
+        struct OnePost;
+        #[async_trait]
+        impl InfluencerFeed for OnePost {
+            async fn pulse(
+                &self,
+                _t: &Ticker,
+                _a: &[String],
+                _h: u32,
+                _l: usize,
+            ) -> Result<Vec<PulsePost>, DomainError> {
+                Ok(vec![PulsePost {
+                    id: "1".into(),
+                    author: "jensenhuang".into(),
+                    text: PostText::parse("shipping").unwrap(),
+                    created_at: chrono::Utc::now(),
+                    engagement: 5,
+                }])
+            }
+        }
+
+        let out = run_pulse(
+            PulseToolArgs {
+                ticker: "NVDA".into(),
+                accounts: Some(vec!["@jensenhuang".into()]),
+                hours_back: None,
+                limit: None,
+            },
+            &OnePost,
+        )
+        .await
+        .unwrap();
+        assert!(out.summary.contains("⚡ 1 high-impact post(s)"));
+        assert_eq!(out.report.accounts, vec!["jensenhuang"]); // @-stripped
+        assert!(out.disclaimer.contains("Not financial advice"));
     }
 }


### PR DESCRIPTION
## What

**X Pulse**: posts about a ticker from *specific high-impact X accounts* (POTUS, CEOs, activist funds — per-call curated), surfaced as **catalyst events to reason about — never averaged into sentiment**. Built on X's pay-per-use API ($0.005/post read), so the entire design is credit-aware:

- **Opt-in only**: nothing calls X except an explicit `openintel pulse` / MCP `x_pulse` invocation. `analyze`, `scan_watchlist`, fusion, `build_social_sources` untouched; `SourceKind::X` does not return.
- **Cost-honest**: every report carries `posts_read` (what X actually returned = billed, not the display count — `max_results` has an API floor of 10) + `estimated_cost_usd`; the CLI renders the cost line; the MCP tool description contractually requires the agent to propose the account list **and cost estimate** for user confirmation before spending; `setup x` confirms before its ~5¢ verify probe.
- **Rate-limit aware**: 429s fail fast with the `x-rate-limit-reset` time surfaced.

## Surfaces

- `openintel pulse NVDA --accounts jensenhuang,elonmusk --hours 24 --limit 20` (defaults to a small macro list: POTUS/WH/Musk/Fed). Zero posts = successful quiet result.
- MCP `x_pulse(ticker, accounts?, hours_back?, limit?)` — the tool description carries the agent-curation contract (research CEO/holders/activists/journalists/macro → propose list + cost → user confirms → call).
- `openintel setup x` — first single-credential setup source (hidden bearer prompt → cost-confirmed live verify → keychain). Reddit/Bluesky flows behavior-identical (verified against base).

## Architecture

New hexagonal vertical: `PulsePost`/`PulseReport`/`PulseFetch` entities + `InfluencerFeed` port + `application::pulse` (clamps, `@`-strip + X-username-charset validation — all-invalid input errors rather than silently spending on default accounts) + `XPulseSource` adapter (pure `build_query`/`parse_posts`, one `expose_secret` site).

## Review trail

Per-task reviews ×6 clean. Opus whole-branch review caught one Important pre-merge: **cost under-reporting** — `posts_read` counted post-truncation display posts while X bills what it returns (up to 10× understatement at `--limit 1`); fixed by carrying the billed count through the port (`PulseFetch`). Also fixed: 403→credits hint, handle validation, style nit.

## Tests

163 lib + 3 integration passing (5 `#[ignore]`d live incl. the new paid `x_live_pulse`), clippy `-D warnings` + fmt clean. Live X validation (cashtag-operator contingency + real probe, ~5–10¢) happens post-merge with the owner's bearer token.

Spec: `docs/superpowers/specs/2026-07-16-x-pulse-design.md` · Plan: `docs/superpowers/plans/2026-07-16-x-pulse.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)