### PR TITLE
fix(pulse): close paid-probe confirm gap; disclose billing floor; 167h cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ openintel setup x                                      # guided token setup (ver
 openintel pulse NVDA --accounts jensenhuang,elonmusk   # ≤ 20 reads ≈ $0.10 max
 ```
 
+Note: X's API bills a minimum of 10 post reads per call, so even `--limit 1` costs ≈ $0.05.
+
 No `--accounts` → a small macro default list (POTUS, White House, Musk, the Fed).
 Via MCP, the `x_pulse` tool asks the agent to research which accounts matter for
 your ticker and confirm the cost with you before spending.

--- a/src/adapters/sources/x/mod.rs
+++ b/src/adapters/sources/x/mod.rs
@@ -163,7 +163,7 @@ mod tests {
             .map(|s| s.to_string())
             .collect();
         let fetch = src
-            .pulse(&Ticker::parse("AAPL").unwrap(), &accounts, 168, 10)
+            .pulse(&Ticker::parse("AAPL").unwrap(), &accounts, 167, 10)
             .await
             .unwrap(); // cashtag-operator contingency check: a 400 here means switch build_query to bare keyword
         for p in &fetch.posts {

--- a/src/application/pulse.rs
+++ b/src/application/pulse.rs
@@ -22,7 +22,9 @@ pub const DEFAULT_PULSE_ACCOUNTS: [&str; 4] = [
     "federalreserve",
 ];
 
-pub const MAX_HOURS_BACK: u32 = 168;
+/// X recent search covers 7 days; cap below the boundary so start_time never
+/// lands outside the window mid-flight.
+pub const MAX_HOURS_BACK: u32 = 167;
 pub const MAX_PULSE_LIMIT: usize = 100;
 
 /// Trim, strip a leading `@`, drop invalid handles (X username charset:
@@ -192,7 +194,7 @@ mod tests {
         let (ticker, accounts, hours, limit) = feed.seen.lock().unwrap().clone().unwrap();
         assert_eq!(ticker, "NVDA"); // Ticker::parse normalizes
         assert_eq!(accounts, DEFAULT_PULSE_ACCOUNTS.to_vec());
-        assert_eq!(hours, 168);
+        assert_eq!(hours, 167);
         assert_eq!(limit, 100);
         assert_eq!(report.posts_read, 3);
         assert!((report.estimated_cost_usd - 0.015).abs() < 1e-9);

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -83,11 +83,11 @@ pub struct PulseArgs {
     #[arg(long, value_delimiter = ',')]
     pub accounts: Vec<String>,
 
-    /// Lookback window in hours (1-168)
+    /// Lookback window in hours (1-167)
     #[arg(long, default_value_t = 24)]
     pub hours: u32,
 
-    /// Max posts to read — each read costs ~$0.005 (1-100)
+    /// Max posts to read — each costs ~$0.005; X bills a minimum of 10 reads per call (1-100)
     #[arg(long, default_value_t = 20)]
     pub limit: usize,
 

--- a/src/cli/pulse.rs
+++ b/src/cli/pulse.rs
@@ -108,6 +108,14 @@ fn render_table(report: &PulseReport, now: DateTime<Utc>) -> String {
         "cost: {} posts read (≈ ${:.2} at ${}/read; X dedupes re-reads for 24h)",
         report.posts_read, report.estimated_cost_usd, X_COST_PER_READ_USD
     );
+    if report.posts_read as usize > report.posts.len() {
+        let _ = writeln!(
+            out,
+            "note: X returned {} post(s) (billed); {} shown after limit/filtering",
+            report.posts_read,
+            report.posts.len()
+        );
+    }
     let _ = writeln!(out, "\n{DISCLAIMER}");
     out
 }
@@ -155,6 +163,7 @@ mod tests {
         assert!(rendered.contains("Blackwell Ultra shipping at scale"));
         assert!(rendered.contains("cost: 1 posts read (≈ $0.01 at $0.005/read"));
         assert!(rendered.contains("Not financial advice"));
+        assert!(!rendered.contains("billed")); // read == shown -> no note
     }
 
     #[test]
@@ -162,6 +171,17 @@ mod tests {
         let rendered = render_table(&report(vec![]), at());
         assert!(rendered.contains("no posts from these accounts in the window"));
         assert!(rendered.contains("cost: 0 posts read"));
+        assert!(!rendered.contains("billed"));
+    }
+
+    #[test]
+    fn table_notes_when_billed_reads_exceed_shown_posts() {
+        let mut r = report(vec![post(1), post(2)]);
+        r.posts_read = 10;
+        r.estimated_cost_usd = 10.0 * X_COST_PER_READ_USD;
+        let rendered = render_table(&r, at());
+        assert!(rendered
+            .contains("note: X returned 10 post(s) (billed); 2 shown after limit/filtering"));
     }
 
     #[test]

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -332,11 +332,23 @@ pub async fn run(
     match outcome {
         InteractiveOutcome::Done(Outcome::Success) => ExitCode::SUCCESS,
         InteractiveOutcome::Done(Outcome::Failure) => ExitCode::FAILURE,
-        InteractiveOutcome::VerifyExisting => match source {
-            SetupSource::Reddit => setup_reddit(credentials).await,
-            SetupSource::Bluesky => setup_bluesky(credentials).await,
-            SetupSource::X => setup_x(credentials).await,
-        },
+        InteractiveOutcome::VerifyExisting => {
+            if let Some(confirm) = spec.pre_probe_confirm {
+                match read_visible(&mut io, confirm) {
+                    Ok(ans) if confirm_answer_proceeds(&ans) => {}
+                    Ok(_) => {
+                        println!("Aborted — nothing spent.");
+                        return ExitCode::FAILURE;
+                    }
+                    Err(_) => return ExitCode::FAILURE,
+                }
+            }
+            match source {
+                SetupSource::Reddit => setup_reddit(credentials).await,
+                SetupSource::Bluesky => setup_bluesky(credentials).await,
+                SetupSource::X => setup_x(credentials).await,
+            }
+        }
     }
 }
 
@@ -398,6 +410,11 @@ enum InteractiveOutcome {
 
 const MAX_ATTEMPTS: usize = 3;
 
+/// Shared decision for every "cost confirm" prompt (blank/y/yes -> proceed).
+fn confirm_answer_proceeds(ans: &str) -> bool {
+    matches!(ans.trim().to_lowercase().as_str(), "" | "y" | "yes")
+}
+
 async fn run_interactive<F, Fut>(
     io: &mut SetupIo<'_>,
     store: &dyn CredentialStore,
@@ -442,7 +459,7 @@ where
 
         if let Some(confirm) = spec.pre_probe_confirm {
             match read_visible(io, confirm) {
-                Ok(ans) if matches!(ans.trim().to_lowercase().as_str(), "" | "y" | "yes") => {}
+                Ok(ans) if confirm_answer_proceeds(&ans) => {}
                 Ok(_) => {
                     println!("Aborted — nothing was saved.");
                     return InteractiveOutcome::Done(Outcome::Failure);
@@ -1026,6 +1043,18 @@ mod tests {
             InteractiveOutcome::Done(Outcome::Failure)
         ));
         assert!(store.map.borrow().is_empty());
+    }
+
+    #[test]
+    fn confirm_answer_proceeds_accepts_blank_and_yes_variants() {
+        assert!(confirm_answer_proceeds(""));
+        assert!(confirm_answer_proceeds("y"));
+        assert!(confirm_answer_proceeds("Y"));
+        assert!(confirm_answer_proceeds("yes"));
+        assert!(confirm_answer_proceeds("YES"));
+        assert!(!confirm_answer_proceeds("n"));
+        assert!(!confirm_answer_proceeds("no"));
+        assert!(!confirm_answer_proceeds("x"));
     }
 
     #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -310,9 +310,10 @@ pub struct PulseToolArgs {
     /// holders or activist funds, sector journalists, macro figures. Omit only
     /// if the user asked for the default macro list.
     pub accounts: Option<Vec<String>>,
-    /// Lookback window in hours (default 24, max 168).
+    /// Lookback window in hours (default 24, max 167).
     pub hours_back: Option<u32>,
     /// Max posts to read — each read costs ~$0.005 (default 20, max 100).
+    /// X bills a minimum of 10 reads per call.
     pub limit: Option<usize>,
 }
 


### PR DESCRIPTION
Follow-up PR for the independent post-merge audit of #54 (CodeRabbit was quota-blocked on that PR, so a second fresh-eyes review ran instead and found these):

1. **Important — paid probe without a cost ack**: with X already configured, interactive `openintel setup x` → decline "Replace it? [y/N]" (incl. the default blank Enter) routed to verify and spent ~$0.05 with no confirmation. The verify-existing path is now gated by the same cost-confirm as the fresh-token path (`Aborted — nothing spent.` on decline); confirm-answer parsing extracted to a tested pure helper shared by both gates.
2. **10-read billing floor disclosed**: X bills a minimum of 10 reads per call (`max_results` floor), so `--limit 1` costs ≈$0.05 — now stated in `--limit` help, the README, and the MCP schema.
3. **167h cap**: `--hours 168` rode the exact edge of X's 7-day recent-search window (latency/truncation → 400 on a paid call). Cap is now 167 with the rationale in a comment; help/docs/live-test aligned.
4. **Billed-vs-shown note**: when X returns (and bills) more posts than the report displays (limit/filter), the table now says so instead of looking like an overcharge.

Tests: 165 lib + 3 integration green, clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)