### PR TITLE
feat(pulse): agent-curated keywords — match influencer language, not just cashtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ sentiment. X's API is pay-per-use (~$0.005 per post read, deduped over 24h), so
 the pulse is strictly opt-in: nothing calls X unless you run it.
 
 ```bash
-openintel setup x                                      # guided token setup (verify reads ≈ $0.05)
-openintel pulse NVDA --accounts jensenhuang,elonmusk   # ≤ 20 reads ≈ $0.10 max
+openintel setup x                                                       # guided token setup (verify reads ≈ $0.05)
+openintel pulse TSLA --accounts elonmusk --keywords tesla,robotaxi     # ≤ 20 reads ≈ $0.10 max
 ```
+
+Add `--keywords` with the company's own vocabulary — influencer posts say "Tesla", not "$TSLA".
 
 Note: X's API bills a minimum of 10 post reads per call, so even `--limit 1` costs ≈ $0.05.
 

--- a/src/adapters/sources/x/mod.rs
+++ b/src/adapters/sources/x/mod.rs
@@ -13,6 +13,8 @@ use crate::domain::ports::influencer_feed::InfluencerFeed;
 
 const SEARCH_URL: &str = "https://api.x.com/2/tweets/search/recent";
 const TIMEOUT_SECS: u64 = 10;
+/// X caps `search/recent` `query` at 512 chars on this tier.
+const MAX_QUERY_CHARS: usize = 512;
 
 /// Build the author-filtered search query.
 /// High-impact accounts write company language ("Tesla", "Robotaxi"), not
