### PR TITLE
feat(dip): dip_scan — gated dip-setup scanner with margin-aware sizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1346,7 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
+ "chrono-tz",
  "clap",
  "futures",
  "keyring",
@@ -1383,6 +1394,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2028,6 +2057,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ secrecy = "0.10"
 async-trait = "0.1"
 thiserror = "2"
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 futures = "0.3"
 rmcp = { version = "2", features = ["transport-io"] }
 schemars = "1"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,41 @@ your ticker and confirm the cost with you before spending.
 
 Turn a trade idea into exact numbers: `openintel risk NVDA --budget 200` returns an ATR(14)-based stop, the whole-share size that caps a stop-out at your budget, max loss, and 1R/2R/3R reference levels. Deterministic math over free Yahoo daily bars — it never recommends taking a trade. Also exposed to agents as the `risk_frame` MCP tool, whose contract requires presenting the numbers and getting your explicit approval before any execution step. Run intraday, the entry default is the live price and ATR includes today's still-forming bar — re-run near the close for settled numbers.
 
+## Dip scan (gated setups, not picks)
+
+`openintel dip` pulls the day's 100 biggest losers (Yahoo's keyless screener), applies a
+quality floor (≥ $5, ≥ $500M cap, ≥ 1M avg volume, listed ≥ 180 days, no OTC) and a drop
+band (−15%…−4% — the catastrophic tail is excluded by design), then grades survivors
+through **hard gates** into a tiered verdict:
+
+| Verdict | Meaning |
+|---|---|
+| `no_setup` | Eligibility failed or a catalyst was CONFIRMED (same-day SEC 8-K/6-K/424B5/S-3/FWP via EDGAR, or a catalyst-keyword headline) — evidence shown |
+| `watch` | Eligible, no confirmed catalyst, but ≥ 1 gate failed or could not be verified (**unverifiable evidence fails closed**) |
+| `high_confidence` | ALL gates pass post-close: no filing, no catalyst headline, idiosyncratic vs SPY (≤ −3% excess), closed in the upper half of the day's range, score ≥ 65 |
+
+`high_confidence` means **conformance to the setup template — never probability of
+profit**. Zero candidates is a normal result. Intraday runs always cap at `watch` (the day
+bar isn't final); run after the close for real verdicts. The composite score's weights are
+**v0 and unvalidated** — every scan appends a JSONL line to `~/.openintel/dip_journal.jsonl`
+(opt out with `--no-journal`) so they can be graded against forward returns later; a
+`dip --review` grader is the named follow-up.
+
+```bash
+openintel dip                                 # scan the losers universe
+openintel dip NVDA                            # one ticker (floor unverifiable -> caps at watch)
+openintel dip --equity 25000 --leverage 2     # adds ATR-stop sizing + margin mechanics
+```
+
+With `--equity`, each candidate gets a risk frame (1% of equity to a 2×ATR stop by
+default) plus margin mechanics: buying-power cap, borrowed amount, margin-call price and
+its distance, and a warning when the margin call would fire **before** your stop.
+Overnight Reg-T caps leverage at 2x; `--intraday-bp` unlocks 4x with a
+not-holdable-overnight note. Single-position model; interest not modeled.
+
+Data: Yahoo screener + news (keyless, unofficial — failure mode is a clean error) and SEC
+EDGAR (keyless, official; identify yourself via `OPENINTEL_SEC_CONTACT` if you fork this).
+
 ## Use with an AI agent (MCP)
 
 OpenIntel can run as a local **MCP server** so an AI agent can consult its analysis while
@@ -128,6 +163,7 @@ Tools exposed (all **read-only** — OpenIntel never places trades):
 | `compare_tickers` | Rank a set by `crowding` / `speculation_index` / `net_sentiment` / `divergence` |
 | `list_sources` | Which data sources are available |
 | `risk_frame` | ATR stop + budget-capped size + R targets for one trade idea |
+| `dip_scan` | Day's biggest losers → gated dip-setup verdicts (`no_setup`/`watch`/`high_confidence`), optional margin-aware sizing; pass `ticker` for one symbol |
 
 ### ⚠️ Risk & responsibility — read before connecting a broker
 

--- a/docs/superpowers/plans/2026-08-15-dip-scan.md
+++ b/docs/superpowers/plans/2026-08-15-dip-scan.md
@@ -1,0 +1,135 @@
+# dip_scan Implementation Plan (rev 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `openintel dip [--equity N --leverage K]` + MCP `dip_scan`: pull the day's 100 biggest losers, apply a quality floor + drop band, and evaluate survivors through hard boolean gates (no same-day SEC filing, no catalyst headlines, idiosyncratic vs index, buyers-at-close) plus a v0 ranking score. Verdict is tiered — `no_setup` (the default; most days produce zero candidates and that is correct output), `watch`, `high_confidence` — where gates decide and score only ranks. Same signal is exposed per-ticker inside `analyze_ticker`. Flags setup conformance — never predicts outcomes, never advises entry. READ-ONLY, never trades.
+
+**Architecture:** Three new ports — `MoversSource` (Yahoo predefined screener), `NewsSource` (Yahoo search headlines), `FilingsSource` (SEC EDGAR submissions API + ticker→CIK map) — → pure single-ticker `domain/dip.rs::dip_signal` (gates + score) + pure `domain/margin.rs` → `application/dip.rs` (`dip_check` for one ticker, `dip_scan` = losers universe → `dip_check` each; JSONL journal) → CLI leaf + MCP tool + additive `dip_signal` section in `analyze_ticker`. Reuses `BarSource`, `domain::risk`, social layer.
+
+**Tech Stack:** Rust; clap; rmcp; new dep `chrono-tz` (NY session logic). Endpoints verified live 2026-08-15, all keyless:
+- Yahoo `v1/finance/screener/predefined/saved?scrIds=day_losers&count=100` (100 rows: changePercent, price, marketCap, avgVolume3Month, regularMarketVolume, fullExchangeName, firstTradeDateMilliseconds)
+- Yahoo `v1/finance/search?q={T}&newsCount=N&quotesCount=0` (headlines + `providerPublishTime`)
+- SEC `data.sec.gov/submissions/CIK{10-digit}.json` (recent form types + filing dates) and `sec.gov/files/company_tickers.json` (ticker→CIK); SEC requires a UA with contact email, ≤10 req/s — we stay ≤5 concurrent
+- Yahoo v8 chart for `^GSPC` bars (existing adapter). `quoteSummary` is crumb-gated — NOT used.
+
+## Global Constraints
+
+- **Gates decide, score ranks.** `high_confidence` requires ALL gates G1–G7 true. Any gate *unknown* (fetch failure, ticker absent from CIK map) → **fail closed**: cap at `watch`, never `high_confidence`, with the reason in `notes`. A *confirmed* catalyst (G3 or G4 hit) → `no_setup` with the evidence (form + date, or headline + matched term).
+- **Gates pinned (evaluated per ticker):**
+  - G1 quality floor: price ≥ $5, market cap ≥ $500M, 3-mo avg volume ≥ 1M sh, listed ≥ 180 days, exchange not OTC/Pink (each reject records its reason)
+  - G2 drop band: day change in **[−15%, −4%]** (both configurable) — the catastrophic tail is excluded by design, not deep-analyzed
+  - G3 no SEC filing of form `8-K, 6-K, 424B5, S-3, FWP` dated drop-day or the prior calendar day
+  - G4 no catalyst keyword in same-day headlines (`providerPublishTime` on drop day, NY tz); keywords: `earnings, miss, guidance, cut, offering, dilution, downgrade, halt, fraud, lawsuit, recall, FDA, bankruptcy, delisting, investigation, resign` (case-insensitive whole-word)
+  - G5 idiosyncratic: `excess = ticker_change_pct − spx_change_pct ≤ −3%` (^GSPC same day)
+  - G6 buyers at close: `close_location = (close − low) / (high − low) ≥ 0.5` on the drop-day bar (0/0 → gate unknown)
+  - G7 score ≥ 65 (configurable)
+- **Session rule:** NY time (chrono-tz `America/New_York`). `post_close` = ≥ 16:05 ET or outside trading days; else `intraday`. **Intraday runs cap every verdict at `watch`** (G6 and the day bar aren't final) and say so. Baselines (SMA/ATR/RSI/multi-day) are computed on bars **excluding** any bar dated today-NY; stretch = (sma20_prior − last_price) / atr_prior. Requires ≥ 21 prior bars else per-entry error `not enough history`.
+- **Score v0 — weights live in one `ScoreWeights` struct, explicitly labeled v0/unvalidated (journal exists to fix that):** stretch 20 (`min(stretch_atr, 3.5)/3.5 × 20`); close_location 20 (linear 0.0→0, 1.0→20; **omitted intraday**, total then annotated `/80`); idiosyncrasy 15 (excess −3%→0, −10%→15); quiet_volume 15 (**low** volume reverts: ratio ≤ 1.0 → 15, ≥ 3.0 → 0, linear — deliberate sign flip vs "capitulation" intuition); rsi 10 (Cutler RSI-14: ≥50→0, ≤20→10); multi_day 10 (consecutive down closes incl. drop day: 1→0, ≥4→10); divergence 10 (price down + social sentiment neutral-or-bullish, **scaled by `min(1, mentions/20)`**; no social data → 0 + note).
+- **Confidence semantics pinned in all copy:** "high confidence" = high conformance to the setup template, NEVER probability the trade wins. Framing line (CLI footer + MCP `framing`): `dip_scan grades setup conformance — it never predicts outcomes or recommends entry. Zero candidates is a normal result. Margin amplifies losses as well as gains.` above the standard DISCLAIMER.
+- **Margin math (pure `domain/margin.rs`, computed only when `equity_usd` given):** `L = leverage.clamp(1.0, 2.0)` default 2.0 — overnight Reg-T; `--intraday-bp` raises the clamp to 4.0 and adds note `4x is intraday buying power — not holdable overnight`. `m = maintenance.clamp(0.10, 0.90)` default 0.25. Base shares from `domain::risk::frame` (budget = `equity_usd × risk_pct`, default 0.01, clamp 0.001–0.05); `shares = min(risk_shares, floor(equity × L / entry))`; `notional = shares × entry`; `cash_used = min(equity, notional)`; `borrowed = notional − cash_used`; `margin_call_price = borrowed / (shares × (1 − m))` (no borrow → `None`); distances in % and ATRs. `mc_price ≥ stop` → note `margin call would trigger before your stop at this leverage`. Interest/fees not modeled; single-position model — both in disclaimer.
+- **Journal:** every scan appends one JSONL line to `~/.openintel/dip_journal.jsonl` (`generated_at, session, spx_change, candidates: [{ticker, change_pct, score, components, verdict, gates, price}]`) — the record that makes weights tunable later (a `dip --review` grading forward returns is a named follow-up feature, not built now). `--no-journal` / `journal: false` opts out; write failure warns, never fails the scan. MCP description discloses the journal write.
+- **Rate/citizenship:** candidate fan-out `buffer_unordered(5)` (not unbounded `join_all`) — respects SEC's 10 req/s and avoids Yahoo 429s; SEC UA = `openintel/<ver> (contact: adam@kloudysky.io)`; `company_tickers.json` fetched once per run, cached in the adapter.
+- **Errors:** screener failure fails the tool with one clear message; per-candidate failures collected per entry; gate-source failures degrade per the fail-closed rule. Never NaN/panic.
+- **Additive only:** `MarketDataSource`, `MarketSnapshot`, `domain/risk.rs` semantics, and every existing test untouched. `Bar` gains `pub open: f64` (needed by G6/gap context) — additive field; Yahoo parser, `FixedBars`, `mock_market` updated in the same commit. New ports implemented by `YahooMarketSource` (movers, news — shared client) and new `EdgarSource`; `OpenIntelServer` gains one field (`filings`).
+- **stdout discipline:** `cli/dip.rs` returns Strings; only `main.rs` prints.
+- **Hermetic tests** (mock movers/news/filings + `FixedBars` + fixture social) + `#[ignore]`d live tests for screener, news, EDGAR.
+- **Every commit green:** `cargo build --all-targets && cargo test && cargo clippy --all-targets -- -D warnings && cargo fmt -- --check`.
+- Branch `kloud/dip-scan`; squash-merge via PR per repo workflow.
+
+---
+
+### Task 1: Domain values — `MoverRow`, `Headline`, `Filing`; `Bar` gains `open`
+
+**Files:**
+- Create: `src/domain/values/mover.rs`, `src/domain/values/headline.rs`, `src/domain/values/filing.rs`
+- Modify: `src/domain/values/bar.rs` (+`open`), `src/domain/values/mod.rs`, `src/adapters/market/yahoo/response.rs` (`parse_bars` keeps `open`), `src/adapters/market/mock_market.rs`, every `Bar{...}` literal in existing tests
+
+**Interfaces:**
+- `MoverRow { symbol: String, change_pct: f64, price: f64, market_cap: Option<u64>, avg_volume_3mo: Option<u64>, day_volume: Option<u64>, exchange: String, first_trade_ms: Option<i64> }`
+- `Headline { title: String, publisher: String, published_at: DateTime<Utc> }`
+- `Filing { form: String, filed_on: NaiveDate }`
+- `Bar { open, high, low, close }` (all `f64`)
+
+- [ ] Step 1: values + registrations; Bar migration compiles green with all existing tests passing
+
+### Task 2: Pure domain — `domain/dip.rs` (single-ticker signal: floor, metrics, gates, score, verdict)
+
+**Files:** Create `src/domain/dip.rs`; modify `src/domain/mod.rs`
+
+**Interfaces (later tasks rely on exactly these):**
+- `QualityFloor` + `Default`; `apply_floor(&[MoverRow], &QualityFloor, now) -> (Vec<MoverRow>, Vec<FloorReject>)`
+- `sma(closes, period) -> Option<f64>`; `rsi_cutler(closes, period) -> Option<f64>`; `consecutive_down_closes(bars) -> usize`; `close_location(bar) -> Option<f64>`
+- `ScoreWeights` (v0 defaults pinned above) + `ScoreComponents` (one field per component, each already weighted)
+- `GateResults { g1..g7: GateStatus }` with `GateStatus { Pass, Fail(String), Unknown(String) }`
+- `Verdict { NoSetup, Watch, HighConfidence }` (`Serialize`, lowercase)
+- `pub fn dip_signal(inputs: &DipInputs) -> Result<DipSignal, DomainError>` — `DipInputs { ticker, prior_bars, drop_day_bar: Option<Bar>, last_price, change_pct, spx_change_pct: Option<f64>, filings: GateEvidence<Vec<Filing>>, headlines: GateEvidence<Vec<Headline>>, sentiment: Option<SentimentSummary>, session: Session, floor_pass: bool, band, weights, score_min }` where `GateEvidence<T> = Ok(T) | Unavailable(String)` drives fail-closed
+- `DipSignal { verdict, score, components, gates, metrics: { stretch_atr, rsi14, sma20, atr, volume_ratio, close_location, down_days, excess_vs_spx }, catalyst_evidence: Vec<String>, notes: Vec<String> }`
+- `CATALYST_KEYWORDS` + `catalyst_hits(texts) -> Vec<String>` (whole-word)
+
+- [ ] Step 1: metrics + score mappers, tests: Cutler RSI known vector, stretch sign, each mapper's 0/max/linear bounds, whole-word matching (`miss` ≠ `dismissal`)
+- [ ] Step 2: gates + verdict, tests: all-pass post_close → HighConfidence; filing hit → NoSetup w/ evidence; EDGAR Unavailable → Watch capped + note; intraday all-pass → Watch; band edges; 0/0 close_location → Unknown
+
+### Task 3: Ports + adapters — movers, news, filings
+
+**Files:**
+- Create: `src/domain/ports/{movers_source,news_source,filings_source}.rs`, `src/adapters/market/yahoo/{screener,news}.rs`, `src/adapters/filings/edgar/mod.rs` (+`response.rs`), mocks `src/adapters/market/mock_movers.rs`, `src/adapters/filings/mock_filings.rs`, mock news in yahoo tests
+- Modify: port/adapter `mod.rs` registrations, `src/adapters/market/yahoo/mod.rs`
+
+**Interfaces:**
+- `MoversSource { name(); day_losers(count) -> Vec<MoverRow> }` — impl on `YahooMarketSource`; count clamp 1–100; malformed rows skipped w/ count; zero rows → error
+- `NewsSource { headlines(&Ticker, count) -> Vec<Headline> }` — impl on `YahooMarketSource` via search endpoint
+- `FilingsSource { recent_filings(&Ticker, since: NaiveDate) -> GateEvidence<Vec<Filing>> }` — `EdgarSource`: ticker→CIK map fetched once + cached (`tokio::sync::OnceCell`), then submissions JSON filtered to forms/dates; ticker absent from map → `Unavailable("no SEC filer mapping")`; SEC UA with contact email
+
+- [ ] Step 1: three port traits + registrations
+- [ ] Step 2: yahoo screener + news parsers, fixture-JSON tests, `#[ignore]` live tests
+- [ ] Step 3: `EdgarSource` + fixture tests (form/date filtering, missing ticker) + `#[ignore]` live test
+- [ ] Step 4: mocks
+
+### Task 4: Pure domain — `domain/margin.rs`
+
+**Files:** Create `src/domain/margin.rs`; modify `src/domain/mod.rs`
+
+- `MarginInputs { equity_usd, leverage, maintenance, risk_pct, intraday_bp: bool }` + defaults; `margin_frame(risk: &RiskFrame, inputs) -> Result<MarginFrame, DomainError>`; `MarginFrame` fields as pinned (shares, notional, cash_used, borrowed, margin_call_price, distances, capped_by_buying_power, note)
+
+- [ ] Step 1: implement + tests: no-borrow → `None`; hand-computed 2x case; mc-above-stop note; overnight clamp vs `intraday_bp` unlock + its note; `shares == 0` passthrough
+
+### Task 5: Application — `application/dip.rs` (`dip_check`, `dip_scan`, journal)
+
+**Files:** Create `src/application/dip.rs`; modify `src/application/mod.rs`
+
+**Interfaces:**
+- `pub async fn dip_check(ticker, deps: DipDeps<'_>, cfg, now) -> Result<TickerDipReport, DomainError>` — fetches bars (splits prior/drop-day by NY date), ^GSPC bars, headlines, filings, social; assembles `DipInputs`; the reusable single-ticker entry point (used by dip_scan AND analyze integration)
+- `pub async fn dip_scan(req: DipScanRequest, deps, now) -> Result<DipScanReport, DomainError>` — losers → floor → band → `buffer_unordered(5)` of `dip_check` → sort by (verdict desc, score desc) → optional margin frames → journal append
+- `DipScanRequest { count: 100, deep_n: 10 clamp 1–25, band, floor, weights, score_min, margin: Option<MarginInputs>, journal: bool }`
+- `DipScanReport { generated_at, session, spx_change_pct, universe_size, floor_rejects, candidates: Vec<DipCandidate>, errors }`; `DipCandidate { ticker, change_pct, signal: DipSignal, risk: Option<RiskFrame>, margin: Option<MarginFrame> }`
+- Journal write to `~/.openintel/dip_journal.jsonl` (create dir; append; failure → note in report, never error)
+
+- [ ] Step 1: `dip_check` + session/date-splitting logic, tests (FixedBars w/ today-dated last bar excluded from baselines)
+- [ ] Step 2: `dip_scan` orchestration, tests: ranking (HighConfidence above Watch regardless of score), one ticker's fetch failure doesn't sink batch, fail-closed propagation, journal line shape, `--no-journal`
+
+### Task 6: CLI — `openintel dip`
+
+**Files:** Create `src/cli/dip.rs`; modify `src/cli/args.rs`, `src/cli/mod.rs`, `src/main.rs`
+
+- [ ] Step 1: `Command::Dip(DipArgs)`: `--count --deep --band-min --band-max --equity --leverage --intraday-bp --maintenance --risk-pct --score-min --min-price --min-cap --min-volume --min-listed-days --no-journal --format table|json`
+- [ ] Step 2: `run()` + renders mirroring `cli/risk.rs` — table: verdict, ticker, day %, excess vs SPX, score (+ components), stretch, RSI, vol×, close-loc, gates summary (✓/✗/? per gate), catalyst evidence; margin rows when `--equity`; empty candidates renders `no setups today — that's a result, not an error`; footer = framing + DISCLAIMER
+- [ ] Step 3: `main.rs` arm
+
+### Task 7: MCP — `dip_scan` tool
+
+**Files:** Modify `src/mcp/tools.rs`, `src/mcp/server.rs`
+
+- [ ] Step 1: `DipScanArgs` (Task-6 knobs + `ticker: Option<String>` — when set, skips the universe and returns `dip_check` for that one symbol: the "considering a trade" mode), `DipScanOutput { summary, report, framing, disclaimer }`; summary counts by verdict + top-3
+- [ ] Step 2: registration; server gains `filings: Arc<EdgarSource>` built in `serve()`; description states read-only, gate semantics (fail-closed), journal write, margin assumptions
+- [ ] Step 3: tool tests w/ mocks
+
+### Task 8: `analyze_ticker` integration (additive)
+
+**Files:** Modify `src/mcp/tools.rs` (`AnalyzeOutput` gains `dip_signal: Option<DipSignal>`), `src/application/analyze.rs` untouched — dip runs beside it in `run_analyze`; `src/cli/run.rs` table gains a `Dip signal` section when present
+
+- [ ] Step 1: compute via `dip_check` (band/floor gates marked n/a for arbitrary tickers — signal reports metrics/gates/score with `verdict` only when the ticker is down ≥ band-min today, else `dip_signal: None`); failure to compute → `None` + note, never fails analyze
+- [ ] Step 2: tests: down-day ticker gets a signal; flat ticker gets `None`; dip failure doesn't break analyze
+
+### Task 9: Docs
+
+- [ ] README: tool table, usage, gate table, journal location/opt-out, endpoints (keyless/unofficial, clean-error failure mode), v0-weights honesty note, follow-up: `dip --review` forward-return grading

--- a/src/adapters/filings/edgar/mod.rs
+++ b/src/adapters/filings/edgar/mod.rs
@@ -20,9 +20,10 @@ use crate::domain::values::filing::Filing;
 const TICKER_MAP_URL: &str = "https://www.sec.gov/files/company_tickers.json";
 const SUBMISSIONS_BASE: &str = "https://data.sec.gov/submissions";
 const TIMEOUT_SECS: u64 = 10;
-/// Overridable contact for SEC's fair-access UA policy.
+/// Overridable contact for SEC's fair-access UA policy. SEC 403s UAs
+/// without an email-style contact (verified 2026-08-15).
 const CONTACT_ENV: &str = "OPENINTEL_SEC_CONTACT";
-const DEFAULT_CONTACT: &str = "+https://github.com/kloudysky/openintel";
+const DEFAULT_CONTACT: &str = "contact: adam@kloudysky.io";
 
 fn fail(message: impl Into<String>) -> DomainError {
     DomainError::SourceFailure {

--- a/src/adapters/filings/edgar/mod.rs
+++ b/src/adapters/filings/edgar/mod.rs
@@ -1,0 +1,137 @@
+//! SEC EDGAR filings source (keyless, official). Two feeds: the ticker→CIK
+//! map (fetched once per process, cached) and per-company submissions.
+//! SEC's fair-access policy requires a descriptive User-Agent with contact
+//! info and ≤10 requests/second — callers must bound their concurrency.
+
+mod response;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::NaiveDate;
+use tokio::sync::OnceCell;
+
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::filings_source::FilingsSource;
+use crate::domain::values::filing::Filing;
+
+const TICKER_MAP_URL: &str = "https://www.sec.gov/files/company_tickers.json";
+const SUBMISSIONS_BASE: &str = "https://data.sec.gov/submissions";
+const TIMEOUT_SECS: u64 = 10;
+/// Overridable contact for SEC's fair-access UA policy.
+const CONTACT_ENV: &str = "OPENINTEL_SEC_CONTACT";
+const DEFAULT_CONTACT: &str = "+https://github.com/kloudysky/openintel";
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "edgar".into(),
+        message: message.into(),
+    }
+}
+
+pub struct EdgarSource {
+    client: reqwest::Client,
+    ticker_map: OnceCell<HashMap<String, u64>>,
+}
+
+impl EdgarSource {
+    pub fn new() -> Result<Self, DomainError> {
+        let contact = std::env::var(CONTACT_ENV).unwrap_or_else(|_| DEFAULT_CONTACT.to_string());
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(TIMEOUT_SECS))
+            .user_agent(format!(
+                "openintel/{} ({contact})",
+                env!("CARGO_PKG_VERSION")
+            ))
+            .build()
+            .map_err(|e| fail(format!("client build failed: {e}")))?;
+        Ok(Self {
+            client,
+            ticker_map: OnceCell::new(),
+        })
+    }
+
+    async fn fetch(&self, url: &str) -> Result<String, DomainError> {
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| fail(format!("request failed: {e}")))?;
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(fail(format!("HTTP {status} for {url}")));
+        }
+        resp.text()
+            .await
+            .map_err(|e| fail(format!("reading body failed: {e}")))
+    }
+
+    async fn cik_for(&self, ticker: &Ticker) -> Result<u64, DomainError> {
+        let map = self
+            .ticker_map
+            .get_or_try_init(|| async {
+                let body = self.fetch(TICKER_MAP_URL).await?;
+                response::parse_ticker_map(&body)
+            })
+            .await?;
+        map.get(ticker.as_str()).copied().ok_or_else(|| {
+            fail(format!(
+                "no SEC filer mapping for {} — cannot verify filings",
+                ticker.as_str()
+            ))
+        })
+    }
+}
+
+#[async_trait]
+impl FilingsSource for EdgarSource {
+    async fn recent_filings(
+        &self,
+        ticker: &Ticker,
+        since: NaiveDate,
+    ) -> Result<Vec<Filing>, DomainError> {
+        let cik = self.cik_for(ticker).await?;
+        let body = self
+            .fetch(&format!("{SUBMISSIONS_BASE}/CIK{cik:010}.json"))
+            .await?;
+        response::parse_recent_filings(&body, since)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_with_default_contact_ua() {
+        assert!(EdgarSource::new().is_ok());
+    }
+
+    #[tokio::test]
+    #[ignore = "hits live SEC EDGAR (keyless, free); run with --ignored"]
+    async fn live_apple_has_recent_filings() {
+        let src = EdgarSource::new().unwrap();
+        let since = chrono::Utc::now().date_naive() - chrono::Days::new(90);
+        let filings = src
+            .recent_filings(&Ticker::parse("AAPL").unwrap(), since)
+            .await
+            .unwrap();
+        assert!(!filings.is_empty());
+        assert!(filings.iter().all(|f| f.filed_on >= since));
+    }
+
+    #[tokio::test]
+    #[ignore = "hits live SEC EDGAR (keyless, free); run with --ignored"]
+    async fn live_unmapped_ticker_errors() {
+        let src = EdgarSource::new().unwrap();
+        let since = chrono::Utc::now().date_naive();
+        // ZZZZZ is a valid Ticker shape but not an SEC filer
+        assert!(src
+            .recent_filings(&Ticker::parse("ZZZZZ").unwrap(), since)
+            .await
+            .is_err());
+    }
+}

--- a/src/adapters/filings/edgar/response.rs
+++ b/src/adapters/filings/edgar/response.rs
@@ -1,0 +1,106 @@
+//! Parsers for SEC EDGAR's two keyless JSON feeds: the ticker→CIK map and
+//! the per-company submissions index.
+
+use std::collections::HashMap;
+
+use chrono::NaiveDate;
+use serde::Deserialize;
+
+use crate::domain::error::DomainError;
+use crate::domain::values::filing::Filing;
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "edgar".into(),
+        message: message.into(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TickerEntry {
+    cik_str: u64,
+    ticker: String,
+}
+
+/// `company_tickers.json` is a map of arbitrary numeric keys to entries.
+pub(crate) fn parse_ticker_map(body: &str) -> Result<HashMap<String, u64>, DomainError> {
+    let entries: HashMap<String, TickerEntry> =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed ticker map: {e}")))?;
+    if entries.is_empty() {
+        return Err(fail("empty ticker map"));
+    }
+    Ok(entries
+        .into_values()
+        .map(|e| (e.ticker.to_ascii_uppercase(), e.cik_str))
+        .collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct Submissions {
+    filings: Filings,
+}
+
+#[derive(Debug, Deserialize)]
+struct Filings {
+    recent: Recent,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Recent {
+    #[serde(default)]
+    form: Vec<String>,
+    #[serde(default)]
+    filing_date: Vec<String>,
+}
+
+/// Filings on/after `since` from a submissions body. Rows with unparseable
+/// dates are skipped; form/date arrays are zipped positionally per EDGAR's
+/// column-oriented format.
+pub(crate) fn parse_recent_filings(
+    body: &str,
+    since: NaiveDate,
+) -> Result<Vec<Filing>, DomainError> {
+    let subs: Submissions =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed submissions: {e}")))?;
+    let recent = subs.filings.recent;
+    Ok(recent
+        .form
+        .into_iter()
+        .zip(recent.filing_date)
+        .filter_map(|(form, date)| {
+            let filed_on = NaiveDate::parse_from_str(&date, "%Y-%m-%d").ok()?;
+            (filed_on >= since).then_some(Filing { form, filed_on })
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ticker_map_uppercases_symbols() {
+        let body = r#"{"0":{"cik_str":320193,"ticker":"aapl","title":"Apple Inc."},
+                       "1":{"cik_str":1045810,"ticker":"NVDA","title":"NVIDIA CORP"}}"#;
+        let map = parse_ticker_map(body).unwrap();
+        assert_eq!(map.get("AAPL"), Some(&320193));
+        assert_eq!(map.get("NVDA"), Some(&1045810));
+        assert!(parse_ticker_map("{}").is_err());
+        assert!(parse_ticker_map("nope").is_err());
+    }
+
+    #[test]
+    fn filings_filter_by_date_and_zip_positionally() {
+        let body = r#"{"filings":{"recent":{
+            "form":["8-K","4","10-Q","424B5"],
+            "filingDate":["2026-08-14","2026-08-13","2026-07-31","bogus"]
+        }}}"#;
+        let since = NaiveDate::from_ymd_opt(2026, 8, 13).unwrap();
+        let filings = parse_recent_filings(body, since).unwrap();
+        assert_eq!(filings.len(), 2); // 10-Q too old, bogus date skipped
+        assert_eq!(filings[0].form, "8-K");
+        assert_eq!(filings[1].form, "4");
+        assert!(parse_recent_filings("nope", since).is_err());
+    }
+}

--- a/src/adapters/filings/edgar/response.rs
+++ b/src/adapters/filings/edgar/response.rs
@@ -54,9 +54,10 @@ struct Recent {
     filing_date: Vec<String>,
 }
 
-/// Filings on/after `since` from a submissions body. Rows with unparseable
-/// dates are skipped; form/date arrays are zipped positionally per EDGAR's
-/// column-oriented format.
+/// Filings on/after `since` from a submissions body. Form/date arrays are
+/// zipped positionally per EDGAR's column-oriented format. Malformed rows are
+/// an ERROR, not a skip — a silently dropped filing could hide a catalyst,
+/// and callers treat an error as "could not verify" (fail closed).
 pub(crate) fn parse_recent_filings(
     body: &str,
     since: NaiveDate,
@@ -64,15 +65,22 @@ pub(crate) fn parse_recent_filings(
     let subs: Submissions =
         serde_json::from_str(body).map_err(|e| fail(format!("malformed submissions: {e}")))?;
     let recent = subs.filings.recent;
-    Ok(recent
-        .form
-        .into_iter()
-        .zip(recent.filing_date)
-        .filter_map(|(form, date)| {
-            let filed_on = NaiveDate::parse_from_str(&date, "%Y-%m-%d").ok()?;
-            (filed_on >= since).then_some(Filing { form, filed_on })
-        })
-        .collect())
+    if recent.form.len() != recent.filing_date.len() {
+        return Err(fail(format!(
+            "submissions column mismatch: {} forms vs {} dates",
+            recent.form.len(),
+            recent.filing_date.len()
+        )));
+    }
+    let mut filings = Vec::new();
+    for (form, date) in recent.form.into_iter().zip(recent.filing_date) {
+        let filed_on = NaiveDate::parse_from_str(&date, "%Y-%m-%d")
+            .map_err(|_| fail(format!("unparseable filing date '{date}' for form {form}")))?;
+        if filed_on >= since {
+            filings.push(Filing { form, filed_on });
+        }
+    }
+    Ok(filings)
 }
 
 #[cfg(test)]
@@ -93,14 +101,29 @@ mod tests {
     #[test]
     fn filings_filter_by_date_and_zip_positionally() {
         let body = r#"{"filings":{"recent":{
-            "form":["8-K","4","10-Q","424B5"],
-            "filingDate":["2026-08-14","2026-08-13","2026-07-31","bogus"]
+            "form":["8-K","4","10-Q"],
+            "filingDate":["2026-08-14","2026-08-13","2026-07-31"]
         }}}"#;
         let since = NaiveDate::from_ymd_opt(2026, 8, 13).unwrap();
         let filings = parse_recent_filings(body, since).unwrap();
-        assert_eq!(filings.len(), 2); // 10-Q too old, bogus date skipped
+        assert_eq!(filings.len(), 2); // 10-Q too old
         assert_eq!(filings[0].form, "8-K");
         assert_eq!(filings[1].form, "4");
         assert!(parse_recent_filings("nope", since).is_err());
+    }
+
+    #[test]
+    fn malformed_rows_fail_closed_instead_of_skipping() {
+        let since = NaiveDate::from_ymd_opt(2026, 8, 13).unwrap();
+        // bogus date: an error, never a silent skip (could hide a catalyst)
+        let bogus_date = r#"{"filings":{"recent":{
+            "form":["424B5"],"filingDate":["bogus"]
+        }}}"#;
+        assert!(parse_recent_filings(bogus_date, since).is_err());
+        // column length mismatch: same
+        let mismatch = r#"{"filings":{"recent":{
+            "form":["8-K","4"],"filingDate":["2026-08-14"]
+        }}}"#;
+        assert!(parse_recent_filings(mismatch, since).is_err());
     }
 }