@@ -33,7 +35,14 @@ pub(crate) fn build_query(ticker: &Ticker, accounts: &[String], keywords: &[Stri
         .collect::<Vec<_>>()
         .join(" OR ");
     let mut terms = vec![format!("${}", ticker.as_str()), ticker.as_str().to_string()];
-    terms.extend(keywords.iter().map(|k| format!("\"{k}\"")));
+    terms.extend(keywords.iter().filter_map(|k| {
+        // Defense in depth: the application layer validates keywords, but this
+        // is a pub adapter — strip quote chars so a raw caller can't break the
+        // phrase grammar, and skip anything left empty.
+        let clean = k.replace('"', "");
+        let clean = clean.trim();
+        (!clean.is_empty()).then(|| format!("\"{clean}\""))
+    }));
     let terms = terms.join(" OR ");
     format!("({terms}) ({from}) -is:retweet")
 }
@@ -89,10 +98,18 @@ impl InfluencerFeed for XPulseSource {
             .to_rfc3339_opts(SecondsFormat::Secs, true);
         let max_results = limit.clamp(10, 100).to_string(); // API minimum is 10
 
+        let query = build_query(ticker, accounts, keywords);
+        if query.chars().count() > MAX_QUERY_CHARS {
+            return Err(fail(format!(
+                "query too long ({} chars, max {MAX_QUERY_CHARS}) — use fewer accounts/keywords",
+                query.chars().count()
+            )));
+        }
+
         // `.query()` is behind reqwest's un-enabled `query` feature; build manually.
         let mut url = reqwest::Url::parse(SEARCH_URL).map_err(|e| fail(format!("bad url: {e}")))?;
         url.query_pairs_mut()
-            .append_pair("query", &build_query(ticker, accounts, keywords))
+            .append_pair("query", &query)
             .append_pair("start_time", &start_time)
             .append_pair("max_results", &max_results)
             .append_pair("tweet.fields", "created_at,public_metrics")
@@ -204,8 +221,42 @@ mod tests {
     }
 
     #[test]
+    fn build_query_strips_embedded_quotes_and_skips_quote_only_keywords() {
+        // Defense in depth: application::pulse::normalize_keywords is trusted to
+        // reject `"`-bearing keywords, but XPulseSource is `pub` so an external
+        // caller could bypass it. build_query must not let a raw `"` break the
+        // phrase grammar.
+        let t = Ticker::parse("TSLA").unwrap();
+        let accounts = vec!["elonmusk".to_string()];
+        let keywords = vec!["ha\"ha".to_string(), "\"\"\"".to_string()];
+        assert_eq!(
+            build_query(&t, &accounts, &keywords),
+            "($TSLA OR TSLA OR \"haha\") (from:elonmusk) -is:retweet"
+        );
+    }
+
+    #[test]
     fn new_builds() {
         assert!(XPulseSource::new(secret("token")).is_ok());
+    }
+
+    #[tokio::test]
+    async fn pulse_rejects_oversized_query_before_any_network_io() {
+        // The 512-char check runs before the HTTP client is touched, so this
+        // is hermetic despite being a `#[tokio::test]` calling `.pulse()` —
+        // no request is ever sent.
+        let t = Ticker::parse("TSLA").unwrap();
+        let accounts = vec!["elonmusk".to_string()];
+        let keywords: Vec<String> = (0..60).map(|i| format!("keyword-number-{i}")).collect();
+        let src = XPulseSource::new(secret("token")).unwrap();
+        let err = src
+            .pulse(&t, &accounts, &keywords, 24, 10)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("query too long"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/adapters/sources/x/mod.rs
+++ b/src/adapters/sources/x/mod.rs
@@ -15,15 +15,22 @@ const SEARCH_URL: &str = "https://api.x.com/2/tweets/search/recent";
 const TIMEOUT_SECS: u64 = 10;
 
 /// Build the author-filtered search query.
+/// High-impact accounts write company language ("Tesla", "Robotaxi"), not
+/// cashtags — live-verified: 0 posts in 7 days from hourly-posting accounts
+/// on a cashtag-only query. The symbol terms (`$TICKER`, `TICKER`) are always
+/// present; caller-supplied keywords broaden recall onto that language.
 /// Contingency (spec): if pay-per-use rejects the `$` cashtag operator
 /// (HTTP 400 naming the operator in the live test), drop the `$` prefix here.
-pub(crate) fn build_query(ticker: &Ticker, accounts: &[String]) -> String {
+pub(crate) fn build_query(ticker: &Ticker, accounts: &[String], keywords: &[String]) -> String {
     let from = accounts
         .iter()
         .map(|a| format!("from:{a}"))
         .collect::<Vec<_>>()
         .join(" OR ");
-    format!("${} ({from}) -is:retweet", ticker.as_str())
+    let mut terms = vec![format!("${}", ticker.as_str()), ticker.as_str().to_string()];
+    terms.extend(keywords.iter().cloned());
+    let terms = terms.join(" OR ");
+    format!("({terms}) ({from}) -is:retweet")
 }
 
 fn fail(message: impl Into<String>) -> DomainError {
@@ -61,6 +68,7 @@ impl InfluencerFeed for XPulseSource {
         &self,
         ticker: &Ticker,
         accounts: &[String],
+        keywords: &[String],
         hours_back: u32,
         limit: usize,
     ) -> Result<PulseFetch, DomainError> {
@@ -79,7 +87,7 @@ impl InfluencerFeed for XPulseSource {
         // `.query()` is behind reqwest's un-enabled `query` feature; build manually.
         let mut url = reqwest::Url::parse(SEARCH_URL).map_err(|e| fail(format!("bad url: {e}")))?;
         url.query_pairs_mut()
-            .append_pair("query", &build_query(ticker, accounts))
+            .append_pair("query", &build_query(ticker, accounts, keywords))
             .append_pair("start_time", &start_time)
             .append_pair("max_results", &max_results)
             .append_pair("tweet.fields", "created_at,public_metrics")
@@ -141,11 +149,25 @@ mod tests {
         let t = Ticker::parse("NVDA").unwrap();
         let accounts = vec!["jensenhuang".to_string(), "elonmusk".to_string()];
         assert_eq!(
-            build_query(&t, &accounts),
-            "$NVDA (from:jensenhuang OR from:elonmusk) -is:retweet"
+            build_query(&t, &accounts, &[]),
+            "($NVDA OR NVDA) (from:jensenhuang OR from:elonmusk) -is:retweet"
         );
         let one = vec!["WhiteHouse".to_string()];
-        assert_eq!(build_query(&t, &one), "$NVDA (from:WhiteHouse) -is:retweet");
+        assert_eq!(
+            build_query(&t, &one, &[]),
+            "($NVDA OR NVDA) (from:WhiteHouse) -is:retweet"
+        );
+    }
+
+    #[test]
+    fn build_query_appends_keywords_after_symbol_terms() {
+        let t = Ticker::parse("TSLA").unwrap();
+        let accounts = vec!["elonmusk".to_string()];
+        let keywords = vec!["Tesla".to_string(), "Robotaxi".to_string()];
+        assert_eq!(
+            build_query(&t, &accounts, &keywords),
+            "($TSLA OR TSLA OR Tesla OR Robotaxi) (from:elonmusk) -is:retweet"
+        );
     }
 
     #[test]
@@ -163,7 +185,7 @@ mod tests {
             .map(|s| s.to_string())
             .collect();
         let fetch = src
-            .pulse(&Ticker::parse("AAPL").unwrap(), &accounts, 167, 10)
+            .pulse(&Ticker::parse("AAPL").unwrap(), &accounts, &[], 167, 10)
             .await
             .unwrap(); // cashtag-operator contingency check: a 400 here means switch build_query to bare keyword
         for p in &fetch.posts {

--- a/src/adapters/sources/x/mod.rs
+++ b/src/adapters/sources/x/mod.rs
@@ -18,7 +18,12 @@ const TIMEOUT_SECS: u64 = 10;
 /// High-impact accounts write company language ("Tesla", "Robotaxi"), not
 /// cashtags — live-verified: 0 posts in 7 days from hourly-posting accounts
 /// on a cashtag-only query. The symbol terms (`$TICKER`, `TICKER`) are always
-/// present; caller-supplied keywords broaden recall onto that language.
+/// present, bare (trusted — sourced from `Ticker`, not free text). Caller
+/// -supplied keywords broaden recall onto that language and are each wrapped
+/// in `"…"`: X's grammar treats a quoted string as a literal phrase, which
+/// neutralizes operator interpretation (a keyword starting with `-` can't be
+/// read as the NOT operator, `OR`/`from:` inside a keyword are just words)
+/// and, as a side effect, allows multi-word phrases like "General Motors".
 /// Contingency (spec): if pay-per-use rejects the `$` cashtag operator
 /// (HTTP 400 naming the operator in the live test), drop the `$` prefix here.
 pub(crate) fn build_query(ticker: &Ticker, accounts: &[String], keywords: &[String]) -> String {
@@ -28,7 +33,7 @@ pub(crate) fn build_query(ticker: &Ticker, accounts: &[String], keywords: &[Stri
         .collect::<Vec<_>>()
         .join(" OR ");
     let mut terms = vec![format!("${}", ticker.as_str()), ticker.as_str().to_string()];
-    terms.extend(keywords.iter().cloned());
+    terms.extend(keywords.iter().map(|k| format!("\"{k}\"")));
     let terms = terms.join(" OR ");
     format!("({terms}) ({from}) -is:retweet")
 }
@@ -160,13 +165,41 @@ mod tests {
     }
 
     #[test]
-    fn build_query_appends_keywords_after_symbol_terms() {
+    fn build_query_appends_quoted_keywords_after_symbol_terms() {
         let t = Ticker::parse("TSLA").unwrap();
         let accounts = vec!["elonmusk".to_string()];
         let keywords = vec!["Tesla".to_string(), "Robotaxi".to_string()];
         assert_eq!(
             build_query(&t, &accounts, &keywords),
-            "($TSLA OR TSLA OR Tesla OR Robotaxi) (from:elonmusk) -is:retweet"
+            "($TSLA OR TSLA OR \"Tesla\" OR \"Robotaxi\") (from:elonmusk) -is:retweet"
+        );
+    }
+
+    #[test]
+    fn build_query_quotes_leading_dash_keyword_so_it_cannot_act_as_not_operator() {
+        // Regression: a bare `-recall` inside the OR group is X's NOT
+        // operator and matches nearly everything, collapsing the ticker
+        // filter. Quoting makes it a literal phrase instead.
+        let t = Ticker::parse("TSLA").unwrap();
+        let accounts = vec!["elonmusk".to_string()];
+        let keywords = vec!["-recall".to_string()];
+        assert_eq!(
+            build_query(&t, &accounts, &keywords),
+            "($TSLA OR TSLA OR \"-recall\") (from:elonmusk) -is:retweet"
+        );
+    }
+
+    #[test]
+    fn build_query_supports_multi_word_keyword_phrases() {
+        // The motivating use case: "General Motors" is dropped by the
+        // charset check if bare (spaces are invalid unquoted operators) but
+        // survives as one quoted literal phrase.
+        let t = Ticker::parse("GM").unwrap();
+        let accounts = vec!["elonmusk".to_string()];
+        let keywords = vec!["General Motors".to_string()];
+        assert_eq!(
+            build_query(&t, &accounts, &keywords),
+            "($GM OR GM OR \"General Motors\") (from:elonmusk) -is:retweet"
         );
     }
 

--- a/src/application/pulse.rs
+++ b/src/application/pulse.rs
@@ -10,6 +10,14 @@ fn is_valid_handle(a: &str) -> bool {
     !a.is_empty() && a.len() <= 15 && a.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
+/// Keyword charset: letters, digits, underscore, hyphen, dot, max 30 chars.
+fn is_valid_keyword(k: &str) -> bool {
+    !k.is_empty()
+        && k.len() <= 30
+        && k.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+}
+
 /// X pay-per-use price per post read (docs.x.com pricing, 2026-02 launch).
 pub const X_COST_PER_READ_USD: f64 = 0.005;
 
@@ -55,9 +63,32 @@ pub fn normalize_accounts(raw: &[String]) -> Result<Vec<String>, DomainError> {
     Ok(cleaned)
 }
 
+/// Trim each keyword; drop empties. Empty raw input -> `Ok(vec![])` — keywords
+/// are optional, there's no default list. If raw was non-empty but every
+/// keyword was invalid, error rather than silently dropping the caller's
+/// intent to broaden the query.
+pub fn normalize_keywords(raw: &[String]) -> Result<Vec<String>, DomainError> {
+    if raw.is_empty() {
+        return Ok(Vec::new());
+    }
+    let cleaned: Vec<String> = raw
+        .iter()
+        .map(|k| k.trim().to_string())
+        .filter(|k| is_valid_keyword(k))
+        .collect();
+    if cleaned.is_empty() {
+        return Err(DomainError::SourceFailure {
+            name: "x".into(),
+            message: format!("no valid keywords in {raw:?} (letters, digits, _ . -, max 30 chars)"),
+        });
+    }
+    Ok(cleaned)
+}
+
 pub async fn pulse(
     ticker_raw: &str,
     accounts_raw: &[String],
+    keywords_raw: &[String],
     hours_back: u32,
     limit: usize,
     feed: &dyn InfluencerFeed,
@@ -65,14 +96,18 @@ pub async fn pulse(
 ) -> Result<PulseReport, DomainError> {
     let ticker = Ticker::parse(ticker_raw)?;
     let accounts = normalize_accounts(accounts_raw)?;
+    let keywords = normalize_keywords(keywords_raw)?;
     let hours_back = hours_back.clamp(1, MAX_HOURS_BACK);
     let limit = limit.clamp(1, MAX_PULSE_LIMIT);
-    let fetch = feed.pulse(&ticker, &accounts, hours_back, limit).await?;
+    let fetch = feed
+        .pulse(&ticker, &accounts, &keywords, hours_back, limit)
+        .await?;
     let posts = fetch.posts;
     let posts_read = fetch.posts_returned;
     Ok(PulseReport {
         ticker: ticker.as_str().to_string(),
         accounts,
+        keywords,
         hours_back,
         posts,
         posts_read,
@@ -93,8 +128,8 @@ mod tests {
         Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap()
     }
 
-    /// (ticker, accounts, hours_back, limit) the fake was called with.
-    type SeenCall = (String, Vec<String>, u32, usize);
+    /// (ticker, accounts, keywords, hours_back, limit) the fake was called with.
+    type SeenCall = (String, Vec<String>, Vec<String>, u32, usize);
 
     /// Records what it was called with; returns `n` canned posts and
     /// `posts_returned` (defaults to `n` via `fake()`, overridable via
@@ -111,12 +146,14 @@ mod tests {
             &self,
             ticker: &Ticker,
             accounts: &[String],
+            keywords: &[String],
             hours_back: u32,
             limit: usize,
         ) -> Result<PulseFetch, DomainError> {
             *self.seen.lock().unwrap() = Some((
                 ticker.as_str().to_string(),
                 accounts.to_vec(),
+                keywords.to_vec(),
                 hours_back,
                 limit,
             ));
@@ -187,13 +224,38 @@ mod tests {
         assert!(err.to_string().contains("no valid X handles"));
     }
 
+    #[test]
+    fn normalize_keywords_trims_and_drops_invalid() {
+        let raw = vec![
+            "  Tesla ".to_string(),
+            "robo taxi".to_string(), // space -> invalid
+            "FSD".to_string(),
+        ];
+        assert_eq!(
+            normalize_keywords(&raw).unwrap(),
+            vec!["Tesla".to_string(), "FSD".to_string()]
+        );
+        assert_eq!(normalize_keywords(&[]).unwrap(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn normalize_keywords_all_invalid_nonempty_errors() {
+        let raw = vec!["robo taxi".to_string(), "  ".to_string()];
+        let err = normalize_keywords(&raw).unwrap_err();
+        assert!(matches!(err, DomainError::SourceFailure { ref name, .. } if name == "x"));
+        assert!(err.to_string().contains("no valid keywords"));
+    }
+
     #[tokio::test]
     async fn pulse_clamps_and_computes_cost() {
         let feed = fake(3);
-        let report = pulse("nvda", &[], 500, 900, &feed, at()).await.unwrap();
-        let (ticker, accounts, hours, limit) = feed.seen.lock().unwrap().clone().unwrap();
+        let report = pulse("nvda", &[], &[], 500, 900, &feed, at())
+            .await
+            .unwrap();
+        let (ticker, accounts, keywords, hours, limit) = feed.seen.lock().unwrap().clone().unwrap();
         assert_eq!(ticker, "NVDA"); // Ticker::parse normalizes
         assert_eq!(accounts, DEFAULT_PULSE_ACCOUNTS.to_vec());
+        assert!(keywords.is_empty());
         assert_eq!(hours, 167);
         assert_eq!(limit, 100);
         assert_eq!(report.posts_read, 3);
@@ -206,7 +268,7 @@ mod tests {
         // Client-side truncation/skips kept 2 posts, but X returned (and
         // billed) 10 — e.g. the max_results floor of 10 with a low limit.
         let feed = fake_with_returned(2, 10);
-        let report = pulse("AAPL", &[], 24, 2, &feed, at()).await.unwrap();
+        let report = pulse("AAPL", &[], &[], 24, 2, &feed, at()).await.unwrap();
         assert_eq!(report.posts.len(), 2);
         assert_eq!(report.posts_read, 10);
         assert!((report.estimated_cost_usd - 0.05).abs() < 1e-9);
@@ -215,10 +277,10 @@ mod tests {
     #[tokio::test]
     async fn pulse_clamps_low_bounds_and_zero_posts_is_ok() {
         let feed = fake(0);
-        let report = pulse("AAPL", &["a".into()], 0, 0, &feed, at())
+        let report = pulse("AAPL", &["a".into()], &[], 0, 0, &feed, at())
             .await
             .unwrap();
-        let (_, _, hours, limit) = feed.seen.lock().unwrap().clone().unwrap();
+        let (_, _, _, hours, limit) = feed.seen.lock().unwrap().clone().unwrap();
         assert_eq!(hours, 1);
         assert_eq!(limit, 1);
         assert_eq!(report.posts_read, 0);
@@ -228,7 +290,7 @@ mod tests {
     #[tokio::test]
     async fn pulse_rejects_all_invalid_handles_without_falling_back_to_defaults() {
         let feed = fake(0);
-        let err = pulse("AAPL", &["bad handle".into()], 24, 20, &feed, at())
+        let err = pulse("AAPL", &["bad handle".into()], &[], 24, 20, &feed, at())
             .await
             .unwrap_err();
         assert!(err.to_string().contains("no valid X handles"));
@@ -236,8 +298,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pulse_rejects_all_invalid_keywords_without_falling_back() {
+        let feed = fake(0);
+        let err = pulse(
+            "AAPL",
+            &["a".into()],
+            &["robo taxi".into()],
+            24,
+            20,
+            &feed,
+            at(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("no valid keywords"));
+        assert!(feed.seen.lock().unwrap().is_none()); // never reached the paid call
+    }
+
+    #[tokio::test]
     async fn pulse_rejects_bad_ticker() {
         let feed = fake(0);
-        assert!(pulse("$$$", &[], 24, 20, &feed, at()).await.is_err());
+        assert!(pulse("$$$", &[], &[], 24, 20, &feed, at()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn pulse_threads_keywords_to_feed_and_report() {
+        let feed = fake(1);
+        let report = pulse(
+            "TSLA",
+            &["elonmusk".into()],
+            &["Tesla".into(), "Robotaxi".into()],
+            24,
+            20,
+            &feed,
+            at(),
+        )
+        .await
+        .unwrap();
+        let (_, _, keywords, _, _) = feed.seen.lock().unwrap().clone().unwrap();
+        assert_eq!(keywords, vec!["Tesla".to_string(), "Robotaxi".to_string()]);
+        assert_eq!(
+            report.keywords,
+            vec!["Tesla".to_string(), "Robotaxi".to_string()]
+        );
     }
 }

--- a/src/application/pulse.rs
+++ b/src/application/pulse.rs
@@ -10,12 +10,15 @@ fn is_valid_handle(a: &str) -> bool {
     !a.is_empty() && a.len() <= 15 && a.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-/// Keyword charset: letters, digits, underscore, hyphen, dot, max 30 chars.
+/// Keyword charset: letters, digits, spaces, underscore, hyphen, dot, max 30
+/// chars, no double-quote (the adapter wraps every keyword in `"…"` to make
+/// it a literal phrase in X's query grammar — a keyword containing `"` could
+/// break out of that quoting).
 fn is_valid_keyword(k: &str) -> bool {
     !k.is_empty()
         && k.len() <= 30
         && k.chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+            .all(|c| c.is_ascii_alphanumeric() || c == ' ' || c == '_' || c == '-' || c == '.')
 }
 
 /// X pay-per-use price per post read (docs.x.com pricing, 2026-02 launch).
@@ -63,10 +66,13 @@ pub fn normalize_accounts(raw: &[String]) -> Result<Vec<String>, DomainError> {
     Ok(cleaned)
 }
 
-/// Trim each keyword; drop empties. Empty raw input -> `Ok(vec![])` — keywords
-/// are optional, there's no default list. If raw was non-empty but every
-/// keyword was invalid, error rather than silently dropping the caller's
-/// intent to broaden the query.
+/// Trim each keyword; drop empties/invalid (see `is_valid_keyword` — spaces
+/// are allowed so multi-word names like "General Motors" survive; the
+/// adapter quotes every keyword as a literal phrase, so charset-safe
+/// characters like a leading `-` can't be interpreted as a query operator).
+/// Empty raw input -> `Ok(vec![])` — keywords are optional, there's no
+/// default list. If raw was non-empty but every keyword was invalid, error
+/// rather than silently dropping the caller's intent to broaden the query.
 pub fn normalize_keywords(raw: &[String]) -> Result<Vec<String>, DomainError> {
     if raw.is_empty() {
         return Ok(Vec::new());
@@ -79,7 +85,9 @@ pub fn normalize_keywords(raw: &[String]) -> Result<Vec<String>, DomainError> {
     if cleaned.is_empty() {
         return Err(DomainError::SourceFailure {
             name: "x".into(),
-            message: format!("no valid keywords in {raw:?} (letters, digits, _ . -, max 30 chars)"),
+            message: format!(
+                "no valid keywords in {raw:?} (letters, digits, spaces, _ . -, max 30 chars)"
+            ),
         });
     }
     Ok(cleaned)
@@ -228,7 +236,7 @@ mod tests {
     fn normalize_keywords_trims_and_drops_invalid() {
         let raw = vec![
             "  Tesla ".to_string(),
-            "robo taxi".to_string(), // space -> invalid
+            "say \"hi\"".to_string(), // quote char -> invalid
             "FSD".to_string(),
         ];
         assert_eq!(
@@ -239,8 +247,37 @@ mod tests {
     }
 
     #[test]
+    fn normalize_keywords_keeps_multi_word_names() {
+        // The motivating use case: multi-word company names must survive —
+        // the adapter quotes them as a literal phrase downstream.
+        let raw = vec!["  General Motors ".to_string()];
+        assert_eq!(
+            normalize_keywords(&raw).unwrap(),
+            vec!["General Motors".to_string()]
+        );
+    }
+
+    #[test]
+    fn normalize_keywords_keeps_leading_dash() {
+        // A leading `-` is charset-safe now that the adapter quotes every
+        // keyword — it can no longer be interpreted as X's NOT operator.
+        let raw = vec!["-recall".to_string()];
+        assert_eq!(
+            normalize_keywords(&raw).unwrap(),
+            vec!["-recall".to_string()]
+        );
+    }
+
+    #[test]
+    fn normalize_keywords_drops_tab_and_emoji() {
+        let raw = vec!["ta\tb".to_string(), "🚀rocket".to_string()];
+        let err = normalize_keywords(&raw).unwrap_err();
+        assert!(err.to_string().contains("no valid keywords"));
+    }
+
+    #[test]
     fn normalize_keywords_all_invalid_nonempty_errors() {
-        let raw = vec!["robo taxi".to_string(), "  ".to_string()];
+        let raw = vec!["say \"hi\"".to_string(), "  ".to_string()];
         let err = normalize_keywords(&raw).unwrap_err();
         assert!(matches!(err, DomainError::SourceFailure { ref name, .. } if name == "x"));
         assert!(err.to_string().contains("no valid keywords"));
@@ -303,7 +340,7 @@ mod tests {
         let err = pulse(
             "AAPL",
             &["a".into()],
-            &["robo taxi".into()],
+            &["say \"hi\"".into()],
             24,
             20,
             &feed,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -83,8 +83,9 @@ pub struct PulseArgs {
     #[arg(long, value_delimiter = ',')]
     pub accounts: Vec<String>,
 
-    /// Extra search terms in the accounts' own language, comma-separated
-    /// (e.g. tesla,robotaxi) — cashtags are rare in influencer posts
+    /// Extra search terms in the accounts' own language, comma-separated;
+    /// phrases allowed (e.g. tesla,robotaxi,General Motors) — cashtags are
+    /// rare in influencer posts
     #[arg(long, value_delimiter = ',')]
     pub keywords: Vec<String>,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -83,6 +83,11 @@ pub struct PulseArgs {
     #[arg(long, value_delimiter = ',')]
     pub accounts: Vec<String>,
 
+    /// Extra search terms in the accounts' own language, comma-separated
+    /// (e.g. tesla,robotaxi) — cashtags are rare in influencer posts
+    #[arg(long, value_delimiter = ',')]
+    pub keywords: Vec<String>,
+
     /// Lookback window in hours (1-167)
     #[arg(long, default_value_t = 24)]
     pub hours: u32,
@@ -213,6 +218,25 @@ mod tests {
             panic!("expected pulse command");
         };
         assert!(args.accounts.is_empty());
+        assert!(args.keywords.is_empty());
         assert_eq!(args.hours, 24);
+    }
+
+    #[test]
+    fn parses_pulse_with_keywords() {
+        let cli = Cli::try_parse_from([
+            "openintel",
+            "pulse",
+            "TSLA",
+            "--accounts",
+            "elonmusk",
+            "--keywords",
+            "tesla,robotaxi",
+        ])
+        .unwrap();
+        let Command::Pulse(args) = cli.command else {
+            panic!("expected pulse command");
+        };
+        assert_eq!(args.keywords, vec!["tesla", "robotaxi"]);
     }
 }

--- a/src/cli/pulse.rs
+++ b/src/cli/pulse.rs
@@ -29,6 +29,7 @@ pub async fn run(args: &PulseArgs, credentials: &Credentials) -> Result<String, 
     let report = crate::application::pulse::pulse(
         &args.ticker,
         &args.accounts,
+        &args.keywords,
         args.hours,
         args.limit,
         &feed,
@@ -79,6 +80,9 @@ fn render_table(report: &PulseReport, now: DateTime<Utc>) -> String {
         report.hours_back,
         report.accounts.join(", ")
     );
+    if !report.keywords.is_empty() {
+        let _ = writeln!(out, "keywords: {}", report.keywords.join(", "));
+    }
     let _ = writeln!(
         out,
         "generated: {}\n",
@@ -136,6 +140,7 @@ mod tests {
         PulseReport {
             ticker: "NVDA".into(),
             accounts: vec!["jensenhuang".into(), "elonmusk".into()],
+            keywords: vec![],
             hours_back: 24,
             posts,
             posts_read,
@@ -164,6 +169,20 @@ mod tests {
         assert!(rendered.contains("cost: 1 posts read (≈ $0.01 at $0.005/read"));
         assert!(rendered.contains("Not financial advice"));
         assert!(!rendered.contains("billed")); // read == shown -> no note
+    }
+
+    #[test]
+    fn table_shows_keywords_line_when_present() {
+        let mut r = report(vec![post(3)]);
+        r.keywords = vec!["Tesla".into(), "Robotaxi".into()];
+        let rendered = render_table(&r, at());
+        assert!(rendered.contains("keywords: Tesla, Robotaxi"));
+    }
+
+    #[test]
+    fn table_omits_keywords_line_when_empty() {
+        let rendered = render_table(&report(vec![post(3)]), at());
+        assert!(!rendered.contains("keywords:"));
     }
 
     #[test]

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -655,7 +655,7 @@ async fn probe_x(bearer: SecretString) -> Result<usize, DomainError> {
         .iter()
         .map(|s| s.to_string())
         .collect();
-    let fetch = feed.pulse(&ticker, &accounts, 24, 10).await?;
+    let fetch = feed.pulse(&ticker, &accounts, &[], 24, 10).await?;
     Ok(fetch.posts.len()) // display count for the "pulled N posts" message, not billing count
 }
 

--- a/src/domain/entities/pulse.rs
+++ b/src/domain/entities/pulse.rs
@@ -29,6 +29,7 @@ pub struct PulseFetch {
 pub struct PulseReport {
     pub ticker: String,
     pub accounts: Vec<String>,
+    pub keywords: Vec<String>,
     pub hours_back: u32,
     pub posts: Vec<PulsePost>,
     pub posts_read: u32,

--- a/src/domain/ports/influencer_feed.rs
+++ b/src/domain/ports/influencer_feed.rs
@@ -10,10 +10,14 @@ use crate::domain::error::DomainError;
 pub trait InfluencerFeed: Send + Sync {
     /// `posts_returned` on the result drives cost accounting — it's what the
     /// upstream API billed, not necessarily `posts.len()`.
+    /// `keywords` broadens the text match beyond the ticker symbol — the
+    /// caller supplies company-language terms (e.g. "Tesla" for TSLA), since
+    /// high-impact accounts write those, not cashtags.
     async fn pulse(
         &self,
         ticker: &Ticker,
         accounts: &[String],
+        keywords: &[String],
         hours_back: u32,
         limit: usize,
     ) -> Result<PulseFetch, DomainError>;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -99,8 +99,11 @@ impl OpenIntelServer {
                        actually matter for this ticker — CEO/founder, major institutional holders \
                        or activist funds, respected sector journalists, and market-moving macro \
                        figures — then propose the account list and estimated max cost \
-                       (limit × $0.005) to the user and get their confirmation. Omit `accounts` \
-                       only if the user asks for the default macro list. Returned posts are \
+                       (limit × $0.005) to the user and get their confirmation. Also propose \
+                       company-language keywords (e.g. \"Tesla\" for TSLA) — these accounts \
+                       rarely write cashtags, so symbol-only matching misses their posts. \
+                       Omit `accounts` only if the user asks for the default macro list. \
+                       Returned posts are \
                        catalyst events — reason about them directly; do not treat them as a \
                        sentiment sample. Read-only — does not trade."
     )]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -99,7 +99,8 @@ impl OpenIntelServer {
                        actually matter for this ticker — CEO/founder, major institutional holders \
                        or activist funds, respected sector journalists, and market-moving macro \
                        figures — then propose the account list and estimated max cost \
-                       (limit × $0.005) to the user and get their confirmation. Also propose \
+                       (max(limit, 10) × $0.005 — X bills a minimum of 10 reads) to the user \
+                       and get their confirmation. Also propose \
                        company-language keywords (e.g. \"Tesla\" for TSLA) — these accounts \
                        rarely write cashtags, so symbol-only matching misses their posts. \
                        Omit `accounts` only if the user asks for the default macro list. \

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -312,7 +312,7 @@ pub struct PulseToolArgs {
     pub accounts: Option<Vec<String>>,
     /// Company-language search terms (e.g. ["Tesla","Robotaxi"] for TSLA) —
     /// high-impact accounts rarely write cashtags, so propose these alongside
-    /// accounts.
+    /// accounts. Multi-word phrases are fine (e.g. "General Motors").
     pub keywords: Option<Vec<String>>,
     /// Lookback window in hours (default 24, max 167).
     pub hours_back: Option<u32>,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -310,6 +310,10 @@ pub struct PulseToolArgs {
     /// holders or activist funds, sector journalists, macro figures. Omit only
     /// if the user asked for the default macro list.
     pub accounts: Option<Vec<String>>,
+    /// Company-language search terms (e.g. ["Tesla","Robotaxi"] for TSLA) —
+    /// high-impact accounts rarely write cashtags, so propose these alongside
+    /// accounts.
+    pub keywords: Option<Vec<String>>,
     /// Lookback window in hours (default 24, max 167).
     pub hours_back: Option<u32>,
     /// Max posts to read — each read costs ~$0.005 (default 20, max 100).
@@ -329,9 +333,11 @@ pub async fn run_pulse(
     feed: &dyn InfluencerFeed,
 ) -> Result<PulseOutput, DomainError> {
     let accounts = args.accounts.unwrap_or_default();
+    let keywords = args.keywords.unwrap_or_default();
     let report = pulse_app::pulse(
         &args.ticker,
         &accounts,
+        &keywords,
         args.hours_back.unwrap_or(24),
         args.limit.unwrap_or(20),
         feed,
@@ -538,6 +544,7 @@ mod tests {
                 &self,
                 _t: &Ticker,
                 _a: &[String],
+                _k: &[String],
                 _h: u32,
                 _l: usize,
             ) -> Result<PulseFetch, DomainError> {
@@ -558,6 +565,7 @@ mod tests {
             PulseToolArgs {
                 ticker: "NVDA".into(),
                 accounts: Some(vec!["@jensenhuang".into()]),
+                keywords: None,
                 hours_back: None,
                 limit: None,
             },
@@ -568,5 +576,56 @@ mod tests {
         assert!(out.summary.contains("⚡ 1 high-impact post(s)"));
         assert_eq!(out.report.accounts, vec!["jensenhuang"]); // @-stripped
         assert!(out.disclaimer.contains("Not financial advice"));
+    }
+
+    #[tokio::test]
+    async fn run_pulse_threads_keywords_to_feed_and_report() {
+        use crate::domain::entities::pulse::{PulseFetch, PulsePost};
+        use crate::domain::entities::social_post::PostText;
+        use crate::domain::entities::ticker::Ticker;
+        use crate::domain::ports::influencer_feed::InfluencerFeed;
+        use async_trait::async_trait;
+
+        struct KeywordSpy;
+        #[async_trait]
+        impl InfluencerFeed for KeywordSpy {
+            async fn pulse(
+                &self,
+                _t: &Ticker,
+                _a: &[String],
+                keywords: &[String],
+                _h: u32,
+                _l: usize,
+            ) -> Result<PulseFetch, DomainError> {
+                assert_eq!(keywords, ["Tesla".to_string(), "Robotaxi".to_string()]);
+                Ok(PulseFetch {
+                    posts: vec![PulsePost {
+                        id: "1".into(),
+                        author: "elonmusk".into(),
+                        text: PostText::parse("robotaxi launch").unwrap(),
+                        created_at: chrono::Utc::now(),
+                        engagement: 5,
+                    }],
+                    posts_returned: 1,
+                })
+            }
+        }
+
+        let out = run_pulse(
+            PulseToolArgs {
+                ticker: "TSLA".into(),
+                accounts: Some(vec!["elonmusk".into()]),
+                keywords: Some(vec!["Tesla".into(), "Robotaxi".into()]),
+                hours_back: None,
+                limit: None,
+            },
+            &KeywordSpy,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            out.report.keywords,
+            vec!["Tesla".to_string(), "Robotaxi".to_string()]
+        );
     }
 }


### PR DESCRIPTION
## What

Live validation of X Pulse exposed a recall hole: the cashtag-only query (`$TSLA (from:…)`) returned **zero posts in 7 days** from accounts that post hourly — high-impact accounts write "Tesla", never "$TSLA". Fixes:

- The query now always includes the bare symbol: `($TSLA OR TSLA) (from:…) -is:retweet`.
- New agent/user-curated `keywords`: `--keywords tesla,robotaxi,General Motors` (CLI) / `keywords` (MCP) — the agent that researches accounts also proposes the company's own vocabulary. The MCP curation contract grew that sentence.
- **Every keyword is rendered as a quoted literal phrase** — this both neutralizes operator injection (a bare leading-`-` keyword would have become X's NOT operator and collapsed the ticker filter into a firehose; caught in review, regression-tested) and enables multi-word names.
- Validation mirrors handles: charset-checked (quotes banned — closes the phrase-escape hole), invalid dropped, all-invalid-from-non-empty errors instead of silently spending on the wrong query. `PulseReport` serializes the effective keywords for transparency.

Money invariants untouched (cost accounting, 10-read floor disclosure, confirm gates, opt-in posture — re-verified in review).

## Tests

179 lib + 3 integration green (incl. operator-injection + multi-word-phrase regressions), clippy `-D warnings` + fmt clean.

Review trail: implementer → reviewer caught the Critical operator-injection + the multi-word gap → joint quoting fix → re-review approved with zero remaining findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional keyword filtering to X Pulse searches.
  * Added `--keywords` support to the command line and MCP tool.
  * Pulse reports now display the keywords used for filtering.
  * Keywords support company vocabulary, including multi-word phrases.

* **Documentation**
  * Updated X Pulse examples and guidance to demonstrate keyword usage.
  * Clarified that keywords should use company terms rather than cashtags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->