--- a/src/adapters/filings/mock_filings.rs
+++ b/src/adapters/filings/mock_filings.rs
@@ -1,0 +1,31 @@
+use async_trait::async_trait;
+use chrono::NaiveDate;
+
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::filings_source::FilingsSource;
+use crate::domain::values::filing::Filing;
+
+/// Test double: a fixed filing list, or a fixed failure (for fail-closed paths).
+pub struct MockFilingsSource(pub Result<Vec<Filing>, String>);
+
+#[async_trait]
+impl FilingsSource for MockFilingsSource {
+    async fn recent_filings(
+        &self,
+        _ticker: &Ticker,
+        since: NaiveDate,
+    ) -> Result<Vec<Filing>, DomainError> {
+        match &self.0 {
+            Ok(filings) => Ok(filings
+                .iter()
+                .filter(|f| f.filed_on >= since)
+                .cloned()
+                .collect()),
+            Err(message) => Err(DomainError::SourceFailure {
+                name: "mock-filings".into(),
+                message: message.clone(),
+            }),
+        }
+    }
+}

--- a/src/adapters/filings/mod.rs
+++ b/src/adapters/filings/mod.rs
@@ -1,0 +1,2 @@
+pub mod edgar;
+pub mod mock_filings;

--- a/src/adapters/market/mock_movers.rs
+++ b/src/adapters/market/mock_movers.rs
@@ -1,0 +1,19 @@
+use async_trait::async_trait;
+
+use crate::domain::error::DomainError;
+use crate::domain::ports::movers_source::MoversSource;
+use crate::domain::values::mover::MoverRow;
+
+/// Test double: a fixed losers list (already worst-first).
+pub struct MockMoversSource(pub Vec<MoverRow>);
+
+#[async_trait]
+impl MoversSource for MockMoversSource {
+    fn name(&self) -> &str {
+        "mock-movers"
+    }
+
+    async fn day_losers(&self, count: usize) -> Result<Vec<MoverRow>, DomainError> {
+        Ok(self.0.iter().take(count).cloned().collect())
+    }
+}

--- a/src/adapters/market/mock_news.rs
+++ b/src/adapters/market/mock_news.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::news_source::NewsSource;
+use crate::domain::values::headline::Headline;
+
+/// Test double: fixed headlines, or a fixed failure (for fail-closed paths).
+pub struct MockNewsSource(pub Result<Vec<Headline>, String>);
+
+#[async_trait]
+impl NewsSource for MockNewsSource {
+    async fn headlines(
+        &self,
+        _ticker: &Ticker,
+        count: usize,
+    ) -> Result<Vec<Headline>, DomainError> {
+        match &self.0 {
+            Ok(headlines) => Ok(headlines.iter().take(count).cloned().collect()),
+            Err(message) => Err(DomainError::SourceFailure {
+                name: "mock-news".into(),
+                message: message.clone(),
+            }),
+        }
+    }
+}

--- a/src/adapters/market/mod.rs
+++ b/src/adapters/market/mod.rs
@@ -1,2 +1,4 @@
 pub mod mock_market;
+pub mod mock_movers;
+pub mod mock_news;
 pub mod yahoo;

--- a/src/adapters/market/yahoo/mod.rs
+++ b/src/adapters/market/yahoo/mod.rs
@@ -1,4 +1,6 @@
+mod news;
 mod response;
+mod screener;
 
 use std::time::Duration;
 
@@ -10,9 +12,16 @@ use crate::domain::entities::ticker::Ticker;
 use crate::domain::error::DomainError;
 use crate::domain::ports::bar_source::BarSource;
 use crate::domain::ports::market_data_source::MarketDataSource;
+use crate::domain::ports::movers_source::MoversSource;
+use crate::domain::ports::news_source::NewsSource;
 use crate::domain::values::bar::Bar;
+use crate::domain::values::headline::Headline;
+use crate::domain::values::mover::MoverRow;
 
 const BASE_URL: &str = "https://query1.finance.yahoo.com/v8/finance/chart";
+const SCREENER_URL: &str = "https://query1.finance.yahoo.com/v1/finance/screener/predefined/saved";
+const SEARCH_URL: &str = "https://query1.finance.yahoo.com/v1/finance/search";
+const MAX_SCREENER_ROWS: usize = 100;
 const TIMEOUT_SECS: u64 = 10;
 
 #[derive(Clone)]
@@ -65,6 +74,30 @@ impl YahooMarketSource {
     async fn fetch_chart_body(&self, ticker: &Ticker) -> Result<String, DomainError> {
         self.fetch_chart(ticker).await.map(|(_, body)| body)
     }
+
+    async fn fetch_body(&self, name: &str, url: String) -> Result<String, DomainError> {
+        let resp = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| DomainError::SourceFailure {
+                name: name.into(),
+                message: format!("request failed: {e}"),
+            })?;
+        let status = resp.status();
+        let body = resp.text().await.map_err(|e| DomainError::SourceFailure {
+            name: name.into(),
+            message: format!("reading body failed (HTTP {status}): {e}"),
+        })?;
+        if !status.is_success() {
+            return Err(DomainError::SourceFailure {
+                name: name.into(),
+                message: format!("HTTP {status}"),
+            });
+        }
+        Ok(body)
+    }
 }
 
 #[async_trait]
@@ -85,6 +118,32 @@ impl BarSource for YahooMarketSource {
     async fn bars(&self, ticker: &Ticker) -> Result<Vec<Bar>, DomainError> {
         let body = self.fetch_chart_body(ticker).await?;
         response::parse_bars(&body)
+    }
+}
+
+#[async_trait]
+impl MoversSource for YahooMarketSource {
+    fn name(&self) -> &str {
+        "yahoo-screener"
+    }
+
+    async fn day_losers(&self, count: usize) -> Result<Vec<MoverRow>, DomainError> {
+        let count = count.clamp(1, MAX_SCREENER_ROWS);
+        let url = format!("{SCREENER_URL}?scrIds=day_losers&count={count}");
+        let body = self.fetch_body("yahoo-screener", url).await?;
+        screener::parse_movers(&body).map(|(rows, _skipped)| rows)
+    }
+}
+
+#[async_trait]
+impl NewsSource for YahooMarketSource {
+    async fn headlines(&self, ticker: &Ticker, count: usize) -> Result<Vec<Headline>, DomainError> {
+        let url = format!(
+            "{SEARCH_URL}?q={}&newsCount={count}&quotesCount=0",
+            ticker.as_str()
+        );
+        let body = self.fetch_body("yahoo-news", url).await?;
+        news::parse_headlines(&body)
     }
 }
 
@@ -117,7 +176,8 @@ mod tests {
     #[test]
     fn new_builds_and_names_yahoo() {
         let src = YahooMarketSource::new().unwrap();
-        assert_eq!(src.name(), "yahoo");
+        assert_eq!(MarketDataSource::name(&src), "yahoo");
+        assert_eq!(MoversSource::name(&src), "yahoo-screener");
     }
 
     #[tokio::test]
@@ -138,6 +198,31 @@ mod tests {
         for b in &bars {
             assert!(b.high >= b.low);
         }
+        // dates strictly increase (session dates, deduped by the venue)
+        for w in bars.windows(2) {
+            assert!(w[1].date > w[0].date);
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "hits live Yahoo (keyless, free); run with --ignored"]
+    async fn live_day_losers_returns_rows() {
+        let src = YahooMarketSource::new().unwrap();
+        let rows = src.day_losers(100).await.unwrap();
+        assert!(rows.len() >= 50, "got {}", rows.len());
+        assert!(rows.iter().all(|r| r.change_pct < 0.0));
+    }
+
+    #[tokio::test]
+    #[ignore = "hits live Yahoo (keyless, free); run with --ignored"]
+    async fn live_headlines_parse() {
+        let src = YahooMarketSource::new().unwrap();
+        // AAPL always has news; content varies — assert shape only.
+        let news = NewsSource::headlines(&src, &Ticker::parse("AAPL").unwrap(), 5)
+            .await
+            .unwrap();
+        assert!(!news.is_empty());
+        assert!(news.iter().all(|h| !h.title.is_empty()));
     }
 
     #[test]

--- a/src/adapters/market/yahoo/news.rs
+++ b/src/adapters/market/yahoo/news.rs
@@ -31,9 +31,11 @@ fn fail(message: impl Into<String>) -> DomainError {
     }
 }
 
-/// Headlines with all required fields; incomplete items are skipped (a
-/// missing timestamp would defeat the same-day filter). An empty list is a
-/// valid result — quiet tickers have no news.
+/// Headlines from the search body. Only title-less items are skipped (they
+/// carry no scannable evidence); a missing/invalid timestamp yields
+/// `published_at: None` so the catalyst gate can treat the item
+/// conservatively instead of losing it. An empty list is a valid result —
+/// quiet tickers have no news.
 pub(crate) fn parse_headlines(body: &str) -> Result<Vec<Headline>, DomainError> {
     let resp: SearchResponse =
         serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
@@ -44,7 +46,9 @@ pub(crate) fn parse_headlines(body: &str) -> Result<Vec<Headline>, DomainError> 
             Some(Headline {
                 title: n.title?,
                 publisher: n.publisher.unwrap_or_else(|| "unknown".into()),
-                published_at: Utc.timestamp_opt(n.provider_publish_time?, 0).single()?,
+                published_at: n
+                    .provider_publish_time
+                    .and_then(|t| Utc.timestamp_opt(t, 0).single()),
             })
         })
         .collect())
@@ -55,16 +59,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_headlines_and_skips_incomplete() {
+    fn parses_headlines_keeps_undated_skips_titleless() {
         let body = r#"{"news":[
             {"title":"Company cuts guidance","publisher":"Wire","providerPublishTime":1786818192},
             {"title":"No timestamp","publisher":"Wire"},
             {"publisher":"Wire","providerPublishTime":1786818192}
         ]}"#;
         let h = parse_headlines(body).unwrap();
-        assert_eq!(h.len(), 1);
+        assert_eq!(h.len(), 2); // only the title-less item is dropped
         assert_eq!(h[0].title, "Company cuts guidance");
-        assert_eq!(h[0].published_at.timestamp(), 1786818192);
+        assert_eq!(h[0].published_at.unwrap().timestamp(), 1786818192);
+        assert_eq!(h[1].published_at, None); // undated survives for the gate
     }
 
     #[test]

--- a/src/adapters/market/yahoo/news.rs
+++ b/src/adapters/market/yahoo/news.rs
@@ -1,0 +1,76 @@
+//! Parser for Yahoo's search endpoint news items (keyless). Only the
+//! headline fields the catalyst heuristic needs are read.
+
+use chrono::{TimeZone, Utc};
+use serde::Deserialize;
+
+use crate::domain::error::DomainError;
+use crate::domain::values::headline::Headline;
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    news: Vec<NewsItem>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NewsItem {
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    publisher: Option<String>,
+    #[serde(default)]
+    provider_publish_time: Option<i64>,
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "yahoo-news".into(),
+        message: message.into(),
+    }
+}
+
+/// Headlines with all required fields; incomplete items are skipped (a
+/// missing timestamp would defeat the same-day filter). An empty list is a
+/// valid result — quiet tickers have no news.
+pub(crate) fn parse_headlines(body: &str) -> Result<Vec<Headline>, DomainError> {
+    let resp: SearchResponse =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
+    Ok(resp
+        .news
+        .into_iter()
+        .filter_map(|n| {
+            Some(Headline {
+                title: n.title?,
+                publisher: n.publisher.unwrap_or_else(|| "unknown".into()),
+                published_at: Utc.timestamp_opt(n.provider_publish_time?, 0).single()?,
+            })
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_headlines_and_skips_incomplete() {
+        let body = r#"{"news":[
+            {"title":"Company cuts guidance","publisher":"Wire","providerPublishTime":1786818192},
+            {"title":"No timestamp","publisher":"Wire"},
+            {"publisher":"Wire","providerPublishTime":1786818192}
+        ]}"#;
+        let h = parse_headlines(body).unwrap();
+        assert_eq!(h.len(), 1);
+        assert_eq!(h[0].title, "Company cuts guidance");
+        assert_eq!(h[0].published_at.timestamp(), 1786818192);
+    }
+
+    #[test]
+    fn empty_news_is_ok_malformed_is_err() {
+        assert!(parse_headlines(r#"{"news":[]}"#).unwrap().is_empty());
+        assert!(parse_headlines(r#"{}"#).unwrap().is_empty());
+        assert!(parse_headlines("nope").is_err());
+    }
+}

--- a/src/adapters/market/yahoo/response.rs
+++ b/src/adapters/market/yahoo/response.rs
@@ -67,6 +67,8 @@ struct Quote {
     high: Vec<Option<f64>>,
     #[serde(default)]
     low: Vec<Option<f64>>,
+    #[serde(default)]
+    open: Vec<Option<f64>>,
 }
 
 fn fail(message: impl Into<String>) -> DomainError {
@@ -182,18 +184,31 @@ pub(crate) fn parse_snapshot(
 
 /// OHLC bars from the same chart response `parse_snapshot` reads. Rows with
 /// any missing leg (Yahoo emits nulls for halts/partial days) are skipped.
+/// Bar dates are the New York session date of each timestamp — Yahoo stamps
+/// daily bars at the session open in exchange time.
 pub(crate) fn parse_bars(body: &str) -> Result<Vec<Bar>, DomainError> {
     let chart: ChartResponse =
         serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
     let result = extract_result(chart)?;
+    let timestamps = result
+        .timestamp
+        .ok_or_else(|| fail("no timestamps in chart response"))?;
     let quote = extract_quote(result.indicators)?;
-    let bars = quote
-        .high
+    let bars = timestamps
         .iter()
+        .zip(quote.open.iter())
+        .zip(quote.high.iter())
         .zip(quote.low.iter())
         .zip(quote.close.iter())
-        .filter_map(|((h, l), c)| {
+        .filter_map(|((((ts, o), h), l), c)| {
+            let date = Utc
+                .timestamp_opt(*ts, 0)
+                .single()?
+                .with_timezone(&chrono_tz::America::New_York)
+                .date_naive();
             Some(Bar {
+                date,
+                open: (*o)?,
                 high: (*h)?,
                 low: (*l)?,
                 close: (*c)?,
@@ -305,16 +320,37 @@ mod tests {
 
     #[test]
     fn parse_bars_zips_and_skips_null_legs() {
-        let body = r#"{"chart":{"result":[{"meta":{},"indicators":{"quote":[{
+        // timestamps are 13:30 UTC = 09:30 New York on 2026-06-22..25
+        let body = r#"{"chart":{"result":[{"meta":{},
+            "timestamp":[1782135000,1782221400,1782307800,1782394200],
+            "indicators":{"quote":[{
             "close":[100.0,106.0,null,107.0],
             "volume":[1,1,1,1],
+            "open":[100.5,105.0,106.0,106.5],
             "high":[101.0,108.0,109.0,null],
             "low":[99.0,104.0,105.0,106.0]
         }]}}],"error":null}}"#;
         let bars = parse_bars(body).unwrap();
         assert_eq!(bars.len(), 2); // rows 2 (null close) and 3 (null high) skipped
         assert_eq!(bars[0].high, 101.0);
+        assert_eq!(bars[0].open, 100.5);
         assert_eq!(bars[1].close, 106.0);
+        assert_eq!(
+            bars[0].date,
+            chrono::NaiveDate::from_ymd_opt(2026, 6, 22).unwrap()
+        );
+        assert_eq!(
+            bars[1].date,
+            chrono::NaiveDate::from_ymd_opt(2026, 6, 23).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_bars_requires_timestamps() {
+        let body = r#"{"chart":{"result":[{"meta":{},"indicators":{"quote":[{
+            "close":[100.0],"open":[100.0],"high":[101.0],"low":[99.0]
+        }]}}],"error":null}}"#;
+        assert!(parse_bars(body).is_err());
     }
 
     #[test]

--- a/src/adapters/market/yahoo/screener.rs
+++ b/src/adapters/market/yahoo/screener.rs
@@ -1,0 +1,147 @@
+//! Parser for Yahoo's predefined `day_losers` screener (keyless, unofficial —
+//! failure mode is a clean error, never a partial silent result).
+
+use serde::Deserialize;
+
+use crate::domain::error::DomainError;
+use crate::domain::values::mover::MoverRow;
+
+#[derive(Debug, Deserialize)]
+struct ScreenerResponse {
+    finance: Finance,
+}
+
+#[derive(Debug, Deserialize)]
+struct Finance {
+    #[serde(default)]
+    result: Option<Vec<ScreenerResult>>,
+    #[serde(default)]
+    error: Option<FinanceError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FinanceError {
+    #[serde(default)]
+    code: String,
+    #[serde(default)]
+    description: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ScreenerResult {
+    #[serde(default)]
+    quotes: Vec<ScreenerQuote>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScreenerQuote {
+    #[serde(default)]
+    symbol: Option<String>,
+    #[serde(default)]
+    regular_market_change_percent: Option<f64>,
+    #[serde(default)]
+    regular_market_price: Option<f64>,
+    #[serde(default)]
+    market_cap: Option<u64>,
+    #[serde(default)]
+    average_daily_volume3_month: Option<u64>,
+    #[serde(default)]
+    regular_market_volume: Option<u64>,
+    #[serde(default)]
+    full_exchange_name: Option<String>,
+    #[serde(default)]
+    first_trade_date_milliseconds: Option<i64>,
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "yahoo-screener".into(),
+        message: message.into(),
+    }
+}
+
+/// Parse the screener body into rows plus a count of rows skipped for missing
+/// required fields (symbol, change, price, exchange). Optional fields stay
+/// optional — the quality floor decides what a missing value means.
+pub(crate) fn parse_movers(body: &str) -> Result<(Vec<MoverRow>, usize), DomainError> {
+    let resp: ScreenerResponse =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
+    if let Some(err) = resp.finance.error {
+        return Err(fail(format!("{}: {}", err.code, err.description)));
+    }
+    let quotes = resp
+        .finance
+        .result
+        .and_then(|mut r| (!r.is_empty()).then(|| r.remove(0)))
+        .ok_or_else(|| fail("empty result"))?
+        .quotes;
+
+    let mut rows = Vec::new();
+    let mut skipped = 0usize;
+    for q in quotes {
+        match (
+            q.symbol,
+            q.regular_market_change_percent,
+            q.regular_market_price,
+            q.full_exchange_name,
+        ) {
+            (Some(symbol), Some(change_pct), Some(price), Some(exchange)) => {
+                rows.push(MoverRow {
+                    symbol,
+                    change_pct,
+                    price,
+                    market_cap: q.market_cap,
+                    avg_volume_3mo: q.average_daily_volume3_month,
+                    day_volume: q.regular_market_volume,
+                    exchange,
+                    first_trade_ms: q.first_trade_date_milliseconds,
+                });
+            }
+            _ => skipped += 1,
+        }
+    }
+    if rows.is_empty() {
+        return Err(fail("screener returned no usable rows"));
+    }
+    Ok((rows, skipped))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HAPPY: &str = r#"{"finance":{"result":[{"quotes":[
+        {"symbol":"BLSH","regularMarketChangePercent":-11.24,"regularMarketPrice":24.39,
+         "marketCap":3698703104,"averageDailyVolume3Month":1607109,"regularMarketVolume":3086768,
+         "fullExchangeName":"NYSE","firstTradeDateMilliseconds":1755091800000},
+        {"symbol":"NOCAP","regularMarketChangePercent":-9.0,"regularMarketPrice":12.0,
+         "fullExchangeName":"NasdaqGS"},
+        {"regularMarketChangePercent":-8.0,"regularMarketPrice":5.0,"fullExchangeName":"NYSE"}
+    ]}],"error":null}}"#;
+
+    #[test]
+    fn parses_rows_and_skips_malformed() {
+        let (rows, skipped) = parse_movers(HAPPY).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(skipped, 1); // the symbol-less row
+        assert_eq!(rows[0].symbol, "BLSH");
+        assert!((rows[0].change_pct + 11.24).abs() < 1e-9);
+        assert_eq!(rows[0].market_cap, Some(3698703104));
+        assert_eq!(rows[0].first_trade_ms, Some(1755091800000));
+        // optional fields survive as None
+        assert_eq!(rows[1].market_cap, None);
+        assert_eq!(rows[1].avg_volume_3mo, None);
+    }
+
+    #[test]
+    fn error_body_empty_result_and_no_rows_fail() {
+        let err = r#"{"finance":{"result":null,"error":{"code":"Bad","description":"nope"}}}"#;
+        assert!(parse_movers(err).is_err());
+        assert!(parse_movers(r#"{"finance":{"result":[],"error":null}}"#).is_err());
+        // rows present but all malformed -> error, not silent empty
+        let all_bad = r#"{"finance":{"result":[{"quotes":[{"symbol":"X"}]}],"error":null}}"#;
+        assert!(parse_movers(all_bad).is_err());
+        assert!(parse_movers("not json").is_err());
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,3 +1,4 @@
 pub mod analyzer;
+pub mod filings;
 pub mod market;
 pub mod sources;

--- a/src/application/dip.rs
+++ b/src/application/dip.rs
@@ -198,6 +198,9 @@ struct CheckContext {
     day_volume: Option<u64>,
     avg_volume_3mo: Option<u64>,
     floor: GateStatus,
+    /// Sentiment already computed by the caller (analyze reuses its own
+    /// social fetch); None = fetch here.
+    known_sentiment: Option<SentimentSummary>,
 }
 
 /// Evaluate one ticker end-to-end and return the signal plus the bar history
@@ -230,20 +233,25 @@ async fn check(
     };
 
     let headlines = match deps.news.headlines(&ticker, HEADLINE_COUNT).await {
+        // Undated headlines are kept — they MIGHT be same-day, and dropping
+        // them could hide a catalyst (fail closed, not open).
         Ok(all) => GateEvidence::Available(
             all.into_iter()
-                .filter(|h| {
-                    h.published_at
-                        .with_timezone(&chrono_tz::America::New_York)
-                        .date_naive()
-                        == drop_date
+                .filter(|h| match h.published_at {
+                    Some(at) => {
+                        at.with_timezone(&chrono_tz::America::New_York).date_naive() == drop_date
+                    }
+                    None => true,
                 })
                 .collect(),
         ),
         Err(e) => GateEvidence::Unavailable(e.to_string()),
     };
 
-    let sentiment = sentiment_for(ticker.as_str(), deps.social).await;
+    let sentiment = match ctx.known_sentiment {
+        Some(s) => Some(s),
+        None => sentiment_for(ticker.as_str(), deps.social).await,
+    };
 
     let signal = dip_signal(&DipInputs {
         ticker: ticker.as_str(),
@@ -267,15 +275,30 @@ async fn check(
     Ok((signal, bars))
 }
 
+/// Single-ticker result: the signal plus the sizing overlay when the request
+/// carries margin inputs.
+#[derive(Debug, Serialize)]
+pub struct TickerDipReport {
+    pub signal: DipSignal,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk: Option<RiskFrame>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub margin: Option<MarginFrame>,
+    pub notes: Vec<String>,
+}
+
 /// Single-ticker mode — the "considering a trade" entry point. The quality
 /// floor is Unknown here (no screener row to evaluate), so the verdict caps
 /// at `watch`; volumes come from a market snapshot when one is wired.
+/// `known_sentiment` lets a caller that already fetched social data (analyze)
+/// avoid refetching it.
 pub async fn dip_check(
     ticker_raw: &str,
     req: &DipScanRequest,
     deps: &DipDeps<'_>,
+    known_sentiment: Option<SentimentSummary>,
     now: DateTime<Utc>,
-) -> Result<DipSignal, DomainError> {
+) -> Result<TickerDipReport, DomainError> {
     let (day_volume, avg_volume_3mo) = match deps.market {
         Some(market) => match market.snapshot(&Ticker::parse(ticker_raw)?).await {
             Ok(snap) => (Some(snap.volume), Some(snap.avg_volume)),
@@ -291,10 +314,20 @@ pub async fn dip_check(
         floor: GateStatus::Unknown(
             "quality floor not evaluated — ticker not from the screener universe".into(),
         ),
+        known_sentiment,
     };
-    check(ticker_raw, ctx, spx, req, deps, now)
-        .await
-        .map(|(signal, _)| signal)
+    let (signal, bars) = check(ticker_raw, ctx, spx, req, deps, now).await?;
+    let mut notes = Vec::new();
+    let (risk, margin) = match &req.margin {
+        Some(inputs) => risk_and_margin(&signal.ticker, &bars, inputs, now, &mut notes),
+        None => (None, None),
+    };
+    Ok(TickerDipReport {
+        signal,
+        risk,
+        margin,
+        notes,
+    })
 }
 
 fn verdict_rank(v: Verdict) -> u8 {
@@ -348,6 +381,7 @@ pub async fn dip_scan(
                 day_volume: row.day_volume,
                 avg_volume_3mo: row.avg_volume_3mo,
                 floor: GateStatus::Pass,
+                known_sentiment: None,
             };
             let outcome = check(&row.symbol, ctx, spx_change_pct, req, deps, now).await;
             (row.symbol, row.change_pct, outcome)
@@ -530,7 +564,7 @@ mod tests {
             .collect();
         v.push(Bar {
             date: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap(),
-            open: drop_close + 6.0,
+            open: drop_close + 0.4,
             high: drop_close + 0.5,
             low: drop_close - 7.0,
             close: drop_close,
@@ -731,9 +765,11 @@ mod tests {
         let social = fixture_social();
         let req = DipScanRequest::default();
         let deps = clean_deps(&bars, &news, &filings, &social);
-        let signal = dip_check("GOOD", &req, &deps, post_close_now())
+        let outcome = dip_check("GOOD", &req, &deps, None, post_close_now())
             .await
             .unwrap();
+        assert!(outcome.risk.is_none()); // no margin inputs given
+        let signal = outcome.signal;
         // clean everything, but the floor is unverifiable -> watch, not high
         assert_eq!(signal.verdict, Verdict::Watch);
         assert!(matches!(signal.gates.quality_floor, GateStatus::Unknown(_)));

--- a/src/application/dip.rs
+++ b/src/application/dip.rs
@@ -1,0 +1,737 @@
+//! dip_scan / dip_check orchestration: fetch the losers universe, gate
+//! evidence (bars, filings, headlines, social), run the pure domain signal,
+//! and overlay risk + margin frames. IO and the clock live here; the verdict
+//! logic lives in `domain::dip`.
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Datelike, Timelike, Utc, Weekday};
+use futures::StreamExt;
+use serde::Serialize;
+
+use crate::application::request::AnalysisRequest;
+use crate::domain::dip::{
+    apply_floor, dip_signal, DipInputs, DipSignal, DropBand, FloorReject, GateEvidence, GateStatus,
+    QualityFloor, ScoreWeights, SentimentSummary, Session, Verdict,
+};
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::margin::{margin_frame, MarginFrame, MarginInputs};
+use crate::domain::ports::bar_source::BarSource;
+use crate::domain::ports::filings_source::FilingsSource;
+use crate::domain::ports::market_data_source::MarketDataSource;
+use crate::domain::ports::movers_source::MoversSource;
+use crate::domain::ports::news_source::NewsSource;
+use crate::domain::ports::social_data_source::SocialDataSource;
+use crate::domain::risk::{frame, Direction, RiskFrame};
+use crate::domain::values::bar::Bar;
+use crate::domain::values::mover::MoverRow;
+use crate::domain::values::source_kind::SourceKind;
+
+pub const DEFAULT_SCORE_MIN: f64 = 65.0;
+pub const DEFAULT_DEEP_N: usize = 10;
+pub const MAX_DEEP_N: usize = 25;
+/// Concurrent per-candidate fan-out — bounded for SEC's ≤10 req/s policy.
+const CONCURRENCY: usize = 5;
+/// Equity ETF proxy for the S&P 500 (index symbols don't parse as tickers).
+pub const SPX_PROXY: &str = "SPY";
+const HEADLINE_COUNT: usize = 20;
+const SOCIAL_LIMIT: usize = 50;
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "dip".into(),
+        message: message.into(),
+    }
+}
+
+/// Everything dip_check needs besides the universe feed.
+pub struct DipDeps<'a> {
+    pub bars: &'a dyn BarSource,
+    pub news: &'a dyn NewsSource,
+    pub filings: &'a dyn FilingsSource,
+    pub social: &'a [Box<dyn SocialDataSource>],
+    /// Fills day/avg volume in single-ticker mode (scan mode reads the
+    /// screener row instead).
+    pub market: Option<&'a dyn MarketDataSource>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DipScanRequest {
+    pub count: usize,
+    pub deep_n: usize,
+    pub band: DropBand,
+    pub floor: QualityFloor,
+    pub weights: ScoreWeights,
+    pub score_min: f64,
+    pub margin: Option<MarginInputs>,
+    /// None = no journal write.
+    pub journal_path: Option<PathBuf>,
+}
+
+impl Default for DipScanRequest {
+    fn default() -> Self {
+        Self {
+            count: 100,
+            deep_n: DEFAULT_DEEP_N,
+            band: DropBand::default(),
+            floor: QualityFloor::default(),
+            weights: ScoreWeights::default(),
+            score_min: DEFAULT_SCORE_MIN,
+            margin: None,
+            journal_path: None,
+        }
+    }
+}
+
+/// `~/.openintel/dip_journal.jsonl`, or None when no home dir resolves.
+pub fn default_journal_path() -> Option<PathBuf> {
+    std::env::home_dir().map(|h| h.join(".openintel").join("dip_journal.jsonl"))
+}
+
+#[derive(Debug, Serialize)]
+pub struct DipCandidate {
+    pub ticker: String,
+    pub change_pct: f64,
+    /// Drop-day close (intraday: last traded price of the partial bar).
+    pub price: f64,
+    pub signal: DipSignal,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk: Option<RiskFrame>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub margin: Option<MarginFrame>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EntryError {
+    pub ticker: String,
+    pub error: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DipScanReport {
+    pub generated_at: DateTime<Utc>,
+    pub session: Session,
+    pub spx_proxy: &'static str,
+    pub spx_change_pct: Option<f64>,
+    pub universe_size: usize,
+    pub band_excluded: usize,
+    pub floor_rejects: Vec<FloorReject>,
+    pub candidates: Vec<DipCandidate>,
+    pub errors: Vec<EntryError>,
+    pub notes: Vec<String>,
+}
+
+/// Trading-session state in New York. Weekends and anything outside
+/// 09:30–16:05 ET count as post-close (the last completed session is final).
+pub fn session_for(now: DateTime<Utc>) -> Session {
+    let ny = now.with_timezone(&chrono_tz::America::New_York);
+    if matches!(ny.weekday(), Weekday::Sat | Weekday::Sun) {
+        return Session::PostClose;
+    }
+    let minutes = ny.hour() * 60 + ny.minute();
+    if (9 * 60 + 30..16 * 60 + 5).contains(&minutes) {
+        Session::Intraday
+    } else {
+        Session::PostClose
+    }
+}
+
+/// Split history into (prior bars, drop-day bar). The drop day is the last
+/// bar's session — final post-close, partial intraday.
+fn split_history(bars: &[Bar]) -> Result<(&[Bar], Bar), DomainError> {
+    match bars.split_last() {
+        Some((last, prior)) if !prior.is_empty() => Ok((prior, *last)),
+        _ => Err(fail("no price history")),
+    }
+}
+
+fn change_pct_from(prior: &[Bar], last: &Bar) -> Result<f64, DomainError> {
+    let prev_close = prior
+        .last()
+        .map(|b| b.close)
+        .ok_or_else(|| fail("no previous close"))?;
+    if prev_close <= 0.0 {
+        return Err(fail("previous close is not positive"));
+    }
+    Ok((last.close - prev_close) / prev_close * 100.0)
+}
+
+/// The proxy index's drop-day change, from its own bar history.
+async fn spx_change(bars_src: &dyn BarSource) -> Result<f64, DomainError> {
+    let ticker = Ticker::parse(SPX_PROXY)?;
+    let bars = bars_src.bars(&ticker).await?;
+    let (prior, last) = split_history(&bars)?;
+    change_pct_from(prior, &last)
+}
+
+/// Social-only sentiment for the divergence component. Any failure (including
+/// "no posts") degrades to None — the domain scores divergence 0 with a note.
+async fn sentiment_for(
+    ticker: &str,
+    social: &[Box<dyn SocialDataSource>],
+) -> Option<SentimentSummary> {
+    if social.is_empty() {
+        return None;
+    }
+    let req = AnalysisRequest {
+        ticker: ticker.to_string(),
+        enabled_sources: SourceKind::ALL.to_vec(),
+        market_enabled: false,
+        limit: SOCIAL_LIMIT,
+        engine: crate::domain::engine::config::EngineConfig::default(),
+    };
+    let report = crate::application::analyze(&req, social, None).await.ok()?;
+    Some(SentimentSummary {
+        net_sentiment: report.social.net_sentiment.value(),
+        mentions: report.social.total_mentions,
+    })
+}
+
+struct CheckContext {
+    change_pct: Option<f64>,
+    day_volume: Option<u64>,
+    avg_volume_3mo: Option<u64>,
+    floor: GateStatus,
+}
+
+/// Evaluate one ticker end-to-end and return the signal plus the bar history
+/// (so callers can size a risk frame without refetching).
+async fn check(
+    ticker_raw: &str,
+    ctx: CheckContext,
+    spx_change_pct: Option<f64>,
+    req: &DipScanRequest,
+    deps: &DipDeps<'_>,
+    now: DateTime<Utc>,
+) -> Result<(DipSignal, Vec<Bar>), DomainError> {
+    let ticker = Ticker::parse(ticker_raw)?;
+    let session = session_for(now);
+
+    let bars = deps.bars.bars(&ticker).await?;
+    let (prior, drop_bar) = split_history(&bars)?;
+    let drop_date = drop_bar.date;
+    let change_pct = match ctx.change_pct {
+        Some(c) => c,
+        None => change_pct_from(prior, &drop_bar)?,
+    };
+
+    let filings = {
+        let since = drop_date.pred_opt().unwrap_or(drop_date);
+        match deps.filings.recent_filings(&ticker, since).await {
+            Ok(filings) => GateEvidence::Available(filings),
+            Err(e) => GateEvidence::Unavailable(e.to_string()),
+        }
+    };
+
+    let headlines = match deps.news.headlines(&ticker, HEADLINE_COUNT).await {
+        Ok(all) => GateEvidence::Available(
+            all.into_iter()
+                .filter(|h| {
+                    h.published_at
+                        .with_timezone(&chrono_tz::America::New_York)
+                        .date_naive()
+                        == drop_date
+                })
+                .collect(),
+        ),
+        Err(e) => GateEvidence::Unavailable(e.to_string()),
+    };
+
+    let sentiment = sentiment_for(ticker.as_str(), deps.social).await;
+
+    let signal = dip_signal(&DipInputs {
+        ticker: ticker.as_str(),
+        prior_bars: prior,
+        drop_day_bar: Some(drop_bar),
+        drop_date,
+        last_price: drop_bar.close,
+        change_pct,
+        day_volume: ctx.day_volume,
+        avg_volume_3mo: ctx.avg_volume_3mo,
+        spx_change_pct,
+        filings,
+        headlines,
+        sentiment,
+        session,
+        floor: ctx.floor,
+        band: req.band,
+        weights: &req.weights,
+        score_min: req.score_min,
+    })?;
+    Ok((signal, bars))
+}
+
+/// Single-ticker mode — the "considering a trade" entry point. The quality
+/// floor is Unknown here (no screener row to evaluate), so the verdict caps
+/// at `watch`; volumes come from a market snapshot when one is wired.
+pub async fn dip_check(
+    ticker_raw: &str,
+    req: &DipScanRequest,
+    deps: &DipDeps<'_>,
+    now: DateTime<Utc>,
+) -> Result<DipSignal, DomainError> {
+    let (day_volume, avg_volume_3mo) = match deps.market {
+        Some(market) => match market.snapshot(&Ticker::parse(ticker_raw)?).await {
+            Ok(snap) => (Some(snap.volume), Some(snap.avg_volume)),
+            Err(_) => (None, None),
+        },
+        None => (None, None),
+    };
+    let spx = spx_change(deps.bars).await.ok();
+    let ctx = CheckContext {
+        change_pct: None,
+        day_volume,
+        avg_volume_3mo,
+        floor: GateStatus::Unknown(
+            "quality floor not evaluated — ticker not from the screener universe".into(),
+        ),
+    };
+    check(ticker_raw, ctx, spx, req, deps, now)
+        .await
+        .map(|(signal, _)| signal)
+}
+
+fn verdict_rank(v: Verdict) -> u8 {
+    match v {
+        Verdict::HighConfidence => 2,
+        Verdict::Watch => 1,
+        Verdict::NoSetup => 0,
+    }
+}
+
+/// Universe mode: losers list → quality floor → drop band → bounded
+/// concurrent dip_check → risk/margin overlay → rank → journal.
+pub async fn dip_scan(
+    req: &DipScanRequest,
+    movers: &dyn MoversSource,
+    deps: &DipDeps<'_>,
+    now: DateTime<Utc>,
+) -> Result<DipScanReport, DomainError> {
+    let rows = movers.day_losers(req.count).await?;
+    let universe_size = rows.len();
+    let mut notes: Vec<String> = Vec::new();
+
+    let (survivors, floor_rejects) = apply_floor(&rows, &req.floor, now.timestamp_millis());
+    let (eligible, band_excluded): (Vec<MoverRow>, Vec<MoverRow>) = survivors
+        .into_iter()
+        .partition(|r| r.change_pct >= req.band.min_pct && r.change_pct <= req.band.max_pct);
+    let band_excluded = band_excluded.len();
+
+    let deep_n = req.deep_n.clamp(1, MAX_DEEP_N);
+    if eligible.len() > deep_n {
+        notes.push(format!(
+            "{} band-eligible candidates — deep-analyzing the worst {deep_n} (raise deep_n to widen)",
+            eligible.len()
+        ));
+    }
+    let deep: Vec<MoverRow> = eligible.into_iter().take(deep_n).collect();
+
+    let spx_change_pct = match spx_change(deps.bars).await {
+        Ok(c) => Some(c),
+        Err(e) => {
+            notes.push(format!("index proxy {SPX_PROXY} unavailable: {e}"));
+            None
+        }
+    };
+
+    let results: Vec<(String, f64, Result<(DipSignal, Vec<Bar>), DomainError>)> =
+        futures::stream::iter(deep.into_iter().map(|row| async move {
+            let ctx = CheckContext {
+                change_pct: Some(row.change_pct),
+                day_volume: row.day_volume,
+                avg_volume_3mo: row.avg_volume_3mo,
+                floor: GateStatus::Pass,
+            };
+            let outcome = check(&row.symbol, ctx, spx_change_pct, req, deps, now).await;
+            (row.symbol, row.change_pct, outcome)
+        }))
+        .buffer_unordered(CONCURRENCY)
+        .collect()
+        .await;
+
+    let mut candidates: Vec<DipCandidate> = Vec::new();
+    let mut errors: Vec<EntryError> = Vec::new();
+    for (ticker, change_pct, outcome) in results {
+        match outcome {
+            Ok((signal, bars)) => {
+                let (risk, margin) = match &req.margin {
+                    Some(inputs) => risk_and_margin(&ticker, &bars, inputs, now, &mut notes),
+                    None => (None, None),
+                };
+                let price = bars.last().map(|b| b.close).unwrap_or_default();
+                candidates.push(DipCandidate {
+                    ticker,
+                    change_pct,
+                    price,
+                    signal,
+                    risk,
+                    margin,
+                });
+            }
+            Err(e) => errors.push(EntryError {
+                ticker,
+                error: e.to_string(),
+            }),
+        }
+    }
+
+    candidates.sort_by(|a, b| {
+        verdict_rank(b.signal.verdict)
+            .cmp(&verdict_rank(a.signal.verdict))
+            .then_with(|| {
+                b.signal
+                    .score
+                    .partial_cmp(&a.signal.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    });
+
+    let mut report = DipScanReport {
+        generated_at: now,
+        session: session_for(now),
+        spx_proxy: SPX_PROXY,
+        spx_change_pct,
+        universe_size,
+        band_excluded,
+        floor_rejects,
+        candidates,
+        errors,
+        notes,
+    };
+    if let Some(path) = &req.journal_path {
+        if let Err(e) = append_journal(path, &report) {
+            report.notes.push(format!("journal write failed: {e}"));
+        }
+    }
+    Ok(report)
+}
+
+/// Size a long risk frame off the fetched bars, then overlay margin.
+/// Failures degrade to None with a note — sizing must never sink the scan.
+fn risk_and_margin(
+    ticker: &str,
+    bars: &[Bar],
+    inputs: &MarginInputs,
+    now: DateTime<Utc>,
+    notes: &mut Vec<String>,
+) -> (Option<RiskFrame>, Option<MarginFrame>) {
+    let risk_pct = inputs.risk_pct.clamp(0.001, 0.05);
+    let budget = inputs.equity_usd * risk_pct;
+    let entry = match bars.last() {
+        Some(b) => b.close,
+        None => return (None, None),
+    };
+    let risk = match frame(ticker, bars, Direction::Long, entry, budget, 2.0, now) {
+        Ok(r) => r,
+        Err(e) => {
+            notes.push(format!("{ticker}: risk frame unavailable: {e}"));
+            return (None, None);
+        }
+    };
+    match margin_frame(&risk, inputs) {
+        Ok(m) => (Some(risk), Some(m)),
+        Err(e) => {
+            notes.push(format!("{ticker}: margin frame unavailable: {e}"));
+            (Some(risk), None)
+        }
+    }
+}
+
+/// One compact JSONL line per scan — the record that lets the v0 weights be
+/// graded against forward returns later.
+#[derive(Serialize)]
+struct JournalLine<'a> {
+    generated_at: DateTime<Utc>,
+    session: Session,
+    spx_change_pct: Option<f64>,
+    candidates: Vec<JournalCandidate<'a>>,
+}
+
+#[derive(Serialize)]
+struct JournalCandidate<'a> {
+    ticker: &'a str,
+    change_pct: f64,
+    price: f64,
+    score: f64,
+    verdict: Verdict,
+}
+
+fn append_journal(path: &PathBuf, report: &DipScanReport) -> Result<(), String> {
+    use std::io::Write as _;
+    let line = JournalLine {
+        generated_at: report.generated_at,
+        session: report.session,
+        spx_change_pct: report.spx_change_pct,
+        candidates: report
+            .candidates
+            .iter()
+            .map(|c| JournalCandidate {
+                ticker: &c.ticker,
+                change_pct: c.change_pct,
+                price: c.price,
+                score: c.signal.score,
+                verdict: c.signal.verdict,
+            })
+            .collect(),
+    };
+    let json = serde_json::to_string(&line).map_err(|e| e.to_string())?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| e.to_string())?;
+    writeln!(file, "{json}").map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::filings::mock_filings::MockFilingsSource;
+    use crate::adapters::market::mock_movers::MockMoversSource;
+    use crate::adapters::market::mock_news::MockNewsSource;
+    use crate::adapters::sources::test_fixtures::fixture_social;
+    use crate::domain::values::filing::Filing;
+    use async_trait::async_trait;
+    use chrono::{NaiveDate, TimeZone};
+    use std::collections::HashMap;
+
+    /// Friday 2026-08-14 17:30 New York = 21:30 UTC (EDT) — post-close.
+    fn post_close_now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 14, 21, 30, 0).unwrap()
+    }
+
+    fn d(day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 7, day).unwrap()
+    }
+
+    /// 30 prior bars gently declining + a drop-day bar that closes strong.
+    fn dip_bars(drop_close: f64) -> Vec<Bar> {
+        let mut v: Vec<Bar> = (1..=30)
+            .map(|i| {
+                let c = 110.0 - i as f64 * 0.5;
+                Bar {
+                    date: d(i),
+                    open: c,
+                    high: c + 1.0,
+                    low: c - 1.0,
+                    close: c,
+                }
+            })
+            .collect();
+        v.push(Bar {
+            date: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap(),
+            open: drop_close + 6.0,
+            high: drop_close + 0.5,
+            low: drop_close - 7.0,
+            close: drop_close,
+        });
+        v
+    }
+
+    /// Flat index proxy: tiny change so candidate moves are idiosyncratic.
+    fn spy_bars() -> Vec<Bar> {
+        (1..=31)
+            .map(|i| Bar {
+                date: d(i.min(30)).succ_opt().unwrap(),
+                open: 500.0,
+                high: 501.0,
+                low: 499.0,
+                close: if i == 31 { 499.0 } else { 500.0 },
+            })
+            .collect()
+    }
+
+    struct MapBars(HashMap<String, Vec<Bar>>);
+
+    #[async_trait]
+    impl BarSource for MapBars {
+        async fn bars(&self, t: &Ticker) -> Result<Vec<Bar>, DomainError> {
+            self.0
+                .get(t.as_str())
+                .cloned()
+                .ok_or_else(|| DomainError::SourceFailure {
+                    name: "map-bars".into(),
+                    message: format!("no bars for {}", t.as_str()),
+                })
+        }
+    }
+
+    fn row(symbol: &str, change_pct: f64) -> MoverRow {
+        MoverRow {
+            symbol: symbol.into(),
+            change_pct,
+            price: 87.0,
+            market_cap: Some(2_000_000_000),
+            avg_volume_3mo: Some(5_000_000),
+            day_volume: Some(4_000_000),
+            exchange: "NYSE".into(),
+            first_trade_ms: Some(0),
+        }
+    }
+
+    fn bars_map() -> MapBars {
+        let mut m = HashMap::new();
+        m.insert("GOOD".to_string(), dip_bars(87.4));
+        m.insert("FILED".to_string(), dip_bars(87.4));
+        m.insert(SPX_PROXY.to_string(), spy_bars());
+        // NOBAR deliberately absent
+        MapBars(m)
+    }
+
+    #[test]
+    fn session_boundaries_in_new_york() {
+        // Sat noon UTC
+        let sat = Utc.with_ymd_and_hms(2026, 8, 15, 12, 0, 0).unwrap();
+        assert_eq!(session_for(sat), Session::PostClose);
+        // Friday 12:00 NY = 16:00 UTC (EDT)
+        let midday = Utc.with_ymd_and_hms(2026, 8, 14, 16, 0, 0).unwrap();
+        assert_eq!(session_for(midday), Session::Intraday);
+        // Friday 16:10 NY
+        let after = Utc.with_ymd_and_hms(2026, 8, 14, 20, 10, 0).unwrap();
+        assert_eq!(session_for(after), Session::PostClose);
+        // Friday 08:00 NY (pre-open: last session is final)
+        let pre = Utc.with_ymd_and_hms(2026, 8, 14, 12, 0, 0).unwrap();
+        assert_eq!(session_for(pre), Session::PostClose);
+    }
+
+    fn clean_deps<'a>(
+        bars: &'a MapBars,
+        news: &'a MockNewsSource,
+        filings: &'a MockFilingsSource,
+        social: &'a [Box<dyn SocialDataSource>],
+    ) -> DipDeps<'a> {
+        DipDeps {
+            bars,
+            news,
+            filings,
+            social,
+            market: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn scan_ranks_verdicts_and_collects_errors() {
+        let bars = bars_map();
+        let news = MockNewsSource(Ok(vec![]));
+        let filings = MockFilingsSource(Ok(vec![]));
+        let social = fixture_social();
+        let movers = MockMoversSource(vec![
+            row("CRASH", -30.0), // outside band -> excluded pre-analysis
+            row("GOOD", -8.0),   // clean candidate
+            row("NOBAR", -7.0),  // bar fetch fails -> entry error
+            MoverRow {
+                price: 2.0,
+                ..row("CHEAP", -9.0) // floor reject
+            },
+        ]);
+        let req = DipScanRequest::default();
+        let deps = clean_deps(&bars, &news, &filings, &social);
+        let report = dip_scan(&req, &movers, &deps, post_close_now())
+            .await
+            .unwrap();
+
+        assert_eq!(report.universe_size, 4);
+        assert_eq!(report.band_excluded, 1);
+        assert_eq!(report.floor_rejects.len(), 1);
+        assert_eq!(report.floor_rejects[0].symbol, "CHEAP");
+        assert_eq!(report.errors.len(), 1);
+        assert_eq!(report.errors[0].ticker, "NOBAR");
+        assert_eq!(report.candidates.len(), 1);
+        let good = &report.candidates[0];
+        assert_eq!(good.ticker, "GOOD");
+        assert_eq!(good.signal.verdict, Verdict::HighConfidence);
+        assert!(good.risk.is_none() && good.margin.is_none()); // no equity given
+        assert_eq!(report.session, Session::PostClose);
+        assert!(report.spx_change_pct.unwrap().abs() < 1.0);
+    }
+
+    #[tokio::test]
+    async fn scan_fails_closed_when_edgar_down_and_kills_on_filing() {
+        let bars = bars_map();
+        let news = MockNewsSource(Ok(vec![]));
+        let social = fixture_social();
+        let movers = MockMoversSource(vec![row("GOOD", -8.0)]);
+        let req = DipScanRequest::default();
+
+        // EDGAR down -> watch, never high_confidence
+        let filings = MockFilingsSource(Err("EDGAR unreachable".into()));
+        let deps = clean_deps(&bars, &news, &filings, &social);
+        let report = dip_scan(&req, &movers, &deps, post_close_now())
+            .await
+            .unwrap();
+        assert_eq!(report.candidates[0].signal.verdict, Verdict::Watch);
+
+        // 8-K on the drop day -> no_setup with evidence
+        let filings = MockFilingsSource(Ok(vec![Filing {
+            form: "8-K".into(),
+            filed_on: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap(),
+        }]));
+        let deps = clean_deps(&bars, &news, &filings, &social);
+        let report = dip_scan(&req, &movers, &deps, post_close_now())
+            .await
+            .unwrap();
+        assert_eq!(report.candidates[0].signal.verdict, Verdict::NoSetup);
+        assert!(!report.candidates[0].signal.catalyst_evidence.is_empty());
+    }
+
+    #[tokio::test]
+    async fn margin_section_present_only_with_equity_and_journal_written() {
+        let bars = bars_map();
+        let news = MockNewsSource(Ok(vec![]));
+        let filings = MockFilingsSource(Ok(vec![]));
+        let social = fixture_social();
+        let movers = MockMoversSource(vec![row("GOOD", -8.0)]);
+
+        let journal = std::env::temp_dir().join(format!(
+            "openintel-dip-test-{}/journal.jsonl",
+            std::process::id()
+        ));
+        let req = DipScanRequest {
+            margin: Some(MarginInputs {
+                equity_usd: 10_000.0,
+                ..MarginInputs::default()
+            }),
+            journal_path: Some(journal.clone()),
+            ..DipScanRequest::default()
+        };
+        let deps = clean_deps(&bars, &news, &filings, &social);
+        let report = dip_scan(&req, &movers, &deps, post_close_now())
+            .await
+            .unwrap();
+
+        let c = &report.candidates[0];
+        let risk = c.risk.as_ref().unwrap();
+        assert!((risk.budget_usd - 100.0).abs() < 1e-9); // 1% of 10k
+        let margin = c.margin.as_ref().unwrap();
+        assert_eq!(margin.leverage, 2.0);
+        assert!(margin.shares <= risk.shares);
+
+        let line = std::fs::read_to_string(&journal).unwrap();
+        assert!(line.contains("\"ticker\":\"GOOD\""));
+        assert!(line.contains("\"verdict\":\"high_confidence\""));
+        assert!(line.trim().lines().count() == 1);
+        let _ = std::fs::remove_dir_all(journal.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn single_ticker_mode_caps_at_watch() {
+        let bars = bars_map();
+        let news = MockNewsSource(Ok(vec![]));
+        let filings = MockFilingsSource(Ok(vec![]));
+        let social = fixture_social();
+        let req = DipScanRequest::default();
+        let deps = clean_deps(&bars, &news, &filings, &social);
+        let signal = dip_check("GOOD", &req, &deps, post_close_now())
+            .await
+            .unwrap();
+        // clean everything, but the floor is unverifiable -> watch, not high
+        assert_eq!(signal.verdict, Verdict::Watch);
+        assert!(matches!(signal.gates.quality_floor, GateStatus::Unknown(_)));
+        // change computed from bars: 95 -> 87.4 is ~-8%
+        assert!((signal.metrics.excess_vs_spx_pct.unwrap() + 7.8).abs() < 0.5);
+    }
+}

--- a/src/application/dip.rs
+++ b/src/application/dip.rs
@@ -335,7 +335,8 @@ pub async fn dip_scan(
         }
     };
 
-    let results: Vec<(String, f64, Result<(DipSignal, Vec<Bar>), DomainError>)> =
+    type CheckOutcome = Result<(DipSignal, Vec<Bar>), DomainError>;
+    let results: Vec<(String, f64, CheckOutcome)> =
         futures::stream::iter(deep.into_iter().map(|row| async move {
             let ctx = CheckContext {
                 change_pct: Some(row.change_pct),

--- a/src/application/dip.rs
+++ b/src/application/dip.rs
@@ -28,6 +28,11 @@ use crate::domain::values::bar::Bar;
 use crate::domain::values::mover::MoverRow;
 use crate::domain::values::source_kind::SourceKind;
 
+/// Appended to every dip output (CLI footer; MCP `framing` field). Single
+/// source of truth — do not duplicate this string.
+pub const FRAMING: &str = "dip_scan grades setup conformance — it never predicts outcomes \
+or recommends entry. Zero candidates is a normal result. Margin amplifies losses as well as gains.";
+
 pub const DEFAULT_SCORE_MIN: f64 = 65.0;
 pub const DEFAULT_DEEP_N: usize = 10;
 pub const MAX_DEEP_N: usize = 25;

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,4 +1,5 @@
 pub mod analyze;
+pub mod dip;
 pub mod pulse;
 pub mod request;
 pub mod risk;

--- a/src/application/risk.rs
+++ b/src/application/risk.rs
@@ -64,13 +64,18 @@ mod tests {
     }
 
     fn history() -> Vec<Bar> {
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
         let mut v = vec![Bar {
+            date,
+            open: 100.0,
             high: 101.0,
             low: 99.0,
             close: 100.0,
         }];
         for _ in 0..15 {
             v.push(Bar {
+                date,
+                open: 106.0,
                 high: 108.0,
                 low: 104.0,
                 close: 106.0,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -29,6 +29,9 @@ pub enum Command {
 
     /// Deterministic risk math for one trade idea: ATR stop, budget-capped size, R targets
     Risk(RiskArgs),
+
+    /// Scan the day's biggest losers for gated dip setups (grades conformance, never advises)
+    Dip(DipArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -129,6 +132,75 @@ pub struct RiskArgs {
     /// Entry price override (default: last close)
     #[arg(long)]
     pub entry: Option<f64>,
+
+    #[arg(long, value_enum, default_value_t = FormatArg::Table)]
+    pub format: FormatArg,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct DipArgs {
+    /// Evaluate one symbol instead of scanning the losers universe
+    pub ticker: Option<String>,
+
+    /// Losers to pull from the screener (1-100)
+    #[arg(long, default_value_t = 100)]
+    pub count: usize,
+
+    /// Floor+band survivors to deep-analyze (1-25)
+    #[arg(long, default_value_t = 10)]
+    pub deep: usize,
+
+    /// Worst day-change eligible, in percent
+    #[arg(long = "band-min", default_value_t = -15.0, allow_negative_numbers = true)]
+    pub band_min: f64,
+
+    /// Mildest day-change eligible, in percent
+    #[arg(long = "band-max", default_value_t = -4.0, allow_negative_numbers = true)]
+    pub band_max: f64,
+
+    /// Account equity in USD — enables the risk + margin sizing section
+    #[arg(long)]
+    pub equity: Option<f64>,
+
+    /// Buying-power multiple (overnight Reg-T caps at 2)
+    #[arg(long, default_value_t = 2.0)]
+    pub leverage: f64,
+
+    /// Unlock 4x intraday buying power (not holdable overnight)
+    #[arg(long)]
+    pub intraday_bp: bool,
+
+    /// Maintenance requirement fraction
+    #[arg(long, default_value_t = 0.25)]
+    pub maintenance: f64,
+
+    /// Fraction of equity risked to the stop per position
+    #[arg(long = "risk-pct", default_value_t = 0.01)]
+    pub risk_pct: f64,
+
+    /// Minimum composite score for the score gate
+    #[arg(long = "score-min", default_value_t = 65.0)]
+    pub score_min: f64,
+
+    /// Quality floor: minimum share price
+    #[arg(long = "min-price", default_value_t = 5.0)]
+    pub min_price: f64,
+
+    /// Quality floor: minimum market cap in USD
+    #[arg(long = "min-cap", default_value_t = 500_000_000)]
+    pub min_cap: u64,
+
+    /// Quality floor: minimum 3-month average daily volume in shares
+    #[arg(long = "min-volume", default_value_t = 1_000_000)]
+    pub min_volume: u64,
+
+    /// Quality floor: minimum days since listing
+    #[arg(long = "min-listed-days", default_value_t = 180)]
+    pub min_listed_days: i64,
+
+    /// Skip the scan journal (~/.openintel/dip_journal.jsonl)
+    #[arg(long)]
+    pub no_journal: bool,
 
     #[arg(long, value_enum, default_value_t = FormatArg::Table)]
     pub format: FormatArg,

--- a/src/cli/dip.rs
+++ b/src/cli/dip.rs
@@ -7,7 +7,8 @@ use chrono::Utc;
 use crate::adapters::filings::edgar::EdgarSource;
 use crate::adapters::market::yahoo::YahooMarketSource;
 use crate::application::dip::{
-    default_journal_path, dip_check, dip_scan, DipCandidate, DipDeps, DipScanReport, DipScanRequest,
+    default_journal_path, dip_check, dip_scan, DipCandidate, DipDeps, DipScanReport,
+    DipScanRequest, FRAMING,
 };
 use crate::application::DISCLAIMER;
 use crate::cli::args::{DipArgs, FormatArg};
@@ -16,8 +17,7 @@ use crate::domain::dip::{DipSignal, DropBand, GateStatus, QualityFloor};
 use crate::domain::error::DomainError;
 use crate::domain::margin::MarginInputs;
 
-pub const FRAMING_LINE: &str = "dip_scan grades setup conformance — it never predicts outcomes \
-or recommends entry. Zero candidates is a normal result. Margin amplifies losses as well as gains.";
+const FRAMING_LINE: &str = FRAMING;
 
 fn request_from(args: &DipArgs) -> DipScanRequest {
     DipScanRequest {

--- a/src/cli/dip.rs
+++ b/src/cli/dip.rs
@@ -1,0 +1,356 @@
+//! CLI leaf for `openintel dip` — returns rendered Strings; main prints.
+
+use std::fmt::Write as _;
+
+use chrono::Utc;
+
+use crate::adapters::filings::edgar::EdgarSource;
+use crate::adapters::market::yahoo::YahooMarketSource;
+use crate::application::dip::{
+    default_journal_path, dip_check, dip_scan, DipCandidate, DipDeps, DipScanReport, DipScanRequest,
+};
+use crate::application::DISCLAIMER;
+use crate::cli::args::{DipArgs, FormatArg};
+use crate::config::secrets::Credentials;
+use crate::domain::dip::{DipSignal, DropBand, GateStatus, QualityFloor};
+use crate::domain::error::DomainError;
+use crate::domain::margin::MarginInputs;
+
+pub const FRAMING_LINE: &str = "dip_scan grades setup conformance — it never predicts outcomes \
+or recommends entry. Zero candidates is a normal result. Margin amplifies losses as well as gains.";
+
+fn request_from(args: &DipArgs) -> DipScanRequest {
+    DipScanRequest {
+        count: args.count,
+        deep_n: args.deep,
+        band: DropBand {
+            min_pct: args.band_min,
+            max_pct: args.band_max,
+        },
+        floor: QualityFloor {
+            min_price: args.min_price,
+            min_market_cap: args.min_cap,
+            min_avg_volume: args.min_volume,
+            min_listed_days: args.min_listed_days,
+        },
+        score_min: args.score_min,
+        margin: args.equity.map(|equity_usd| MarginInputs {
+            equity_usd,
+            leverage: args.leverage,
+            maintenance: args.maintenance,
+            risk_pct: args.risk_pct,
+            intraday_bp: args.intraday_bp,
+        }),
+        journal_path: (!args.no_journal).then(default_journal_path).flatten(),
+        ..DipScanRequest::default()
+    }
+}
+
+pub async fn run(args: &DipArgs, credentials: &Credentials) -> Result<String, DomainError> {
+    let yahoo = YahooMarketSource::new()?;
+    let edgar = EdgarSource::new()?;
+    let social = crate::adapters::sources::build_social_sources(credentials);
+    let deps = DipDeps {
+        bars: &yahoo,
+        news: &yahoo,
+        filings: &edgar,
+        social: &social,
+        market: Some(&yahoo),
+    };
+    let req = request_from(args);
+    let now = Utc::now();
+
+    match &args.ticker {
+        Some(ticker) => {
+            let signal = dip_check(ticker, &req, &deps, now).await?;
+            Ok(match args.format {
+                FormatArg::Table => render_signal_table(&signal),
+                FormatArg::Json => render_json(&signal)?,
+            })
+        }
+        None => {
+            let report = dip_scan(&req, &yahoo, &deps, now).await?;
+            Ok(match args.format {
+                FormatArg::Table => render_report_table(&report),
+                FormatArg::Json => render_json(&report)?,
+            })
+        }
+    }
+}
+
+fn render_json<T: serde::Serialize>(payload: &T) -> Result<String, DomainError> {
+    #[derive(serde::Serialize)]
+    struct Out<'a, T: serde::Serialize> {
+        report: &'a T,
+        framing: &'static str,
+        disclaimer: &'static str,
+    }
+    serde_json::to_string_pretty(&Out {
+        report: payload,
+        framing: FRAMING_LINE,
+        disclaimer: DISCLAIMER,
+    })
+    .map_err(|e| DomainError::SourceFailure {
+        name: "dip".into(),
+        message: format!("render failed: {e}"),
+    })
+}
+
+fn gate_mark(g: &GateStatus) -> &'static str {
+    match g {
+        GateStatus::Pass => "✓",
+        GateStatus::Fail(_) => "✗",
+        GateStatus::Unknown(_) => "?",
+    }
+}
+
+fn gates_line(signal: &DipSignal) -> String {
+    let g = &signal.gates;
+    format!(
+        "floor {} · band {} · filing {} · headline {} · index {} · close {} · score {}",
+        gate_mark(&g.quality_floor),
+        gate_mark(&g.drop_band),
+        gate_mark(&g.no_filing),
+        gate_mark(&g.no_catalyst_headline),
+        gate_mark(&g.idiosyncratic),
+        gate_mark(&g.close_strength),
+        gate_mark(&g.score_floor),
+    )
+}
+
+fn opt(v: Option<f64>, fmt: &dyn Fn(f64) -> String) -> String {
+    v.map_or_else(|| "n/a".to_string(), fmt)
+}
+
+fn write_signal_block(out: &mut String, signal: &DipSignal) {
+    let m = &signal.metrics;
+    let _ = writeln!(
+        out,
+        "  stretch {:.1} ATR · RSI {} · vol {} · close-loc {} · vs index {} · down {}d",
+        m.stretch_atr,
+        opt(m.rsi14, &|v| format!("{v:.0}")),
+        opt(m.volume_ratio, &|v| format!("{v:.1}x")),
+        opt(m.close_location, &|v| format!("{v:.2}")),
+        opt(m.excess_vs_spx_pct, &|v| format!("{v:+.1}%")),
+        m.down_days,
+    );
+    let _ = writeln!(out, "  gates: {}", gates_line(signal));
+    for e in &signal.catalyst_evidence {
+        let _ = writeln!(out, "  evidence: {e}");
+    }
+    for n in &signal.notes {
+        let _ = writeln!(out, "  note: {n}");
+    }
+}
+
+fn write_sizing(out: &mut String, c: &DipCandidate) {
+    if let Some(risk) = &c.risk {
+        let _ = writeln!(
+            out,
+            "  size: {} sh @ {:.2} · stop {:.2} · max loss ${:.2}",
+            risk.shares, risk.entry, risk.stop, risk.max_loss_usd
+        );
+    }
+    if let Some(m) = &c.margin {
+        let _ = writeln!(
+            out,
+            "  margin ({}x): {} sh · borrowed ${:.2} · m-call {} ({} away)",
+            m.leverage,
+            m.shares,
+            m.borrowed_usd,
+            m.margin_call_price
+                .map_or_else(|| "n/a".into(), |p| format!("{p:.2}")),
+            m.mc_distance_pct
+                .map_or_else(|| "n/a".to_string(), |p| format!("{p:.0}%")),
+        );
+        for n in &m.notes {
+            let _ = writeln!(out, "  margin note: {n}");
+        }
+    }
+}
+
+fn render_report_table(r: &DipScanReport) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "=== OpenIntel Dip Scan — {} ({:?}) ===",
+        r.generated_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        r.session
+    );
+    let _ = writeln!(
+        out,
+        "universe: {} losers · floor rejects: {} · band-excluded: {} · {} {}\n",
+        r.universe_size,
+        r.floor_rejects.len(),
+        r.band_excluded,
+        r.spx_proxy,
+        opt(r.spx_change_pct, &|v| format!("{v:+.1}%")),
+    );
+
+    if r.candidates.is_empty() {
+        let _ = writeln!(out, "no setups today — that's a result, not an error");
+    }
+    for (i, c) in r.candidates.iter().enumerate() {
+        let _ = writeln!(
+            out,
+            "{}. {:?}  {}  {:+.1}%  (score {:.0}/{:.0})",
+            i + 1,
+            c.signal.verdict,
+            c.ticker,
+            c.change_pct,
+            c.signal.score,
+            c.signal.score_max,
+        );
+        write_signal_block(&mut out, &c.signal);
+        write_sizing(&mut out, c);
+        let _ = writeln!(out);
+    }
+
+    for e in &r.errors {
+        let _ = writeln!(out, "error: {} — {}", e.ticker, e.error);
+    }
+    for n in &r.notes {
+        let _ = writeln!(out, "note: {n}");
+    }
+    let _ = writeln!(out, "\n{FRAMING_LINE}");
+    let _ = writeln!(out, "\n{DISCLAIMER}");
+    out
+}
+
+fn render_signal_table(signal: &DipSignal) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "=== OpenIntel Dip Signal — {} ({:?}) ===",
+        signal.ticker, signal.session
+    );
+    let _ = writeln!(
+        out,
+        "verdict: {:?} · score {:.0}/{:.0}\n",
+        signal.verdict, signal.score, signal.score_max
+    );
+    write_signal_block(&mut out, signal);
+    let _ = writeln!(out, "\n{FRAMING_LINE}");
+    let _ = writeln!(out, "\n{DISCLAIMER}");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::dip::{DipMetrics, GateResults, ScoreComponents, Session, Verdict};
+    use chrono::TimeZone;
+
+    fn signal(verdict: Verdict) -> DipSignal {
+        DipSignal {
+            ticker: "GOOD".into(),
+            verdict,
+            session: Session::PostClose,
+            score: 78.0,
+            score_max: 100.0,
+            components: ScoreComponents {
+                stretch: 20.0,
+                close_location: Some(18.0),
+                idiosyncrasy: 10.0,
+                quiet_volume: 15.0,
+                rsi: 5.0,
+                multi_day: 5.0,
+                divergence: 5.0,
+            },
+            metrics: DipMetrics {
+                sma20: 99.75,
+                atr: 2.0,
+                rsi14: Some(28.0),
+                stretch_atr: 2.1,
+                volume_ratio: Some(0.8),
+                close_location: Some(0.88),
+                down_days: 3,
+                excess_vs_spx_pct: Some(-7.6),
+            },
+            gates: GateResults {
+                quality_floor: GateStatus::Pass,
+                drop_band: GateStatus::Pass,
+                no_filing: GateStatus::Pass,
+                no_catalyst_headline: GateStatus::Pass,
+                idiosyncratic: GateStatus::Pass,
+                close_strength: GateStatus::Pass,
+                score_floor: GateStatus::Pass,
+            },
+            catalyst_evidence: vec![],
+            notes: vec![],
+        }
+    }
+
+    fn report(candidates: Vec<DipCandidate>) -> DipScanReport {
+        DipScanReport {
+            generated_at: Utc.with_ymd_and_hms(2026, 8, 14, 21, 30, 0).unwrap(),
+            session: Session::PostClose,
+            spx_proxy: "SPY",
+            spx_change_pct: Some(-0.4),
+            universe_size: 100,
+            band_excluded: 12,
+            floor_rejects: vec![],
+            candidates,
+            errors: vec![],
+            notes: vec![],
+        }
+    }
+
+    #[test]
+    fn empty_scan_renders_no_setups_line() {
+        let t = render_report_table(&report(vec![]));
+        assert!(t.contains("no setups today — that's a result, not an error"));
+        assert!(t.contains("grades setup conformance"));
+        assert!(t.contains("Not financial advice"));
+    }
+
+    #[test]
+    fn candidate_block_shows_gates_and_metrics() {
+        let c = DipCandidate {
+            ticker: "GOOD".into(),
+            change_pct: -8.0,
+            price: 87.4,
+            signal: signal(Verdict::HighConfidence),
+            risk: None,
+            margin: None,
+        };
+        let t = render_report_table(&report(vec![c]));
+        assert!(t.contains("HighConfidence"));
+        assert!(t.contains("score 78/100"));
+        assert!(t.contains("stretch 2.1 ATR"));
+        assert!(t.contains("floor ✓"));
+        assert!(!t.contains("size:")); // no equity given
+    }
+
+    #[test]
+    fn single_signal_table_renders() {
+        let t = render_signal_table(&signal(Verdict::Watch));
+        assert!(t.contains("Dip Signal — GOOD"));
+        assert!(t.contains("verdict: Watch"));
+    }
+
+    #[test]
+    fn request_maps_args_and_journal_opt_out() {
+        use clap::Parser;
+        let cli = crate::cli::args::Cli::try_parse_from([
+            "openintel",
+            "dip",
+            "--equity",
+            "10000",
+            "--band-min",
+            "-12",
+            "--no-journal",
+        ])
+        .unwrap();
+        let crate::cli::args::Command::Dip(args) = cli.command else {
+            panic!("expected dip command");
+        };
+        let req = request_from(&args);
+        assert_eq!(req.band.min_pct, -12.0);
+        assert!(req.journal_path.is_none());
+        let m = req.margin.unwrap();
+        assert_eq!(m.equity_usd, 10_000.0);
+        assert!(!m.intraday_bp);
+    }
+}

--- a/src/cli/dip.rs
+++ b/src/cli/dip.rs
@@ -7,8 +7,8 @@ use chrono::Utc;
 use crate::adapters::filings::edgar::EdgarSource;
 use crate::adapters::market::yahoo::YahooMarketSource;
 use crate::application::dip::{
-    default_journal_path, dip_check, dip_scan, DipCandidate, DipDeps, DipScanReport,
-    DipScanRequest, FRAMING,
+    default_journal_path, dip_check, dip_scan, DipDeps, DipScanReport, DipScanRequest,
+    TickerDipReport, FRAMING,
 };
 use crate::application::DISCLAIMER;
 use crate::cli::args::{DipArgs, FormatArg};
@@ -62,10 +62,10 @@ pub async fn run(args: &DipArgs, credentials: &Credentials) -> Result<String, Do
 
     match &args.ticker {
         Some(ticker) => {
-            let signal = dip_check(ticker, &req, &deps, now).await?;
+            let report = dip_check(ticker, &req, &deps, None, now).await?;
             Ok(match args.format {
-                FormatArg::Table => render_signal_table(&signal),
-                FormatArg::Json => render_json(&signal)?,
+                FormatArg::Table => render_ticker_table(&report),
+                FormatArg::Json => render_json(&report)?,
             })
         }
         None => {
@@ -143,15 +143,19 @@ fn write_signal_block(out: &mut String, signal: &DipSignal) {
     }
 }
 
-fn write_sizing(out: &mut String, c: &DipCandidate) {
-    if let Some(risk) = &c.risk {
+fn write_sizing(
+    out: &mut String,
+    risk: &Option<crate::domain::risk::RiskFrame>,
+    margin: &Option<crate::domain::margin::MarginFrame>,
+) {
+    if let Some(risk) = risk {
         let _ = writeln!(
             out,
             "  size: {} sh @ {:.2} · stop {:.2} · max loss ${:.2}",
             risk.shares, risk.entry, risk.stop, risk.max_loss_usd
         );
     }
-    if let Some(m) = &c.margin {
+    if let Some(m) = margin {
         let _ = writeln!(
             out,
             "  margin ({}x): {} sh · borrowed ${:.2} · m-call {} ({} away)",
@@ -203,7 +207,7 @@ fn render_report_table(r: &DipScanReport) -> String {
             c.signal.score_max,
         );
         write_signal_block(&mut out, &c.signal);
-        write_sizing(&mut out, c);
+        write_sizing(&mut out, &c.risk, &c.margin);
         let _ = writeln!(out);
     }
 
@@ -218,7 +222,8 @@ fn render_report_table(r: &DipScanReport) -> String {
     out
 }
 
-fn render_signal_table(signal: &DipSignal) -> String {
+fn render_ticker_table(report: &TickerDipReport) -> String {
+    let signal = &report.signal;
     let mut out = String::new();
     let _ = writeln!(
         out,
@@ -231,6 +236,10 @@ fn render_signal_table(signal: &DipSignal) -> String {
         signal.verdict, signal.score, signal.score_max
     );
     write_signal_block(&mut out, signal);
+    write_sizing(&mut out, &report.risk, &report.margin);
+    for n in &report.notes {
+        let _ = writeln!(out, "  note: {n}");
+    }
     let _ = writeln!(out, "\n{FRAMING_LINE}");
     let _ = writeln!(out, "\n{DISCLAIMER}");
     out
@@ -239,6 +248,7 @@ fn render_signal_table(signal: &DipSignal) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::dip::DipCandidate;
     use crate::domain::dip::{DipMetrics, GateResults, ScoreComponents, Session, Verdict};
     use chrono::TimeZone;
 
@@ -324,10 +334,42 @@ mod tests {
     }
 
     #[test]
-    fn single_signal_table_renders() {
-        let t = render_signal_table(&signal(Verdict::Watch));
+    fn single_signal_table_renders_with_optional_sizing() {
+        let report = TickerDipReport {
+            signal: signal(Verdict::Watch),
+            risk: None,
+            margin: None,
+            notes: vec![],
+        };
+        let t = render_ticker_table(&report);
         assert!(t.contains("Dip Signal — GOOD"));
         assert!(t.contains("verdict: Watch"));
+        assert!(!t.contains("size:"));
+
+        let report = TickerDipReport {
+            signal: signal(Verdict::Watch),
+            risk: Some(crate::domain::risk::RiskFrame {
+                ticker: "GOOD".into(),
+                direction: crate::domain::risk::Direction::Long,
+                entry: 87.4,
+                atr: 2.0,
+                stop_multiple: 2.0,
+                stop: 83.4,
+                risk_per_share: 4.0,
+                shares: 62,
+                max_loss_usd: 248.0,
+                budget_usd: 250.0,
+                targets: [91.4, 95.4, 99.4],
+                notional_usd: 5418.8,
+                bars_used: 31,
+                note: None,
+                generated_at: Utc.with_ymd_and_hms(2026, 8, 14, 21, 30, 0).unwrap(),
+            }),
+            margin: None,
+            notes: vec![],
+        };
+        let t = render_ticker_table(&report);
+        assert!(t.contains("size: 62 sh @ 87.40"));
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod args;
+pub mod dip;
 pub mod pulse;
 pub mod risk;
 pub mod run;

--- a/src/domain/dip.rs
+++ b/src/domain/dip.rs
@@ -23,9 +23,15 @@ pub const RSI_PERIOD: usize = 14;
 /// Minimum prior (pre-drop-day) bars for baselines: SMA(20) plus one.
 pub const MIN_PRIOR_BARS: usize = 21;
 
-/// Filing forms that mark a real same-day catalyst: material events (8-K,
-/// foreign 6-K) and dilution/offering paper (424B5, S-3, FWP).
-pub const CATALYST_FORMS: &[&str] = &["8-K", "6-K", "424B5", "S-3", "FWP"];
+/// Filing-form PREFIXES that mark a real same-day catalyst: material events
+/// (8-K incl. 8-K/A, foreign 6-K) and dilution/offering paper (the whole
+/// 424B prospectus family, S-3 incl. /A and ASR shelf variants, FWP).
+pub const CATALYST_FORM_PREFIXES: &[&str] = &["8-K", "6-K", "424B", "S-3", "FWP"];
+
+/// Amendments and variants count: `8-K/A` is still a material event.
+pub fn is_catalyst_form(form: &str) -> bool {
+    CATALYST_FORM_PREFIXES.iter().any(|p| form.starts_with(p))
+}
 
 /// Whole-word, case-insensitive markers of a fundamental catalyst in
 /// headline or social text. A hit is evidence, matched conservatively.
@@ -502,7 +508,7 @@ pub fn dip_signal(inputs: &DipInputs) -> Result<DipSignal, DomainError> {
         GateEvidence::Available(filings) => {
             let hits: Vec<&Filing> = filings
                 .iter()
-                .filter(|f| f.filed_on >= since && CATALYST_FORMS.contains(&f.form.as_str()))
+                .filter(|f| f.filed_on >= since && is_catalyst_form(&f.form))
                 .collect();
             if hits.is_empty() {
                 GateStatus::Pass
@@ -766,12 +772,12 @@ mod tests {
         DipInputs {
             ticker: "TEST",
             prior_bars,
-            // Gapped down, sold to 80, closed 87.4 — near the high of the
-            // day's range (location ≈ 0.93): buyers stepped in.
+            // Gapped down to 88, sold to 80, closed 87.4 — near the high of
+            // the day's range (location ≈ 0.87): buyers stepped in.
             drop_day_bar: Some(Bar {
                 date: d(31),
-                open: 94.0,
-                high: 88.0,
+                open: 88.0,
+                high: 88.5,
                 low: 80.0,
                 close: 87.4,
             }),
@@ -847,6 +853,27 @@ mod tests {
     }
 
     #[test]
+    fn amended_and_variant_forms_trigger_plain_forms_do_not() {
+        for form in [
+            "8-K", "8-K/A", "6-K/A", "424B3", "424B5", "S-3/A", "S-3ASR", "FWP",
+        ] {
+            assert!(is_catalyst_form(form), "{form} should be a catalyst");
+        }
+        for form in ["4", "10-Q", "10-K", "S-1", "13F-HR", "SC 13G"] {
+            assert!(!is_catalyst_form(form), "{form} should not be a catalyst");
+        }
+        // end-to-end: an amended 8-K on the drop day still kills the setup
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let mut i = inputs(&prior, &w);
+        i.filings = GateEvidence::Available(vec![Filing {
+            form: "8-K/A".into(),
+            filed_on: d(31),
+        }]);
+        assert_eq!(dip_signal(&i).unwrap().verdict, Verdict::NoSetup);
+    }
+
+    #[test]
     fn catalyst_headline_is_no_setup_with_evidence() {
         let prior = prior();
         let w = ScoreWeights::default();
@@ -854,7 +881,7 @@ mod tests {
         i.headlines = GateEvidence::Available(vec![Headline {
             title: "Company cuts guidance after earnings miss".into(),
             publisher: "Wire".into(),
-            published_at: chrono::Utc::now(),
+            published_at: Some(chrono::Utc::now()),
         }]);
         let sig = dip_signal(&i).unwrap();
         assert_eq!(sig.verdict, Verdict::NoSetup);

--- a/src/domain/dip.rs
+++ b/src/domain/dip.rs
@@ -1,0 +1,971 @@
+//! dip_scan's pure core: quality floor, oversold metrics, hard gates, and a
+//! v0 ranking score for "big down day, no visible catalyst" setups.
+//!
+//! Gates decide the verdict; the score only ranks survivors. Any gate whose
+//! evidence is unavailable fails CLOSED (caps the verdict at `watch`) — an
+//! unverifiable candidate is never `high_confidence`. "High confidence" means
+//! high conformance to the setup template, never probability of profit.
+//! Synchronous, no IO, no clock, no timezone — the application layer stamps
+//! session and dates.
+
+use chrono::NaiveDate;
+use serde::Serialize;
+
+use crate::domain::error::DomainError;
+use crate::domain::risk::{atr, ATR_PERIOD};
+use crate::domain::values::bar::Bar;
+use crate::domain::values::filing::Filing;
+use crate::domain::values::headline::Headline;
+use crate::domain::values::mover::MoverRow;
+
+pub const SMA_PERIOD: usize = 20;
+pub const RSI_PERIOD: usize = 14;
+/// Minimum prior (pre-drop-day) bars for baselines: SMA(20) plus one.
+pub const MIN_PRIOR_BARS: usize = 21;
+
+/// Filing forms that mark a real same-day catalyst: material events (8-K,
+/// foreign 6-K) and dilution/offering paper (424B5, S-3, FWP).
+pub const CATALYST_FORMS: &[&str] = &["8-K", "6-K", "424B5", "S-3", "FWP"];
+
+/// Whole-word, case-insensitive markers of a fundamental catalyst in
+/// headline or social text. A hit is evidence, matched conservatively.
+pub const CATALYST_KEYWORDS: &[&str] = &[
+    "earnings",
+    "miss",
+    "guidance",
+    "cut",
+    "offering",
+    "dilution",
+    "downgrade",
+    "halt",
+    "fraud",
+    "lawsuit",
+    "recall",
+    "fda",
+    "bankruptcy",
+    "delisting",
+    "investigation",
+    "resign",
+];
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "dip".into(),
+        message: message.into(),
+    }
+}
+
+// ---------------------------------------------------------------- quality floor
+
+#[derive(Debug, Clone)]
+pub struct QualityFloor {
+    pub min_price: f64,
+    pub min_market_cap: u64,
+    pub min_avg_volume: u64,
+    pub min_listed_days: i64,
+}
+
+impl Default for QualityFloor {
+    fn default() -> Self {
+        Self {
+            min_price: 5.0,
+            min_market_cap: 500_000_000,
+            min_avg_volume: 1_000_000,
+            min_listed_days: 180,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FloorReject {
+    pub symbol: String,
+    pub reason: String,
+}
+
+/// Split screener rows into floor survivors and rejects (each reject carries
+/// its reason). A missing screener field is a reject, never a pass.
+pub fn apply_floor(
+    rows: &[MoverRow],
+    floor: &QualityFloor,
+    now_ms: i64,
+) -> (Vec<MoverRow>, Vec<FloorReject>) {
+    let mut pass = Vec::new();
+    let mut rejects = Vec::new();
+    for row in rows {
+        let reason = floor_reason(row, floor, now_ms);
+        match reason {
+            None => pass.push(row.clone()),
+            Some(reason) => rejects.push(FloorReject {
+                symbol: row.symbol.clone(),
+                reason,
+            }),
+        }
+    }
+    (pass, rejects)
+}
+
+fn floor_reason(row: &MoverRow, floor: &QualityFloor, now_ms: i64) -> Option<String> {
+    let ex = row.exchange.to_ascii_lowercase();
+    if ex.contains("otc") || ex.contains("pink") {
+        return Some(format!("off-exchange venue ({})", row.exchange));
+    }
+    if row.price < floor.min_price {
+        return Some(format!("price {:.2} < {:.2}", row.price, floor.min_price));
+    }
+    match row.market_cap {
+        Some(cap) if cap >= floor.min_market_cap => {}
+        Some(cap) => return Some(format!("market cap {cap} < {}", floor.min_market_cap)),
+        None => return Some("market cap unavailable".into()),
+    }
+    match row.avg_volume_3mo {
+        Some(v) if v >= floor.min_avg_volume => {}
+        Some(v) => return Some(format!("avg volume {v} < {}", floor.min_avg_volume)),
+        None => return Some("avg volume unavailable".into()),
+    }
+    match row.first_trade_ms {
+        Some(first) if now_ms.saturating_sub(first) >= floor.min_listed_days * 86_400_000 => {}
+        Some(_) => return Some(format!("listed < {} days", floor.min_listed_days)),
+        None => return Some("listing date unavailable".into()),
+    }
+    None
+}
+
+// ---------------------------------------------------------------- metrics
+
+pub fn sma(closes: &[f64], period: usize) -> Option<f64> {
+    if period == 0 || closes.len() < period {
+        return None;
+    }
+    Some(closes[closes.len() - period..].iter().sum::<f64>() / period as f64)
+}
+
+/// Cutler's RSI: simple (not Wilder-smoothed) averages of gains and losses
+/// over the last `period` deltas — deterministic, no seed dependence.
+/// Needs `period + 1` closes. A flat window returns a neutral 50.
+pub fn rsi_cutler(closes: &[f64], period: usize) -> Option<f64> {
+    if period == 0 || closes.len() < period + 1 {
+        return None;
+    }
+    let window = &closes[closes.len() - (period + 1)..];
+    let (mut gains, mut losses) = (0.0_f64, 0.0_f64);
+    for w in window.windows(2) {
+        let d = w[1] - w[0];
+        if d >= 0.0 {
+            gains += d;
+        } else {
+            losses -= d;
+        }
+    }
+    if gains == 0.0 && losses == 0.0 {
+        return Some(50.0);
+    }
+    Some(100.0 * gains / (gains + losses))
+}
+
+/// Where the close sits in the day's range: 0 = at the low, 1 = at the high.
+/// None on a rangeless bar.
+pub fn close_location(bar: &Bar) -> Option<f64> {
+    let range = bar.high - bar.low;
+    (range > 0.0).then(|| ((bar.close - bar.low) / range).clamp(0.0, 1.0))
+}
+
+/// Consecutive down closes counted backward from the last close.
+pub fn consecutive_down_closes(closes: &[f64]) -> usize {
+    closes.windows(2).rev().take_while(|w| w[1] < w[0]).count()
+}
+
+/// Case-insensitive whole-word keyword hits across the given texts, deduped.
+pub fn catalyst_hits(texts: &[&str]) -> Vec<String> {
+    let mut hits: Vec<String> = Vec::new();
+    for text in texts {
+        let lower = text.to_ascii_lowercase();
+        for token in lower.split(|c: char| !c.is_ascii_alphanumeric()) {
+            if CATALYST_KEYWORDS.contains(&token) && !hits.iter().any(|h| h == token) {
+                hits.push(token.to_string());
+            }
+        }
+    }
+    hits
+}
+
+// ---------------------------------------------------------------- score
+
+/// v0 weights — hand-picked and UNVALIDATED. The scan journal exists so these
+/// can be graded against forward returns before anyone trusts them.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScoreWeights {
+    pub stretch: f64,
+    pub close_location: f64,
+    pub idiosyncrasy: f64,
+    pub quiet_volume: f64,
+    pub rsi: f64,
+    pub multi_day: f64,
+    pub divergence: f64,
+}
+
+impl Default for ScoreWeights {
+    fn default() -> Self {
+        Self {
+            stretch: 20.0,
+            close_location: 20.0,
+            idiosyncrasy: 15.0,
+            quiet_volume: 15.0,
+            rsi: 10.0,
+            multi_day: 10.0,
+            divergence: 10.0,
+        }
+    }
+}
+
+/// Weighted points actually awarded per component (already × weight).
+#[derive(Debug, Clone, Serialize)]
+pub struct ScoreComponents {
+    pub stretch: f64,
+    /// None intraday — the day bar is not final until the close.
+    pub close_location: Option<f64>,
+    pub idiosyncrasy: f64,
+    pub quiet_volume: f64,
+    pub rsi: f64,
+    pub multi_day: f64,
+    pub divergence: f64,
+}
+
+impl ScoreComponents {
+    pub fn total(&self) -> f64 {
+        self.stretch
+            + self.close_location.unwrap_or(0.0)
+            + self.idiosyncrasy
+            + self.quiet_volume
+            + self.rsi
+            + self.multi_day
+            + self.divergence
+    }
+}
+
+fn frac_stretch(stretch_atr: f64) -> f64 {
+    (stretch_atr / 3.5).clamp(0.0, 1.0)
+}
+
+/// Low-volume declines revert; volume-confirmed ones are more often informed
+/// moves that continue — so QUIET volume scores, a climax does not.
+fn frac_quiet_volume(ratio: f64) -> f64 {
+    ((3.0 - ratio) / 2.0).clamp(0.0, 1.0)
+}
+
+fn frac_rsi(rsi: f64) -> f64 {
+    ((50.0 - rsi) / 30.0).clamp(0.0, 1.0)
+}
+
+fn frac_idiosyncrasy(excess_pct: f64) -> f64 {
+    ((-excess_pct - 3.0) / 7.0).clamp(0.0, 1.0)
+}
+
+fn frac_multi_day(down_days: usize) -> f64 {
+    ((down_days as f64 - 1.0) / 3.0).clamp(0.0, 1.0)
+}
+
+// ---------------------------------------------------------------- gates
+
+/// Evidence for a gate: available data, or a reason it could not be fetched.
+/// Unavailable evidence fails closed (verdict capped at `watch`).
+#[derive(Debug, Clone)]
+pub enum GateEvidence<T> {
+    Available(T),
+    Unavailable(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "status", content = "reason", rename_all = "lowercase")]
+pub enum GateStatus {
+    Pass,
+    Fail(String),
+    Unknown(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GateResults {
+    pub quality_floor: GateStatus,
+    pub drop_band: GateStatus,
+    pub no_filing: GateStatus,
+    pub no_catalyst_headline: GateStatus,
+    pub idiosyncratic: GateStatus,
+    pub close_strength: GateStatus,
+    pub score_floor: GateStatus,
+}
+
+impl GateResults {
+    fn all_pass(&self) -> bool {
+        [
+            &self.quality_floor,
+            &self.drop_band,
+            &self.no_filing,
+            &self.no_catalyst_headline,
+            &self.idiosyncratic,
+            &self.close_strength,
+            &self.score_floor,
+        ]
+        .iter()
+        .all(|g| matches!(g, GateStatus::Pass))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Verdict {
+    NoSetup,
+    Watch,
+    HighConfidence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Session {
+    Intraday,
+    PostClose,
+}
+
+/// The drop-day change band eligible for evaluation, in percent. The
+/// catastrophic tail is excluded by design — it is where informed moves live.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct DropBand {
+    pub min_pct: f64,
+    pub max_pct: f64,
+}
+
+impl Default for DropBand {
+    fn default() -> Self {
+        Self {
+            min_pct: -15.0,
+            max_pct: -4.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SentimentSummary {
+    pub net_sentiment: f64,
+    pub mentions: usize,
+}
+
+// ---------------------------------------------------------------- signal
+
+pub struct DipInputs<'a> {
+    pub ticker: &'a str,
+    /// Baseline history — MUST exclude the drop-day bar.
+    pub prior_bars: &'a [Bar],
+    /// The drop day's own bar (final post-close, partial intraday).
+    pub drop_day_bar: Option<Bar>,
+    pub drop_date: NaiveDate,
+    pub last_price: f64,
+    /// Drop-day change in percent (negative for a decline).
+    pub change_pct: f64,
+    pub day_volume: Option<u64>,
+    pub avg_volume_3mo: Option<u64>,
+    /// Same-day index change in percent (None = gate unknown).
+    pub spx_change_pct: Option<f64>,
+    /// Recent filings covering drop day minus one calendar day onward.
+    pub filings: GateEvidence<Vec<Filing>>,
+    /// Headlines already filtered to the drop day by the caller.
+    pub headlines: GateEvidence<Vec<Headline>>,
+    pub sentiment: Option<SentimentSummary>,
+    pub session: Session,
+    /// Floor result from the screener row (Unknown in single-ticker mode,
+    /// where no screener row exists to evaluate).
+    pub floor: GateStatus,
+    pub band: DropBand,
+    pub weights: &'a ScoreWeights,
+    pub score_min: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DipMetrics {
+    pub sma20: f64,
+    pub atr: f64,
+    pub rsi14: Option<f64>,
+    /// How far below the 20-day mean the last price sits, in ATR units.
+    pub stretch_atr: f64,
+    pub volume_ratio: Option<f64>,
+    pub close_location: Option<f64>,
+    pub down_days: usize,
+    pub excess_vs_spx_pct: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DipSignal {
+    pub ticker: String,
+    pub verdict: Verdict,
+    pub session: Session,
+    pub score: f64,
+    /// 100 post-close; 80 intraday (close-location is unscoreable).
+    pub score_max: f64,
+    pub components: ScoreComponents,
+    pub metrics: DipMetrics,
+    pub gates: GateResults,
+    pub catalyst_evidence: Vec<String>,
+    pub notes: Vec<String>,
+}
+
+pub fn dip_signal(inputs: &DipInputs) -> Result<DipSignal, DomainError> {
+    if !(inputs.last_price.is_finite() && inputs.last_price > 0.0) {
+        return Err(fail("last price must be a positive number"));
+    }
+    if !inputs.change_pct.is_finite() {
+        return Err(fail("change percent must be a number"));
+    }
+    if inputs.prior_bars.len() < MIN_PRIOR_BARS {
+        return Err(fail(format!(
+            "not enough history — need {MIN_PRIOR_BARS} prior bars, got {}",
+            inputs.prior_bars.len()
+        )));
+    }
+    let closes: Vec<f64> = inputs.prior_bars.iter().map(|b| b.close).collect();
+    let sma20 = sma(&closes, SMA_PERIOD).ok_or_else(|| fail("not enough closes for SMA(20)"))?;
+    let atr = atr(inputs.prior_bars, ATR_PERIOD)
+        .ok_or_else(|| fail(format!("not enough history for ATR({ATR_PERIOD})")))?;
+    if !(atr.is_finite() && atr > 0.0) {
+        return Err(fail("flat price history — ATR is zero"));
+    }
+
+    let mut notes: Vec<String> = Vec::new();
+    let mut catalyst_evidence: Vec<String> = Vec::new();
+
+    let stretch_atr = (sma20 - inputs.last_price) / atr;
+    let rsi14 = rsi_cutler(&closes, RSI_PERIOD);
+    let volume_ratio = match (inputs.day_volume, inputs.avg_volume_3mo) {
+        (Some(day), Some(avg)) if avg > 0 => Some(day as f64 / avg as f64),
+        _ => None,
+    };
+    let close_loc = match inputs.session {
+        Session::Intraday => None,
+        Session::PostClose => inputs.drop_day_bar.as_ref().and_then(close_location),
+    };
+    let mut all_closes = closes.clone();
+    all_closes.push(inputs.last_price);
+    let down_days = consecutive_down_closes(&all_closes);
+    let excess = inputs.spx_change_pct.map(|s| inputs.change_pct - s);
+
+    // -------- components (each fraction × its weight)
+    let w = inputs.weights;
+    if volume_ratio.is_none() {
+        notes.push("volume unavailable — quiet-volume component scored 0".into());
+    }
+    let divergence_frac = match inputs.sentiment {
+        Some(s) if inputs.change_pct < 0.0 && s.net_sentiment >= 0.0 => {
+            (s.mentions as f64 / 20.0).min(1.0)
+        }
+        Some(_) => 0.0,
+        None => {
+            notes.push("no social data — divergence component scored 0".into());
+            0.0
+        }
+    };
+    let components = ScoreComponents {
+        stretch: frac_stretch(stretch_atr) * w.stretch,
+        close_location: close_loc.map(|c| c * w.close_location),
+        idiosyncrasy: excess.map_or(0.0, frac_idiosyncrasy) * w.idiosyncrasy,
+        quiet_volume: volume_ratio.map_or(0.0, frac_quiet_volume) * w.quiet_volume,
+        rsi: rsi14.map_or(0.0, frac_rsi) * w.rsi,
+        multi_day: frac_multi_day(down_days) * w.multi_day,
+        divergence: divergence_frac * w.divergence,
+    };
+    let score = components.total();
+    let score_max = match inputs.session {
+        Session::PostClose => {
+            w.stretch
+                + w.close_location
+                + w.idiosyncrasy
+                + w.quiet_volume
+                + w.rsi
+                + w.multi_day
+                + w.divergence
+        }
+        Session::Intraday => {
+            notes.push("intraday run — close-location unscored, verdict capped at watch".into());
+            w.stretch + w.idiosyncrasy + w.quiet_volume + w.rsi + w.multi_day + w.divergence
+        }
+    };
+
+    // -------- gates
+    let drop_band =
+        if inputs.change_pct >= inputs.band.min_pct && inputs.change_pct <= inputs.band.max_pct {
+            GateStatus::Pass
+        } else {
+            GateStatus::Fail(format!(
+                "day change {:.1}% outside [{:.0}%, {:.0}%]",
+                inputs.change_pct, inputs.band.min_pct, inputs.band.max_pct
+            ))
+        };
+
+    let since = inputs.drop_date.pred_opt().unwrap_or(inputs.drop_date);
+    let no_filing = match &inputs.filings {
+        GateEvidence::Unavailable(reason) => GateStatus::Unknown(reason.clone()),
+        GateEvidence::Available(filings) => {
+            let hits: Vec<&Filing> = filings
+                .iter()
+                .filter(|f| f.filed_on >= since && CATALYST_FORMS.contains(&f.form.as_str()))
+                .collect();
+            if hits.is_empty() {
+                GateStatus::Pass
+            } else {
+                for f in &hits {
+                    catalyst_evidence.push(format!("SEC {} filed {}", f.form, f.filed_on));
+                }
+                GateStatus::Fail(format!(
+                    "{} catalyst filing(s) on/around drop day",
+                    hits.len()
+                ))
+            }
+        }
+    };
+
+    let no_catalyst_headline = match &inputs.headlines {
+        GateEvidence::Unavailable(reason) => GateStatus::Unknown(reason.clone()),
+        GateEvidence::Available(headlines) => {
+            let titles: Vec<&str> = headlines.iter().map(|h| h.title.as_str()).collect();
+            let hits = catalyst_hits(&titles);
+            if hits.is_empty() {
+                GateStatus::Pass
+            } else {
+                for h in headlines {
+                    let title_hits = catalyst_hits(&[h.title.as_str()]);
+                    if !title_hits.is_empty() {
+                        catalyst_evidence.push(format!(
+                            "headline [{}]: \"{}\" (terms: {})",
+                            h.publisher,
+                            h.title,
+                            title_hits.join(", ")
+                        ));
+                    }
+                }
+                GateStatus::Fail(format!(
+                    "catalyst term(s) in headlines: {}",
+                    hits.join(", ")
+                ))
+            }
+        }
+    };
+
+    let idiosyncratic = match excess {
+        None => GateStatus::Unknown("index change unavailable".into()),
+        Some(e) if e <= -3.0 => GateStatus::Pass,
+        Some(e) => GateStatus::Fail(format!(
+            "excess vs index {e:.1}% > -3% — market-driven move"
+        )),
+    };
+
+    let close_strength = match inputs.session {
+        Session::Intraday => GateStatus::Unknown("intraday — day bar not final".into()),
+        Session::PostClose => match close_loc {
+            None => GateStatus::Unknown("day bar range unavailable".into()),
+            Some(c) if c >= 0.5 => GateStatus::Pass,
+            Some(c) => GateStatus::Fail(format!(
+                "closed at {:.0}% of day range — no buyers at the close",
+                c * 100.0
+            )),
+        },
+    };
+
+    let score_floor = if score >= inputs.score_min {
+        GateStatus::Pass
+    } else {
+        GateStatus::Fail(format!("score {score:.0} < {:.0}", inputs.score_min))
+    };
+
+    let gates = GateResults {
+        quality_floor: inputs.floor.clone(),
+        drop_band,
+        no_filing,
+        no_catalyst_headline,
+        idiosyncratic,
+        close_strength,
+        score_floor,
+    };
+
+    // -------- verdict: catalysts and eligibility kill; anything short of
+    // all-gates-pass post-close is at most `watch`.
+    let verdict = if matches!(gates.no_filing, GateStatus::Fail(_))
+        || matches!(gates.no_catalyst_headline, GateStatus::Fail(_))
+        || matches!(gates.quality_floor, GateStatus::Fail(_))
+        || matches!(gates.drop_band, GateStatus::Fail(_))
+    {
+        Verdict::NoSetup
+    } else if gates.all_pass() && inputs.session == Session::PostClose {
+        Verdict::HighConfidence
+    } else {
+        Verdict::Watch
+    };
+
+    Ok(DipSignal {
+        ticker: inputs.ticker.to_string(),
+        verdict,
+        session: inputs.session,
+        score,
+        score_max,
+        components,
+        metrics: DipMetrics {
+            sma20,
+            atr,
+            rsi14,
+            stretch_atr,
+            volume_ratio,
+            close_location: close_loc,
+            down_days,
+            excess_vs_spx_pct: excess,
+        },
+        gates,
+        catalyst_evidence,
+        notes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn d(day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 8, day).unwrap()
+    }
+
+    fn bar_on(day: u32, close: f64) -> Bar {
+        Bar {
+            date: d(day),
+            open: close,
+            high: close + 1.0,
+            low: close - 1.0,
+            close,
+        }
+    }
+
+    fn row(symbol: &str) -> MoverRow {
+        MoverRow {
+            symbol: symbol.into(),
+            change_pct: -8.0,
+            price: 50.0,
+            market_cap: Some(2_000_000_000),
+            avg_volume_3mo: Some(5_000_000),
+            day_volume: Some(4_000_000),
+            exchange: "NYSE".into(),
+            first_trade_ms: Some(0),
+        }
+    }
+
+    const NOW_MS: i64 = 1_786_000_000_000; // well past any test listing date
+
+    #[test]
+    fn floor_passes_quality_and_rejects_with_reasons() {
+        let rows = vec![
+            row("GOOD"),
+            MoverRow {
+                price: 3.0,
+                ..row("CHEAP")
+            },
+            MoverRow {
+                market_cap: None,
+                ..row("NOCAP")
+            },
+            MoverRow {
+                avg_volume_3mo: Some(100),
+                ..row("THIN")
+            },
+            MoverRow {
+                exchange: "Other OTC".into(),
+                ..row("PINK")
+            },
+            MoverRow {
+                first_trade_ms: Some(NOW_MS - 86_400_000), // listed yesterday
+                ..row("IPO")
+            },
+        ];
+        let (pass, rejects) = apply_floor(&rows, &QualityFloor::default(), NOW_MS);
+        assert_eq!(pass.len(), 1);
+        assert_eq!(pass[0].symbol, "GOOD");
+        assert_eq!(rejects.len(), 5);
+        let reason = |s: &str| {
+            rejects
+                .iter()
+                .find(|r| r.symbol == s)
+                .unwrap()
+                .reason
+                .clone()
+        };
+        assert!(reason("CHEAP").contains("price"));
+        assert!(reason("NOCAP").contains("unavailable"));
+        assert!(reason("THIN").contains("avg volume"));
+        assert!(reason("PINK").contains("venue"));
+        assert!(reason("IPO").contains("listed <"));
+    }
+
+    #[test]
+    fn sma_and_rsi_math() {
+        assert_eq!(sma(&[1.0, 2.0, 3.0, 4.0], 2), Some(3.5));
+        assert_eq!(sma(&[1.0], 2), None);
+        // deltas over period 3: +1, -1, +2 -> gains 3, losses 1 -> RSI 75
+        let rsi = rsi_cutler(&[10.0, 11.0, 10.0, 12.0], 3).unwrap();
+        assert!((rsi - 75.0).abs() < 1e-12);
+        assert_eq!(rsi_cutler(&[10.0, 11.0], 3), None);
+        assert_eq!(rsi_cutler(&[5.0; 20], 14), Some(50.0)); // flat -> neutral
+        assert_eq!(rsi_cutler(&[1.0, 2.0, 3.0, 4.0], 3), Some(100.0)); // all gains
+    }
+
+    #[test]
+    fn close_location_and_down_days() {
+        let b = Bar {
+            date: d(1),
+            open: 108.0,
+            high: 110.0,
+            low: 100.0,
+            close: 105.0,
+        };
+        assert_eq!(close_location(&b), Some(0.5));
+        let flat = Bar {
+            date: d(1),
+            open: 5.0,
+            high: 5.0,
+            low: 5.0,
+            close: 5.0,
+        };
+        assert_eq!(close_location(&flat), None);
+        assert_eq!(consecutive_down_closes(&[5.0, 4.0, 3.0]), 2);
+        assert_eq!(consecutive_down_closes(&[3.0, 4.0, 3.5]), 1);
+        assert_eq!(consecutive_down_closes(&[1.0, 2.0]), 0);
+        assert_eq!(consecutive_down_closes(&[1.0]), 0);
+    }
+
+    #[test]
+    fn catalyst_hits_are_whole_word_and_deduped() {
+        let hits = catalyst_hits(&["Earnings miss shocks", "dismissal of claims", "MISS again"]);
+        assert_eq!(hits, vec!["earnings".to_string(), "miss".to_string()]);
+        assert!(catalyst_hits(&["a quiet day"]).is_empty());
+    }
+
+    #[test]
+    fn score_fractions_hit_bounds() {
+        assert_eq!(frac_stretch(0.0), 0.0);
+        assert_eq!(frac_stretch(3.5), 1.0);
+        assert_eq!(frac_stretch(9.0), 1.0);
+        assert_eq!(frac_quiet_volume(1.0), 1.0);
+        assert_eq!(frac_quiet_volume(3.0), 0.0);
+        assert_eq!(frac_quiet_volume(0.2), 1.0);
+        assert_eq!(frac_rsi(50.0), 0.0);
+        assert_eq!(frac_rsi(20.0), 1.0);
+        assert_eq!(frac_idiosyncrasy(-3.0), 0.0);
+        assert_eq!(frac_idiosyncrasy(-10.0), 1.0);
+        assert_eq!(frac_multi_day(1), 0.0);
+        assert_eq!(frac_multi_day(4), 1.0);
+    }
+
+    /// 30 prior bars trending gently down so ATR/SMA are sane, then a -8% day.
+    fn prior() -> Vec<Bar> {
+        (1..=30)
+            .map(|i| bar_on(i, 110.0 - i as f64 * 0.5))
+            .collect()
+    }
+
+    fn inputs<'a>(prior_bars: &'a [Bar], weights: &'a ScoreWeights) -> DipInputs<'a> {
+        DipInputs {
+            ticker: "TEST",
+            prior_bars,
+            // Gapped down, sold to 80, closed 87.4 — near the high of the
+            // day's range (location ≈ 0.93): buyers stepped in.
+            drop_day_bar: Some(Bar {
+                date: d(31),
+                open: 94.0,
+                high: 88.0,
+                low: 80.0,
+                close: 87.4,
+            }),
+            drop_date: d(31),
+            last_price: 87.4,
+            change_pct: -8.0,
+            day_volume: Some(4_000_000),
+            avg_volume_3mo: Some(5_000_000),
+            spx_change_pct: Some(-0.5),
+            filings: GateEvidence::Available(vec![]),
+            headlines: GateEvidence::Available(vec![]),
+            sentiment: Some(SentimentSummary {
+                net_sentiment: 0.2,
+                mentions: 25,
+            }),
+            session: Session::PostClose,
+            floor: GateStatus::Pass,
+            band: DropBand::default(),
+            weights,
+            score_min: 0.0,
+        }
+    }
+
+    #[test]
+    fn clean_post_close_setup_is_high_confidence() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let sig = dip_signal(&inputs(&prior, &w)).unwrap();
+        assert_eq!(
+            sig.verdict,
+            Verdict::HighConfidence,
+            "gates: {:?}",
+            sig.gates
+        );
+        assert_eq!(sig.score_max, 100.0);
+        assert!(sig.score > 0.0 && sig.score <= 100.0);
+        assert!(sig.catalyst_evidence.is_empty());
+        assert_eq!(sig.gates.close_strength, GateStatus::Pass);
+    }
+
+    #[test]
+    fn filing_on_drop_day_is_no_setup_with_evidence() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let mut i = inputs(&prior, &w);
+        i.filings = GateEvidence::Available(vec![
+            Filing {
+                form: "8-K".into(),
+                filed_on: d(31),
+            },
+            Filing {
+                form: "4".into(), // insider form — must NOT trigger
+                filed_on: d(31),
+            },
+        ]);
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::NoSetup);
+        assert_eq!(sig.catalyst_evidence.len(), 1);
+        assert!(sig.catalyst_evidence[0].contains("8-K"));
+    }
+
+    #[test]
+    fn old_filing_does_not_trigger() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let mut i = inputs(&prior, &w);
+        i.filings = GateEvidence::Available(vec![Filing {
+            form: "8-K".into(),
+            filed_on: d(20), // well before the drop
+        }]);
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.gates.no_filing, GateStatus::Pass);
+    }
+
+    #[test]
+    fn catalyst_headline_is_no_setup_with_evidence() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let mut i = inputs(&prior, &w);
+        i.headlines = GateEvidence::Available(vec![Headline {
+            title: "Company cuts guidance after earnings miss".into(),
+            publisher: "Wire".into(),
+            published_at: chrono::Utc::now(),
+        }]);
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::NoSetup);
+        assert!(sig.catalyst_evidence[0].contains("guidance"));
+    }
+
+    #[test]
+    fn unavailable_evidence_fails_closed_to_watch() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let mut i = inputs(&prior, &w);
+        i.filings = GateEvidence::Unavailable("EDGAR unreachable".into());
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::Watch);
+        assert!(matches!(sig.gates.no_filing, GateStatus::Unknown(_)));
+    }
+
+    #[test]
+    fn intraday_caps_at_watch_and_shrinks_score_max() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let mut i = inputs(&prior, &w);
+        i.session = Session::Intraday;
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::Watch);
+        assert_eq!(sig.score_max, 80.0);
+        assert!(sig.components.close_location.is_none());
+        assert!(sig.notes.iter().any(|n| n.contains("intraday")));
+    }
+
+    #[test]
+    fn band_edges_and_catastrophic_tail() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        for (chg, expect_setup) in [(-4.0, true), (-15.0, true), (-3.9, false), (-30.0, false)] {
+            let mut i = inputs(&prior, &w);
+            i.change_pct = chg;
+            let sig = dip_signal(&i).unwrap();
+            if expect_setup {
+                assert_ne!(sig.verdict, Verdict::NoSetup, "change {chg}");
+            } else {
+                assert_eq!(sig.verdict, Verdict::NoSetup, "change {chg}");
+            }
+        }
+    }
+
+    #[test]
+    fn market_driven_move_fails_idiosyncrasy_to_watch() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let mut i = inputs(&prior, &w);
+        i.spx_change_pct = Some(-6.0); // tape-wide crash; excess = -2%
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::Watch);
+        assert!(matches!(sig.gates.idiosyncratic, GateStatus::Fail(_)));
+    }
+
+    #[test]
+    fn weak_close_fails_gate_to_watch() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let mut i = inputs(&prior, &w);
+        i.drop_day_bar = Some(Bar {
+            date: d(31),
+            open: 94.0,
+            high: 95.0,
+            low: 87.0,
+            close: 87.4, // near the low
+        });
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::Watch);
+        assert!(matches!(sig.gates.close_strength, GateStatus::Fail(_)));
+    }
+
+    #[test]
+    fn score_floor_gate_and_divergence_scaling() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let mut i = inputs(&prior, &w);
+        i.score_min = 1000.0; // unreachable
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::Watch);
+        assert!(matches!(sig.gates.score_floor, GateStatus::Fail(_)));
+
+        // 5 mentions scale divergence to a quarter of its weight
+        let mut i = inputs(&prior, &w);
+        i.sentiment = Some(SentimentSummary {
+            net_sentiment: 0.2,
+            mentions: 5,
+        });
+        let sig = dip_signal(&i).unwrap();
+        assert!((sig.components.divergence - 2.5).abs() < 1e-12);
+
+        // bearish sentiment (crowd capitulating) scores zero
+        let mut i = inputs(&prior, &w);
+        i.sentiment = Some(SentimentSummary {
+            net_sentiment: -0.5,
+            mentions: 50,
+        });
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.components.divergence, 0.0);
+    }
+
+    #[test]
+    fn thin_history_and_bad_inputs_error() {
+        let w = ScoreWeights::default();
+        let short: Vec<Bar> = (1..=10).map(|i| bar_on(i, 100.0)).collect();
+        assert!(dip_signal(&inputs(&short, &w)).is_err());
+        let prior = prior();
+        let mut i = inputs(&prior, &w);
+        i.last_price = f64::NAN;
+        assert!(dip_signal(&i).is_err());
+    }
+}

--- a/src/domain/margin.rs
+++ b/src/domain/margin.rs
@@ -1,0 +1,236 @@
+//! Margin overlay on a `RiskFrame`: buying-power cap, borrow amount, and the
+//! price at which a maintenance call would fire. Pure and synchronous.
+//! Single-position model (assumes this is the account's only margined
+//! position); interest and fees are not modeled — the disclaimer says so.
+
+use serde::Serialize;
+
+use crate::domain::error::DomainError;
+use crate::domain::risk::{Direction, RiskFrame};
+
+/// Overnight Reg-T buying power; 4x day-trade BP is opt-in and not holdable.
+pub const OVERNIGHT_MAX_LEVERAGE: f64 = 2.0;
+pub const INTRADAY_MAX_LEVERAGE: f64 = 4.0;
+pub const DEFAULT_LEVERAGE: f64 = 2.0;
+pub const DEFAULT_MAINTENANCE: f64 = 0.25;
+pub const DEFAULT_RISK_PCT: f64 = 0.01;
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "margin".into(),
+        message: message.into(),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MarginInputs {
+    pub equity_usd: f64,
+    pub leverage: f64,
+    pub maintenance: f64,
+    /// Fraction of equity risked to the stop (sizes the underlying RiskFrame).
+    pub risk_pct: f64,
+    /// Unlocks 4x intraday buying power (with a not-holdable-overnight note).
+    pub intraday_bp: bool,
+}
+
+impl Default for MarginInputs {
+    fn default() -> Self {
+        Self {
+            equity_usd: 0.0,
+            leverage: DEFAULT_LEVERAGE,
+            maintenance: DEFAULT_MAINTENANCE,
+            risk_pct: DEFAULT_RISK_PCT,
+            intraday_bp: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MarginFrame {
+    pub equity_usd: f64,
+    pub leverage: f64,
+    pub maintenance: f64,
+    pub shares: u64,
+    pub notional_usd: f64,
+    pub cash_used_usd: f64,
+    pub borrowed_usd: f64,
+    /// None when nothing is borrowed — no maintenance call is possible.
+    pub margin_call_price: Option<f64>,
+    pub mc_distance_pct: Option<f64>,
+    pub mc_distance_atr: Option<f64>,
+    /// True when buying power, not the risk budget, set the share count.
+    pub capped_by_buying_power: bool,
+    pub notes: Vec<String>,
+}
+
+/// Overlay margin mechanics on an already-computed long `RiskFrame`.
+pub fn margin_frame(risk: &RiskFrame, inputs: &MarginInputs) -> Result<MarginFrame, DomainError> {
+    if risk.direction != Direction::Long {
+        return Err(fail("margin framing supports long dip entries only"));
+    }
+    if !(inputs.equity_usd.is_finite() && inputs.equity_usd > 0.0) {
+        return Err(fail("equity must be a positive number"));
+    }
+    if !inputs.leverage.is_finite() || !inputs.maintenance.is_finite() {
+        return Err(fail("leverage and maintenance must be numbers"));
+    }
+    let max_leverage = if inputs.intraday_bp {
+        INTRADAY_MAX_LEVERAGE
+    } else {
+        OVERNIGHT_MAX_LEVERAGE
+    };
+    let leverage = inputs.leverage.clamp(1.0, max_leverage);
+    let maintenance = inputs.maintenance.clamp(0.10, 0.90);
+
+    let mut notes: Vec<String> = Vec::new();
+    if leverage > OVERNIGHT_MAX_LEVERAGE {
+        notes.push(format!(
+            "{leverage}x is intraday buying power — not holdable overnight (Reg-T max is {OVERNIGHT_MAX_LEVERAGE}x)"
+        ));
+    }
+
+    let buying_power = inputs.equity_usd * leverage;
+    let bp_shares = (buying_power / risk.entry).floor() as u64;
+    let shares = risk.shares.min(bp_shares);
+    let capped_by_buying_power = shares < risk.shares;
+    if capped_by_buying_power {
+        notes.push("buying power, not the risk budget, capped this size".into());
+    }
+
+    let notional = shares as f64 * risk.entry;
+    let cash_used = inputs.equity_usd.min(notional);
+    let borrowed = (notional - cash_used).max(0.0);
+
+    let margin_call_price =
+        (borrowed > 0.0 && shares > 0).then(|| borrowed / (shares as f64 * (1.0 - maintenance)));
+    let mc_distance_pct = margin_call_price.map(|mc| (risk.entry - mc) / risk.entry * 100.0);
+    let mc_distance_atr = margin_call_price.map(|mc| (risk.entry - mc) / risk.atr);
+
+    if let Some(mc) = margin_call_price {
+        if mc >= risk.stop {
+            notes.push(format!(
+                "margin call (~{mc:.2}) would trigger BEFORE your stop ({:.2}) at this leverage",
+                risk.stop
+            ));
+        }
+    }
+
+    Ok(MarginFrame {
+        equity_usd: inputs.equity_usd,
+        leverage,
+        maintenance,
+        shares,
+        notional_usd: notional,
+        cash_used_usd: cash_used,
+        borrowed_usd: borrowed,
+        margin_call_price,
+        mc_distance_pct,
+        mc_distance_atr,
+        capped_by_buying_power,
+        notes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::risk::RiskFrame;
+    use chrono::TimeZone;
+
+    /// entry 100, ATR 4, 2xATR stop at 92, risk-budget size 500 shares.
+    fn risk(shares: u64) -> RiskFrame {
+        RiskFrame {
+            ticker: "TEST".into(),
+            direction: Direction::Long,
+            entry: 100.0,
+            atr: 4.0,
+            stop_multiple: 2.0,
+            stop: 92.0,
+            risk_per_share: 8.0,
+            shares,
+            max_loss_usd: shares as f64 * 8.0,
+            budget_usd: shares as f64 * 8.0,
+            targets: [108.0, 116.0, 124.0],
+            notional_usd: shares as f64 * 100.0,
+            bars_used: 30,
+            note: None,
+            generated_at: chrono::Utc.with_ymd_and_hms(2026, 8, 14, 0, 0, 0).unwrap(),
+        }
+    }
+
+    fn inputs(equity: f64) -> MarginInputs {
+        MarginInputs {
+            equity_usd: equity,
+            ..MarginInputs::default()
+        }
+    }
+
+    #[test]
+    fn no_borrow_means_no_margin_call() {
+        // 10 risk shares × $100 = $1,000 notional, equity $50,000 — all cash
+        let f = margin_frame(&risk(10), &inputs(50_000.0)).unwrap();
+        assert_eq!(f.shares, 10);
+        assert_eq!(f.borrowed_usd, 0.0);
+        assert_eq!(f.margin_call_price, None);
+        assert!(!f.capped_by_buying_power);
+        assert!(f.notes.is_empty());
+    }
+
+    #[test]
+    fn two_x_case_hand_computed() {
+        // equity 10k, 2x BP = 20k -> bp cap 200 shares; risk wants 500.
+        // notional 20k, cash 10k, borrowed 10k.
+        // mc = 10_000 / (200 × 0.75) = 66.67
+        let f = margin_frame(&risk(500), &inputs(10_000.0)).unwrap();
+        assert_eq!(f.shares, 200);
+        assert!(f.capped_by_buying_power);
+        assert!((f.notional_usd - 20_000.0).abs() < 1e-9);
+        assert!((f.borrowed_usd - 10_000.0).abs() < 1e-9);
+        let mc = f.margin_call_price.unwrap();
+        assert!((mc - 66.6667).abs() < 1e-3);
+        assert!((f.mc_distance_pct.unwrap() - 33.3333).abs() < 1e-3);
+        assert!((f.mc_distance_atr.unwrap() - 8.3333).abs() < 1e-3);
+        // mc (66.67) < stop (92): stop fires first, no warning note
+        assert!(!f.notes.iter().any(|n| n.contains("BEFORE")));
+    }
+
+    #[test]
+    fn margin_call_above_stop_warns() {
+        // Force a high mc: maintenance 0.90 -> mc = borrowed/(shares×0.1).
+        // equity 10k, 2x -> 200 shares, borrowed 10k -> mc = 10k/20 = 500?? that's
+        // above entry — degenerate but exactly the case the warning exists for.
+        let mut i = inputs(10_000.0);
+        i.maintenance = 0.90;
+        let f = margin_frame(&risk(500), &i).unwrap();
+        assert!(f.margin_call_price.unwrap() >= 92.0);
+        assert!(f.notes.iter().any(|n| n.contains("BEFORE")));
+    }
+
+    #[test]
+    fn overnight_clamp_and_intraday_unlock() {
+        let mut i = inputs(10_000.0);
+        i.leverage = 4.0;
+        let f = margin_frame(&risk(500), &i).unwrap();
+        assert_eq!(f.leverage, 2.0); // clamped to Reg-T overnight
+        assert!(f.notes.iter().all(|n| !n.contains("intraday")));
+
+        i.intraday_bp = true;
+        let f = margin_frame(&risk(500), &i).unwrap();
+        assert_eq!(f.leverage, 4.0);
+        assert_eq!(f.shares, 400); // 40k BP / 100
+        assert!(f.notes.iter().any(|n| n.contains("not holdable overnight")));
+    }
+
+    #[test]
+    fn zero_shares_passthrough_and_errors() {
+        let f = margin_frame(&risk(0), &inputs(10_000.0)).unwrap();
+        assert_eq!(f.shares, 0);
+        assert_eq!(f.margin_call_price, None);
+
+        assert!(margin_frame(&risk(10), &inputs(0.0)).is_err());
+        assert!(margin_frame(&risk(10), &inputs(f64::NAN)).is_err());
+        let mut short = risk(10);
+        short.direction = Direction::Short;
+        assert!(margin_frame(&short, &inputs(10_000.0)).is_err());
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod dip;
 pub mod engine;
 pub mod entities;
 pub mod error;

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -2,6 +2,7 @@ pub mod dip;
 pub mod engine;
 pub mod entities;
 pub mod error;
+pub mod margin;
 pub mod ports;
 pub mod risk;
 pub mod values;

--- a/src/domain/ports/filings_source.rs
+++ b/src/domain/ports/filings_source.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+use chrono::NaiveDate;
+
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::values::filing::Filing;
+
+/// Regulatory filings on/after `since` for a ticker. An error (unreachable
+/// registry, ticker not a mapped filer) means "could not verify" — callers
+/// must fail closed, never treat it as "no filings".
+#[async_trait]
+pub trait FilingsSource: Send + Sync {
+    async fn recent_filings(
+        &self,
+        ticker: &Ticker,
+        since: NaiveDate,
+    ) -> Result<Vec<Filing>, DomainError>;
+}

--- a/src/domain/ports/mod.rs
+++ b/src/domain/ports/mod.rs
@@ -1,5 +1,8 @@
 pub mod bar_source;
+pub mod filings_source;
 pub mod influencer_feed;
 pub mod market_data_source;
+pub mod movers_source;
+pub mod news_source;
 pub mod post_analyzer;
 pub mod social_data_source;

--- a/src/domain/ports/movers_source.rs
+++ b/src/domain/ports/movers_source.rs
@@ -1,0 +1,12 @@
+use async_trait::async_trait;
+
+use crate::domain::error::DomainError;
+use crate::domain::values::mover::MoverRow;
+
+/// The day's biggest percentage losers, worst first. Universe feed for
+/// dip_scan; symbol-scoped ports stay untouched.
+#[async_trait]
+pub trait MoversSource: Send + Sync {
+    fn name(&self) -> &str;
+    async fn day_losers(&self, count: usize) -> Result<Vec<MoverRow>, DomainError>;
+}

--- a/src/domain/ports/news_source.rs
+++ b/src/domain/ports/news_source.rs
@@ -1,0 +1,11 @@
+use async_trait::async_trait;
+
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::values::headline::Headline;
+
+/// Recent news headlines for a ticker (catalyst keyword heuristic input).
+#[async_trait]
+pub trait NewsSource: Send + Sync {
+    async fn headlines(&self, ticker: &Ticker, count: usize) -> Result<Vec<Headline>, DomainError>;
+}

--- a/src/domain/risk.rs
+++ b/src/domain/risk.rs
@@ -153,7 +153,13 @@ mod tests {
     }
 
     fn bar(high: f64, low: f64, close: f64) -> Bar {
-        Bar { high, low, close }
+        Bar {
+            date: chrono::NaiveDate::from_ymd_opt(2026, 7, 15).unwrap(),
+            open: close,
+            high,
+            low,
+            close,
+        }
     }
 
     /// 16 bars: prev_close 100, then 15 identical bars with TR dominated by

--- a/src/domain/values/bar.rs
+++ b/src/domain/values/bar.rs
@@ -1,6 +1,11 @@
-/// One daily OHLC bar (open omitted — nothing here needs it).
+use chrono::NaiveDate;
+
+/// One daily OHLC bar. `date` is the exchange-local session date — adapters
+/// convert venue timestamps; domain math never touches a timezone.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Bar {
+    pub date: NaiveDate,
+    pub open: f64,
     pub high: f64,
     pub low: f64,
     pub close: f64,

--- a/src/domain/values/filing.rs
+++ b/src/domain/values/filing.rs
@@ -1,0 +1,8 @@
+use chrono::NaiveDate;
+
+/// One regulatory filing (form type + filing date), for the catalyst gate.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Filing {
+    pub form: String,
+    pub filed_on: NaiveDate,
+}

--- a/src/domain/values/headline.rs
+++ b/src/domain/values/headline.rs
@@ -1,0 +1,9 @@
+use chrono::{DateTime, Utc};
+
+/// One news headline about a ticker, for the catalyst keyword heuristic.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Headline {
+    pub title: String,
+    pub publisher: String,
+    pub published_at: DateTime<Utc>,
+}

--- a/src/domain/values/headline.rs
+++ b/src/domain/values/headline.rs
@@ -1,9 +1,12 @@
 use chrono::{DateTime, Utc};
 
 /// One news headline about a ticker, for the catalyst keyword heuristic.
+/// `published_at` is None when the provider omits the timestamp — consumers
+/// must treat an undated headline conservatively (it might be same-day),
+/// never silently drop it.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Headline {
     pub title: String,
     pub publisher: String,
-    pub published_at: DateTime<Utc>,
+    pub published_at: Option<DateTime<Utc>>,
 }

--- a/src/domain/values/mod.rs
+++ b/src/domain/values/mod.rs
@@ -1,4 +1,7 @@
 pub mod bar;
+pub mod filing;
+pub mod headline;
+pub mod mover;
 pub mod polarity;
 pub mod post_signal;
 pub mod source_kind;

--- a/src/domain/values/mover.rs
+++ b/src/domain/values/mover.rs
@@ -1,0 +1,16 @@
+/// One row of a "biggest movers" screener. Optional fields are optional
+/// because screeners omit them for some instruments — the quality floor
+/// treats a missing value as a reject, never a pass.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MoverRow {
+    pub symbol: String,
+    /// Regular-session change in percent (e.g. -11.2 for an 11.2% drop).
+    pub change_pct: f64,
+    pub price: f64,
+    pub market_cap: Option<u64>,
+    pub avg_volume_3mo: Option<u64>,
+    pub day_volume: Option<u64>,
+    pub exchange: String,
+    /// First trade timestamp in epoch milliseconds (listing-age screen).
+    pub first_trade_ms: Option<i64>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,5 +89,21 @@ async fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
+        Command::Dip(args) => {
+            // Credentials resolve env-first, then the OS keychain (written by `openintel setup`).
+            let store = KeychainStore::new();
+            let credentials = Credentials::load(&store);
+
+            match openintel::cli::dip::run(&args, &credentials).await {
+                Ok(rendered) => {
+                    println!("{rendered}");
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -16,6 +16,7 @@ pub struct OpenIntelServer {
     tool_router: ToolRouter<OpenIntelServer>,
     social: Arc<Vec<Box<dyn SocialDataSource>>>,
     market: YahooMarketSource,
+    filings: Arc<crate::adapters::filings::edgar::EdgarSource>,
     pulse_feed: Option<Arc<crate::adapters::sources::x::XPulseSource>>,
 }
 
@@ -23,12 +24,14 @@ impl OpenIntelServer {
     pub fn new(
         social: Vec<Box<dyn SocialDataSource>>,
         market: YahooMarketSource,
+        filings: crate::adapters::filings::edgar::EdgarSource,
         pulse_feed: Option<crate::adapters::sources::x::XPulseSource>,
     ) -> Self {
         Self {
             tool_router: Self::tool_router(),
             social: Arc::new(social),
             market,
+            filings: Arc::new(filings),
             pulse_feed: pulse_feed.map(Arc::new),
         }
     }
@@ -146,6 +149,40 @@ impl OpenIntelServer {
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
     }
+
+    #[tool(
+        description = "Scan the day's biggest losers for dip-buy SETUPS, or evaluate one ticker \
+                       (pass `ticker`). Hard gates decide a tiered verdict — no_setup / watch / \
+                       high_confidence: quality floor, -15%..-4% drop band, no same-day SEC \
+                       filing (8-K/6-K/424B5/S-3/FWP via EDGAR), no catalyst headline, \
+                       idiosyncratic vs the index, buyers-at-the-close, and a score floor. \
+                       Unverifiable evidence FAILS CLOSED (caps at watch); intraday runs always \
+                       cap at watch. 'high_confidence' means conformance to the setup template, \
+                       NEVER probability of profit; zero candidates is a normal result. Passing \
+                       equity_usd adds ATR-stop sizing plus margin mechanics (overnight Reg-T 2x \
+                       cap, margin-call price; single-position model, interest not modeled). \
+                       Appends a scan journal line to ~/.openintel/dip_journal.jsonl unless \
+                       no_journal. The composite score's weights are v0 and unvalidated. \
+                       Read-only — does not trade."
+    )]
+    async fn dip_scan(
+        &self,
+        Parameters(args): Parameters<tools::DipScanArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let deps = crate::application::dip::DipDeps {
+            bars: &self.market,
+            news: &self.market,
+            filings: self.filings.as_ref(),
+            social: &self.social,
+            market: Some(&self.market),
+        };
+        let out = tools::run_dip_scan(args, &self.market, &deps)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let json = serde_json::to_string_pretty(&out)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    }
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -174,6 +211,7 @@ pub async fn serve() -> Result<(), Box<dyn std::error::Error>> {
     let social = crate::adapters::sources::build_social_sources(&credentials);
 
     let market = YahooMarketSource::new()?;
+    let filings = crate::adapters::filings::edgar::EdgarSource::new()?;
     let pulse_feed = match credentials.x_bearer.clone() {
         Some(bearer) => match crate::adapters::sources::x::XPulseSource::new(bearer) {
             Ok(src) => Some(src),
@@ -184,7 +222,7 @@ pub async fn serve() -> Result<(), Box<dyn std::error::Error>> {
         },
         None => None,
     };
-    let service = OpenIntelServer::new(social, market, pulse_feed)
+    let service = OpenIntelServer::new(social, market, filings, pulse_feed)
         .serve(stdio())
         .await?;
     service.waiting().await?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -52,13 +52,22 @@ impl OpenIntelServer {
     #[tool(
         description = "Analyze one ticker: fuse social sentiment with market action into a \
                        speculation report (net sentiment, speculation index, crowding, \
-                       alignment = confirming/diverging/quiet). Read-only — does not trade."
+                       alignment = confirming/diverging/quiet). On a ≤ -4% down day the output \
+                       also carries dip_signal — the same gated setup verdict dip_scan computes \
+                       (capped at watch in this mode). Read-only — does not trade."
     )]
     async fn analyze_ticker(
         &self,
         Parameters(args): Parameters<tools::AnalyzeArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let out = tools::run_analyze(args, &self.social, &self.market)
+        let dip_deps = crate::application::dip::DipDeps {
+            bars: &self.market,
+            news: &self.market,
+            filings: self.filings.as_ref(),
+            social: &self.social,
+            market: Some(&self.market),
+        };
+        let out = tools::run_analyze(args, &self.social, &self.market, Some(&dip_deps))
             .await
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         let json = serde_json::to_string_pretty(&out)

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -53,6 +53,13 @@ pub struct AnalyzeArgs {
 pub struct AnalyzeOutput {
     pub summary: String,
     pub report: SpeculationReport,
+    /// Present only on a meaningful down day (≤ -4%) when dip deps are wired:
+    /// the same gated signal `dip_scan` computes, for trade-consideration
+    /// context. Single-ticker mode — verdict caps at watch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dip_signal: Option<crate::domain::dip::DipSignal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dip_note: Option<String>,
     pub disclaimer: &'static str,
 }
 
@@ -99,6 +106,7 @@ pub async fn run_analyze(
     args: AnalyzeArgs,
     social_sources: &[Box<dyn SocialDataSource>],
     market_source: &dyn MarketDataSource,
+    dip_deps: Option<&crate::application::dip::DipDeps<'_>>,
 ) -> Result<AnalyzeOutput, DomainError> {
     let req = request_from(
         args.ticker,
@@ -108,9 +116,41 @@ pub async fn run_analyze(
         args.limit,
     );
     let report = application::analyze(&req, social_sources, Some(market_source)).await?;
+
+    // Attach the dip signal only when today actually looks like a dip —
+    // a mild move would make the signal pure noise. Never fails analyze.
+    let mut dip_note = None;
+    let dip_signal = match (&report.market, dip_deps) {
+        (Some(market), Some(deps))
+            if market.pct_change <= crate::domain::dip::DropBand::default().max_pct =>
+        {
+            let dip_req = crate::application::dip::DipScanRequest {
+                journal_path: None,
+                ..Default::default()
+            };
+            match crate::application::dip::dip_check(
+                report.ticker.as_str(),
+                &dip_req,
+                deps,
+                Utc::now(),
+            )
+            .await
+            {
+                Ok(signal) => Some(signal),
+                Err(e) => {
+                    dip_note = Some(format!("dip signal unavailable: {e}"));
+                    None
+                }
+            }
+        }
+        _ => None,
+    };
+
     Ok(AnalyzeOutput {
         summary: summarize(&report),
         report,
+        dip_signal,
+        dip_note,
         disclaimer: DISCLAIMER,
     })
 }
@@ -597,11 +637,14 @@ mod tests {
             },
             &fixture_social(),
             &MockMarketSource,
+            None,
         )
         .await
         .unwrap();
         assert!(out.summary.contains("ConfirmingBullish"));
         assert_eq!(out.report.social.total_mentions, 10);
+        // mock market is UP +4% — no dip signal even if deps were wired
+        assert!(out.dip_signal.is_none());
         assert!(out.disclaimer.contains("Not financial advice"));
     }
 
@@ -614,9 +657,11 @@ mod tests {
             no_market: None,
             limit: None,
         };
-        assert!(run_analyze(args, &fixture_social(), &MockMarketSource)
-            .await
-            .is_err());
+        assert!(
+            run_analyze(args, &fixture_social(), &MockMarketSource, None)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -1043,6 +1088,98 @@ mod tests {
             assert_eq!(req.deep_n, 5);
             assert!(req.journal_path.is_none()); // no_journal in fixture args
             assert_eq!(req.margin.unwrap().equity_usd, 10_000.0);
+        }
+
+        /// Market mock whose snapshot is an -8% down day.
+        struct DownMarket;
+
+        #[async_trait]
+        impl crate::domain::ports::market_data_source::MarketDataSource for DownMarket {
+            fn name(&self) -> &'static str {
+                "down-market"
+            }
+            async fn snapshot(
+                &self,
+                ticker: &crate::domain::entities::ticker::Ticker,
+            ) -> Result<crate::domain::entities::market_snapshot::MarketSnapshot, DomainError>
+            {
+                Ok(crate::domain::entities::market_snapshot::MarketSnapshot {
+                    ticker: ticker.clone(),
+                    as_of: Utc::now(),
+                    last_price: 87.4,
+                    previous_close: 95.0,
+                    volume: 4_000_000,
+                    avg_volume: 5_000_000,
+                    realized_vol: None,
+                    put_call_ratio: None,
+                    iv_rank: None,
+                })
+            }
+        }
+
+        #[tokio::test]
+        async fn analyze_attaches_dip_signal_on_down_day() {
+            let bars = bars_map();
+            let news = MockNewsSource(Ok(vec![]));
+            let filings = MockFilingsSource(Ok(vec![]));
+            let social = fixture_social();
+            let deps = DipDeps {
+                bars: &bars,
+                news: &news,
+                filings: &filings,
+                social: &social,
+                market: Some(&DownMarket),
+            };
+            let out = run_analyze(
+                AnalyzeArgs {
+                    ticker: "GOOD".into(),
+                    enable_reddit: None,
+                    enable_bluesky: None,
+                    no_market: None,
+                    limit: None,
+                },
+                &social,
+                &DownMarket,
+                Some(&deps),
+            )
+            .await
+            .unwrap();
+            let signal = out.dip_signal.expect("down day should attach a signal");
+            // single-ticker mode never claims high_confidence
+            assert_ne!(signal.verdict, crate::domain::dip::Verdict::HighConfidence);
+            assert!(out.dip_note.is_none());
+        }
+
+        #[tokio::test]
+        async fn analyze_dip_failure_degrades_to_note() {
+            // AAPL has no bars in the map -> dip_check errors -> note, not failure
+            let bars = bars_map();
+            let news = MockNewsSource(Ok(vec![]));
+            let filings = MockFilingsSource(Ok(vec![]));
+            let social = fixture_social();
+            let deps = DipDeps {
+                bars: &bars,
+                news: &news,
+                filings: &filings,
+                social: &social,
+                market: Some(&DownMarket),
+            };
+            let out = run_analyze(
+                AnalyzeArgs {
+                    ticker: "AAPL".into(),
+                    enable_reddit: None,
+                    enable_bluesky: None,
+                    no_market: None,
+                    limit: None,
+                },
+                &social,
+                &DownMarket,
+                Some(&deps),
+            )
+            .await
+            .unwrap();
+            assert!(out.dip_signal.is_none());
+            assert!(out.dip_note.unwrap().contains("dip signal unavailable"));
         }
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -128,15 +128,21 @@ pub async fn run_analyze(
                 journal_path: None,
                 ..Default::default()
             };
+            // Reuse the sentiment analyze just computed — no second social fetch.
+            let sentiment = Some(crate::domain::dip::SentimentSummary {
+                net_sentiment: report.social.net_sentiment.value(),
+                mentions: report.social.total_mentions,
+            });
             match crate::application::dip::dip_check(
                 report.ticker.as_str(),
                 &dip_req,
                 deps,
+                sentiment,
                 Utc::now(),
             )
             .await
             {
-                Ok(signal) => Some(signal),
+                Ok(outcome) => Some(outcome.signal),
                 Err(e) => {
                     dip_note = Some(format!("dip signal unavailable: {e}"));
                     None
@@ -510,8 +516,9 @@ pub struct DipOutput {
     pub summary: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub report: Option<crate::application::dip::DipScanReport>,
+    /// Single-ticker mode: signal plus optional risk/margin sizing.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub signal: Option<crate::domain::dip::DipSignal>,
+    pub ticker_report: Option<crate::application::dip::TickerDipReport>,
     pub framing: &'static str,
     pub disclaimer: &'static str,
 }
@@ -562,7 +569,9 @@ pub async fn run_dip_scan(
     let now = Utc::now();
     match &args.ticker {
         Some(ticker) => {
-            let signal = crate::application::dip::dip_check(ticker, &req, deps, now).await?;
+            let ticker_report =
+                crate::application::dip::dip_check(ticker, &req, deps, None, now).await?;
+            let signal = &ticker_report.signal;
             let summary = format!(
                 "{} — {:?} · score {:.0}/{:.0}",
                 signal.ticker, signal.verdict, signal.score, signal.score_max
@@ -570,7 +579,7 @@ pub async fn run_dip_scan(
             Ok(DipOutput {
                 summary,
                 report: None,
-                signal: Some(signal),
+                ticker_report: Some(ticker_report),
                 framing: crate::application::dip::FRAMING,
                 disclaimer: DISCLAIMER,
             })
@@ -586,8 +595,9 @@ pub async fn run_dip_scan(
             };
             let summary = match report.candidates.first() {
                 None => format!(
-                    "no setups — 0 of {} losers survived the floor+band (that's a normal result)",
-                    report.universe_size
+                    "no candidates evaluated from {} losers ({} per-ticker errors) — zero setups is a normal result",
+                    report.universe_size,
+                    report.errors.len()
                 ),
                 Some(top) => format!(
                     "{} analyzed: {} high_confidence, {} watch, {} no_setup · top: {} {:.0}/{:.0} ({:?})",
@@ -604,7 +614,7 @@ pub async fn run_dip_scan(
             Ok(DipOutput {
                 summary,
                 report: Some(report),
-                signal: None,
+                ticker_report: None,
                 framing: crate::application::dip::FRAMING,
                 disclaimer: DISCLAIMER,
             })
@@ -965,7 +975,7 @@ mod tests {
                 .collect();
             v.push(Bar {
                 date: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap(),
-                open: drop_close + 6.0,
+                open: drop_close + 0.4,
                 high: drop_close + 0.5,
                 low: drop_close - 7.0,
                 close: drop_close,
@@ -1047,7 +1057,7 @@ mod tests {
             };
             let out = run_dip_scan(args(), &movers, &deps).await.unwrap();
             assert!(out.report.is_some());
-            assert!(out.signal.is_none());
+            assert!(out.ticker_report.is_none());
             assert!(out.summary.contains("GOOD"), "got {}", out.summary);
             assert!(out.framing.contains("setup conformance"));
             assert!(out.disclaimer.contains("Not financial advice"));
@@ -1071,7 +1081,7 @@ mod tests {
             a.ticker = Some("GOOD".into());
             let out = run_dip_scan(a, &movers, &deps).await.unwrap();
             assert!(out.report.is_none());
-            let signal = out.signal.unwrap();
+            let signal = out.ticker_report.unwrap().signal;
             assert_eq!(signal.ticker, "GOOD");
             // single-ticker mode: floor unverifiable -> never high_confidence
             assert_ne!(signal.verdict, crate::domain::dip::Verdict::HighConfidence);

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -427,6 +427,151 @@ pub async fn run_risk_frame(
     })
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DipScanArgs {
+    /// Evaluate one symbol instead of scanning the losers universe — the
+    /// "considering a trade" mode. The quality-floor gate is unverifiable for
+    /// a single ticker, so the verdict caps at watch.
+    pub ticker: Option<String>,
+    /// Day losers to pull from the screener (1-100, default 100).
+    pub count: Option<usize>,
+    /// Floor+band survivors to deep-analyze (1-25, default 10).
+    pub deep_n: Option<usize>,
+    /// Worst eligible day change in percent (default -15).
+    pub band_min: Option<f64>,
+    /// Mildest eligible day change in percent (default -4).
+    pub band_max: Option<f64>,
+    /// Account equity in USD — enables the risk + margin sizing section.
+    pub equity_usd: Option<f64>,
+    /// Buying-power multiple (overnight Reg-T caps at 2; default 2).
+    pub leverage: Option<f64>,
+    /// Unlock 4x intraday buying power (NOT holdable overnight).
+    pub intraday_bp: Option<bool>,
+    /// Maintenance requirement fraction (default 0.25).
+    pub maintenance: Option<f64>,
+    /// Fraction of equity risked to the stop per position (default 0.01).
+    pub risk_pct: Option<f64>,
+    /// Minimum composite score for the score gate (default 65).
+    pub score_min: Option<f64>,
+    /// Quality floor: minimum share price (default 5).
+    pub min_price: Option<f64>,
+    /// Quality floor: minimum market cap in USD (default 500M).
+    pub min_cap: Option<u64>,
+    /// Quality floor: minimum 3-month average daily volume (default 1M shares).
+    pub min_volume: Option<u64>,
+    /// Quality floor: minimum days since listing (default 180).
+    pub min_listed_days: Option<i64>,
+    /// Skip the scan journal write (~/.openintel/dip_journal.jsonl).
+    pub no_journal: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DipOutput {
+    pub summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub report: Option<crate::application::dip::DipScanReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal: Option<crate::domain::dip::DipSignal>,
+    pub framing: &'static str,
+    pub disclaimer: &'static str,
+}
+
+fn dip_request_from(args: &DipScanArgs) -> crate::application::dip::DipScanRequest {
+    use crate::application::dip::{default_journal_path, DipScanRequest};
+    use crate::domain::dip::{DropBand, QualityFloor};
+    use crate::domain::margin::MarginInputs;
+    let base = DipScanRequest::default();
+    let band = DropBand::default();
+    let floor = QualityFloor::default();
+    let margin_defaults = MarginInputs::default();
+    DipScanRequest {
+        count: args.count.unwrap_or(base.count),
+        deep_n: args.deep_n.unwrap_or(base.deep_n),
+        band: DropBand {
+            min_pct: args.band_min.unwrap_or(band.min_pct),
+            max_pct: args.band_max.unwrap_or(band.max_pct),
+        },
+        floor: QualityFloor {
+            min_price: args.min_price.unwrap_or(floor.min_price),
+            min_market_cap: args.min_cap.unwrap_or(floor.min_market_cap),
+            min_avg_volume: args.min_volume.unwrap_or(floor.min_avg_volume),
+            min_listed_days: args.min_listed_days.unwrap_or(floor.min_listed_days),
+        },
+        score_min: args.score_min.unwrap_or(base.score_min),
+        margin: args.equity_usd.map(|equity_usd| MarginInputs {
+            equity_usd,
+            leverage: args.leverage.unwrap_or(margin_defaults.leverage),
+            maintenance: args.maintenance.unwrap_or(margin_defaults.maintenance),
+            risk_pct: args.risk_pct.unwrap_or(margin_defaults.risk_pct),
+            intraday_bp: args.intraday_bp.unwrap_or(false),
+        }),
+        journal_path: (!args.no_journal.unwrap_or(false))
+            .then(default_journal_path)
+            .flatten(),
+        ..base
+    }
+}
+
+pub async fn run_dip_scan(
+    args: DipScanArgs,
+    movers: &dyn crate::domain::ports::movers_source::MoversSource,
+    deps: &crate::application::dip::DipDeps<'_>,
+) -> Result<DipOutput, DomainError> {
+    use crate::domain::dip::Verdict;
+    let req = dip_request_from(&args);
+    let now = Utc::now();
+    match &args.ticker {
+        Some(ticker) => {
+            let signal = crate::application::dip::dip_check(ticker, &req, deps, now).await?;
+            let summary = format!(
+                "{} — {:?} · score {:.0}/{:.0}",
+                signal.ticker, signal.verdict, signal.score, signal.score_max
+            );
+            Ok(DipOutput {
+                summary,
+                report: None,
+                signal: Some(signal),
+                framing: crate::application::dip::FRAMING,
+                disclaimer: DISCLAIMER,
+            })
+        }
+        None => {
+            let report = crate::application::dip::dip_scan(&req, movers, deps, now).await?;
+            let count = |v: Verdict| {
+                report
+                    .candidates
+                    .iter()
+                    .filter(|c| c.signal.verdict == v)
+                    .count()
+            };
+            let summary = match report.candidates.first() {
+                None => format!(
+                    "no setups — 0 of {} losers survived the floor+band (that's a normal result)",
+                    report.universe_size
+                ),
+                Some(top) => format!(
+                    "{} analyzed: {} high_confidence, {} watch, {} no_setup · top: {} {:.0}/{:.0} ({:?})",
+                    report.candidates.len(),
+                    count(Verdict::HighConfidence),
+                    count(Verdict::Watch),
+                    count(Verdict::NoSetup),
+                    top.ticker,
+                    top.signal.score,
+                    top.signal.score_max,
+                    top.signal.verdict
+                ),
+            };
+            Ok(DipOutput {
+                summary,
+                report: Some(report),
+                signal: None,
+                framing: crate::application::dip::FRAMING,
+                disclaimer: DISCLAIMER,
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -745,5 +890,159 @@ mod tests {
         assert!(out.summary.contains("25 shares"));
         assert!(out.framing.contains("risk_frame is a calculator"));
         assert!(out.disclaimer.contains("Not financial advice"));
+    }
+
+    mod dip {
+        use super::*;
+        use crate::adapters::filings::mock_filings::MockFilingsSource;
+        use crate::adapters::market::mock_movers::MockMoversSource;
+        use crate::adapters::market::mock_news::MockNewsSource;
+        use crate::application::dip::{DipDeps, SPX_PROXY};
+        use crate::domain::ports::bar_source::BarSource;
+        use crate::domain::values::bar::Bar;
+        use crate::domain::values::mover::MoverRow;
+        use async_trait::async_trait;
+        use chrono::NaiveDate;
+        use std::collections::HashMap;
+
+        fn dip_bars(drop_close: f64) -> Vec<Bar> {
+            let mut v: Vec<Bar> = (1..=30)
+                .map(|i| {
+                    let c = 110.0 - i as f64 * 0.5;
+                    Bar {
+                        date: NaiveDate::from_ymd_opt(2026, 7, i).unwrap(),
+                        open: c,
+                        high: c + 1.0,
+                        low: c - 1.0,
+                        close: c,
+                    }
+                })
+                .collect();
+            v.push(Bar {
+                date: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap(),
+                open: drop_close + 6.0,
+                high: drop_close + 0.5,
+                low: drop_close - 7.0,
+                close: drop_close,
+            });
+            v
+        }
+
+        struct MapBars(HashMap<String, Vec<Bar>>);
+
+        #[async_trait]
+        impl BarSource for MapBars {
+            async fn bars(
+                &self,
+                t: &crate::domain::entities::ticker::Ticker,
+            ) -> Result<Vec<Bar>, DomainError> {
+                self.0.get(t.as_str()).cloned().ok_or(DomainError::NoData)
+            }
+        }
+
+        fn bars_map() -> MapBars {
+            let mut m = HashMap::new();
+            m.insert("GOOD".to_string(), dip_bars(87.4));
+            // flat index proxy
+            let mut spy = dip_bars(95.0);
+            for b in &mut spy {
+                b.open = 500.0;
+                b.high = 501.0;
+                b.low = 499.0;
+                b.close = 500.0;
+            }
+            spy.last_mut().unwrap().close = 499.0;
+            m.insert(SPX_PROXY.to_string(), spy);
+            MapBars(m)
+        }
+
+        fn args() -> DipScanArgs {
+            DipScanArgs {
+                ticker: None,
+                count: None,
+                deep_n: None,
+                band_min: None,
+                band_max: None,
+                equity_usd: None,
+                leverage: None,
+                intraday_bp: None,
+                maintenance: None,
+                risk_pct: None,
+                score_min: None,
+                min_price: None,
+                min_cap: None,
+                min_volume: None,
+                min_listed_days: None,
+                no_journal: Some(true),
+            }
+        }
+
+        #[tokio::test]
+        async fn scan_mode_summarizes_and_frames() {
+            let bars = bars_map();
+            let news = MockNewsSource(Ok(vec![]));
+            let filings = MockFilingsSource(Ok(vec![]));
+            let social = fixture_social();
+            let movers = MockMoversSource(vec![MoverRow {
+                symbol: "GOOD".into(),
+                change_pct: -8.0,
+                price: 87.4,
+                market_cap: Some(2_000_000_000),
+                avg_volume_3mo: Some(5_000_000),
+                day_volume: Some(4_000_000),
+                exchange: "NYSE".into(),
+                first_trade_ms: Some(0),
+            }]);
+            let deps = DipDeps {
+                bars: &bars,
+                news: &news,
+                filings: &filings,
+                social: &social,
+                market: None,
+            };
+            let out = run_dip_scan(args(), &movers, &deps).await.unwrap();
+            assert!(out.report.is_some());
+            assert!(out.signal.is_none());
+            assert!(out.summary.contains("GOOD"), "got {}", out.summary);
+            assert!(out.framing.contains("setup conformance"));
+            assert!(out.disclaimer.contains("Not financial advice"));
+        }
+
+        #[tokio::test]
+        async fn single_ticker_mode_returns_signal() {
+            let bars = bars_map();
+            let news = MockNewsSource(Ok(vec![]));
+            let filings = MockFilingsSource(Ok(vec![]));
+            let social = fixture_social();
+            let movers = MockMoversSource(vec![]);
+            let deps = DipDeps {
+                bars: &bars,
+                news: &news,
+                filings: &filings,
+                social: &social,
+                market: None,
+            };
+            let mut a = args();
+            a.ticker = Some("GOOD".into());
+            let out = run_dip_scan(a, &movers, &deps).await.unwrap();
+            assert!(out.report.is_none());
+            let signal = out.signal.unwrap();
+            assert_eq!(signal.ticker, "GOOD");
+            // single-ticker mode: floor unverifiable -> never high_confidence
+            assert_ne!(signal.verdict, crate::domain::dip::Verdict::HighConfidence);
+        }
+
+        #[test]
+        fn request_mapping_honors_overrides() {
+            let mut a = args();
+            a.equity_usd = Some(10_000.0);
+            a.band_min = Some(-12.0);
+            a.deep_n = Some(5);
+            let req = dip_request_from(&a);
+            assert_eq!(req.band.min_pct, -12.0);
+            assert_eq!(req.deep_n, 5);
+            assert!(req.journal_path.is_none()); // no_journal in fixture args
+            assert_eq!(req.margin.unwrap().equity_usd, 10_000.0);
+        }
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -709,13 +709,18 @@ mod tests {
                 &self,
                 _t: &crate::domain::entities::ticker::Ticker,
             ) -> Result<Vec<Bar>, DomainError> {
+                let date = chrono::NaiveDate::from_ymd_opt(2026, 7, 15).unwrap();
                 let mut v = vec![Bar {
+                    date,
+                    open: 100.0,
                     high: 101.0,
                     low: 99.0,
                     close: 100.0,
                 }];
                 for _ in 0..15 {
                     v.push(Bar {
+                        date,
+                        open: 106.0,
                         high: 108.0,
                         low: 104.0,
                         close: 106.0,


### PR DESCRIPTION
## What

New strategy surface: scan the day's 100 biggest losers for dip-buy **setups**, graded by hard gates into a tiered verdict — \`no_setup\` / \`watch\` / \`high_confidence\`. Exposed as \`openintel dip\` (CLI), \`dip_scan\` (MCP, with single-ticker mode), and an additive \`dip_signal\` on \`analyze_ticker\` for ≤ -4% down days.

## Design (per docs/superpowers/plans/2026-08-15-dip-scan.md)

- **Gates decide, score ranks.** Quality floor → -15%…-4% drop band → no same-day SEC filing (8-K/6-K/424B5/S-3/FWP via EDGAR) → no catalyst headline (Yahoo news keywords) → idiosyncratic vs SPY → buyers-at-the-close → score ≥ 65.
- **Fail closed:** unverifiable evidence (EDGAR down, no CIK mapping) caps at \`watch\`. Confirmed catalyst → \`no_setup\` with the evidence shown. Intraday runs always cap at \`watch\`.
- **Margin overlay** (\`--equity\`): risk_frame sizing + buying-power cap, borrow, margin-call price/distance, warns when the m-call fires before the stop. Overnight Reg-T 2x clamp; \`--intraday-bp\` unlocks 4x with a note. Interest not modeled; single-position model — disclosed.
- **Honesty:** \`high_confidence\` = template conformance, never profit probability; score weights are v0/unvalidated; every scan journals to \`~/.openintel/dip_journal.jsonl\` so weights can be graded against forward returns (\`dip --review\` is the named follow-up).
- **Bar migration:** \`Bar\` gains \`date\` (NY session) + \`open\` — baselines exclude the drop-day bar.

## Verified live (2026-08-15)

Post-close scan caught real catalysts: UCTT killed on same-day 8-K + 424B5 ($400M offering) with the matching headline; BLSH on 6-Ks. Known sharp edge: generic market-roundup headlines can false-positive the keyword gate (fails toward \`no_setup\` — conservative direction).

All endpoints keyless (Yahoo screener/news unofficial → clean-error failure mode; SEC EDGAR official, fair-access UA, ≤5 concurrent).

Tests: 243 passing + 13 live \`#[ignore]\`d; clippy -D warnings clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added gated dip-scan analysis via the `openintel dip` CLI and `dip_scan` MCP tool.
  - Supports ticker checks, market-loser scans, technical signals, quality filters, catalyst checks, risk sizing, margin estimates, journaling, and table or JSON output.
  - Added optional dip insights to ticker analysis.
  - Added market headlines, mover data, and regulatory filing support.

- **Documentation**
  - Documented dip-scan eligibility, verdicts, restrictions, risk mechanics, data sources, and tool availability.

- **Reliability**
  - Added validation, fail-closed handling, error reporting, and safeguards for incomplete or unavailable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->