### PR TITLE
feat(dip): --review forward-return grader + headline gate company discrimination

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,17 +112,24 @@ through **hard gates** into a tiered verdict:
 | `watch` | Eligible, no confirmed catalyst, but ≥ 1 gate failed or could not be verified (**unverifiable evidence fails closed**) |
 | `high_confidence` | ALL gates pass post-close: no filing, no catalyst headline, idiosyncratic vs SPY (≤ −3% excess), closed in the upper half of the day's range, score ≥ 65 |
 
+Keyword hits in headlines that clearly reference the company (by ticker or company name)
+confirm a catalyst; hits only in generic market-roundup headlines cap at `watch` instead
+of killing the candidate.
+
 `high_confidence` means **conformance to the setup template — never probability of
 profit**. Zero candidates is a normal result. Intraday runs always cap at `watch` (the day
 bar isn't final); run after the close for real verdicts. The composite score's weights are
 **v0 and unvalidated** — every scan appends a JSONL line to `~/.openintel/dip_journal.jsonl`
-(opt out with `--no-journal`) so they can be graded against forward returns later; a
-`dip --review` grader is the named follow-up.
+(opt out with `--no-journal`), and `openintel dip --review` grades that journal against
+subsequent prices: 1/5/10-trading-day raw and SPY-adjusted returns per verdict, win rates,
+and a score↔return correlation. Until the graded sample is meaningful (n ≥ 30, and only
+~3 months of entries are gradable per run), the review says so instead of pretending.
 
 ```bash
 openintel dip                                 # scan the losers universe
 openintel dip NVDA                            # one ticker (floor unverifiable -> caps at watch)
 openintel dip --equity 25000 --leverage 2     # adds ATR-stop sizing + margin mechanics
+openintel dip --review                        # grade past scans against forward returns
 ```
 
 With `--equity`, each candidate gets a risk frame (1% of equity to a 2×ATR stop by
@@ -164,6 +171,7 @@ Tools exposed (all **read-only** — OpenIntel never places trades):
 | `list_sources` | Which data sources are available |
 | `risk_frame` | ATR stop + budget-capped size + R targets for one trade idea |
 | `dip_scan` | Day's biggest losers → gated dip-setup verdicts (`no_setup`/`watch`/`high_confidence`), optional margin-aware sizing; pass `ticker` for one symbol |
+| `dip_review` | Grade the dip journal against forward returns (raw + SPY-adjusted, per verdict) — the evidence check on dip_scan's v0 score |
 
 ### ⚠️ Risk & responsibility — read before connecting a broker
 

--- a/src/adapters/market/mock_news.rs
+++ b/src/adapters/market/mock_news.rs
@@ -2,21 +2,19 @@ use async_trait::async_trait;
 
 use crate::domain::entities::ticker::Ticker;
 use crate::domain::error::DomainError;
-use crate::domain::ports::news_source::NewsSource;
-use crate::domain::values::headline::Headline;
+use crate::domain::ports::news_source::{NewsFetch, NewsSource};
 
-/// Test double: fixed headlines, or a fixed failure (for fail-closed paths).
-pub struct MockNewsSource(pub Result<Vec<Headline>, String>);
+/// Test double: a fixed news fetch, or a fixed failure (for fail-closed paths).
+pub struct MockNewsSource(pub Result<NewsFetch, String>);
 
 #[async_trait]
 impl NewsSource for MockNewsSource {
-    async fn headlines(
-        &self,
-        _ticker: &Ticker,
-        count: usize,
-    ) -> Result<Vec<Headline>, DomainError> {
+    async fn headlines(&self, _ticker: &Ticker, count: usize) -> Result<NewsFetch, DomainError> {
         match &self.0 {
-            Ok(headlines) => Ok(headlines.iter().take(count).cloned().collect()),
+            Ok(fetch) => Ok(NewsFetch {
+                headlines: fetch.headlines.iter().take(count).cloned().collect(),
+                company_names: fetch.company_names.clone(),
+            }),
             Err(message) => Err(DomainError::SourceFailure {
                 name: "mock-news".into(),
                 message: message.clone(),

--- a/src/adapters/market/yahoo/mod.rs
+++ b/src/adapters/market/yahoo/mod.rs
@@ -13,9 +13,8 @@ use crate::domain::error::DomainError;
 use crate::domain::ports::bar_source::BarSource;
 use crate::domain::ports::market_data_source::MarketDataSource;
 use crate::domain::ports::movers_source::MoversSource;
-use crate::domain::ports::news_source::NewsSource;
+use crate::domain::ports::news_source::{NewsFetch, NewsSource};
 use crate::domain::values::bar::Bar;
-use crate::domain::values::headline::Headline;
 use crate::domain::values::mover::MoverRow;
 
 const BASE_URL: &str = "https://query1.finance.yahoo.com/v8/finance/chart";
@@ -137,13 +136,15 @@ impl MoversSource for YahooMarketSource {
 
 #[async_trait]
 impl NewsSource for YahooMarketSource {
-    async fn headlines(&self, ticker: &Ticker, count: usize) -> Result<Vec<Headline>, DomainError> {
+    async fn headlines(&self, ticker: &Ticker, count: usize) -> Result<NewsFetch, DomainError> {
+        // quotesCount=2 so the matching quote's company names ride along
+        // (the catalyst gate uses them to tell company news from roundups).
         let url = format!(
-            "{SEARCH_URL}?q={}&newsCount={count}&quotesCount=0",
+            "{SEARCH_URL}?q={}&newsCount={count}&quotesCount=2",
             ticker.as_str()
         );
         let body = self.fetch_body("yahoo-news", url).await?;
-        news::parse_headlines(&body)
+        news::parse_news(&body, ticker.as_str())
     }
 }
 
@@ -218,11 +219,15 @@ mod tests {
     async fn live_headlines_parse() {
         let src = YahooMarketSource::new().unwrap();
         // AAPL always has news; content varies — assert shape only.
-        let news = NewsSource::headlines(&src, &Ticker::parse("AAPL").unwrap(), 5)
+        let fetch = NewsSource::headlines(&src, &Ticker::parse("AAPL").unwrap(), 5)
             .await
             .unwrap();
-        assert!(!news.is_empty());
-        assert!(news.iter().all(|h| !h.title.is_empty()));
+        assert!(!fetch.headlines.is_empty());
+        assert!(fetch.headlines.iter().all(|h| !h.title.is_empty()));
+        assert!(fetch
+            .company_names
+            .iter()
+            .any(|n| n.to_lowercase().contains("apple")));
     }
 
     #[test]

--- a/src/adapters/market/yahoo/news.rs
+++ b/src/adapters/market/yahoo/news.rs
@@ -1,16 +1,30 @@
-//! Parser for Yahoo's search endpoint news items (keyless). Only the
-//! headline fields the catalyst heuristic needs are read.
+//! Parser for Yahoo's search endpoint news items (keyless). Reads the
+//! headline fields the catalyst heuristic needs plus the matching quote's
+//! company names (so the gate can tell company news from market roundups).
 
 use chrono::{TimeZone, Utc};
 use serde::Deserialize;
 
 use crate::domain::error::DomainError;
+use crate::domain::ports::news_source::NewsFetch;
 use crate::domain::values::headline::Headline;
 
 #[derive(Debug, Deserialize)]
 struct SearchResponse {
     #[serde(default)]
     news: Vec<NewsItem>,
+    #[serde(default)]
+    quotes: Vec<QuoteItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QuoteItem {
+    #[serde(default)]
+    symbol: Option<String>,
+    #[serde(default)]
+    shortname: Option<String>,
+    #[serde(default)]
+    longname: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -31,15 +45,16 @@ fn fail(message: impl Into<String>) -> DomainError {
     }
 }
 
-/// Headlines from the search body. Only title-less items are skipped (they
-/// carry no scannable evidence); a missing/invalid timestamp yields
-/// `published_at: None` so the catalyst gate can treat the item
+/// Headlines + company names from the search body. Only title-less items are
+/// skipped (they carry no scannable evidence); a missing/invalid timestamp
+/// yields `published_at: None` so the catalyst gate can treat the item
 /// conservatively instead of losing it. An empty list is a valid result —
-/// quiet tickers have no news.
-pub(crate) fn parse_headlines(body: &str) -> Result<Vec<Headline>, DomainError> {
+/// quiet tickers have no news. Company names come from the quote whose
+/// symbol matches the queried ticker.
+pub(crate) fn parse_news(body: &str, ticker: &str) -> Result<NewsFetch, DomainError> {
     let resp: SearchResponse =
         serde_json::from_str(body).map_err(|e| fail(format!("malformed response: {e}")))?;
-    Ok(resp
+    let headlines = resp
         .news
         .into_iter()
         .filter_map(|n| {
@@ -51,7 +66,21 @@ pub(crate) fn parse_headlines(body: &str) -> Result<Vec<Headline>, DomainError> 
                     .and_then(|t| Utc.timestamp_opt(t, 0).single()),
             })
         })
-        .collect())
+        .collect();
+    let mut company_names: Vec<String> = Vec::new();
+    for q in resp.quotes {
+        if q.symbol.as_deref() == Some(ticker) {
+            for name in [q.shortname, q.longname].into_iter().flatten() {
+                if !company_names.contains(&name) {
+                    company_names.push(name);
+                }
+            }
+        }
+    }
+    Ok(NewsFetch {
+        headlines,
+        company_names,
+    })
 }
 
 #[cfg(test)]
@@ -64,18 +93,28 @@ mod tests {
             {"title":"Company cuts guidance","publisher":"Wire","providerPublishTime":1786818192},
             {"title":"No timestamp","publisher":"Wire"},
             {"publisher":"Wire","providerPublishTime":1786818192}
+        ],"quotes":[
+            {"symbol":"UCTT","shortname":"Ultra Clean Holdings, Inc.","longname":"Ultra Clean Holdings, Inc."},
+            {"symbol":"UCTX","shortname":"Corgi UCTT 2x Daily ETF"}
         ]}"#;
-        let h = parse_headlines(body).unwrap();
+        let fetch = parse_news(body, "UCTT").unwrap();
+        let h = &fetch.headlines;
         assert_eq!(h.len(), 2); // only the title-less item is dropped
         assert_eq!(h[0].title, "Company cuts guidance");
         assert_eq!(h[0].published_at.unwrap().timestamp(), 1786818192);
         assert_eq!(h[1].published_at, None); // undated survives for the gate
+                                             // names deduped and only from the MATCHING symbol (not the 2x ETF)
+        assert_eq!(fetch.company_names, vec!["Ultra Clean Holdings, Inc."]);
     }
 
     #[test]
     fn empty_news_is_ok_malformed_is_err() {
-        assert!(parse_headlines(r#"{"news":[]}"#).unwrap().is_empty());
-        assert!(parse_headlines(r#"{}"#).unwrap().is_empty());
-        assert!(parse_headlines("nope").is_err());
+        assert!(parse_news(r#"{"news":[]}"#, "AAPL")
+            .unwrap()
+            .headlines
+            .is_empty());
+        let fetch = parse_news(r#"{}"#, "AAPL").unwrap();
+        assert!(fetch.headlines.is_empty() && fetch.company_names.is_empty());
+        assert!(parse_news("nope", "AAPL").is_err());
     }
 }

--- a/src/application/dip.rs
+++ b/src/application/dip.rs
@@ -232,20 +232,26 @@ async fn check(
         }
     };
 
-    let headlines = match deps.news.headlines(&ticker, HEADLINE_COUNT).await {
+    let (headlines, company_names) = match deps.news.headlines(&ticker, HEADLINE_COUNT).await {
         // Undated headlines are kept — they MIGHT be same-day, and dropping
         // them could hide a catalyst (fail closed, not open).
-        Ok(all) => GateEvidence::Available(
-            all.into_iter()
-                .filter(|h| match h.published_at {
-                    Some(at) => {
-                        at.with_timezone(&chrono_tz::America::New_York).date_naive() == drop_date
-                    }
-                    None => true,
-                })
-                .collect(),
+        Ok(fetch) => (
+            GateEvidence::Available(
+                fetch
+                    .headlines
+                    .into_iter()
+                    .filter(|h| match h.published_at {
+                        Some(at) => {
+                            at.with_timezone(&chrono_tz::America::New_York).date_naive()
+                                == drop_date
+                        }
+                        None => true,
+                    })
+                    .collect(),
+            ),
+            fetch.company_names,
         ),
-        Err(e) => GateEvidence::Unavailable(e.to_string()),
+        Err(e) => (GateEvidence::Unavailable(e.to_string()), Vec::new()),
     };
 
     let sentiment = match ctx.known_sentiment {
@@ -265,6 +271,7 @@ async fn check(
         spx_change_pct,
         filings,
         headlines,
+        company_names,
         sentiment,
         session,
         floor: ctx.floor,
@@ -656,7 +663,7 @@ mod tests {
     #[tokio::test]
     async fn scan_ranks_verdicts_and_collects_errors() {
         let bars = bars_map();
-        let news = MockNewsSource(Ok(vec![]));
+        let news = MockNewsSource(Ok(Default::default()));
         let filings = MockFilingsSource(Ok(vec![]));
         let social = fixture_social();
         let movers = MockMoversSource(vec![
@@ -692,7 +699,7 @@ mod tests {
     #[tokio::test]
     async fn scan_fails_closed_when_edgar_down_and_kills_on_filing() {
         let bars = bars_map();
-        let news = MockNewsSource(Ok(vec![]));
+        let news = MockNewsSource(Ok(Default::default()));
         let social = fixture_social();
         let movers = MockMoversSource(vec![row("GOOD", -8.0)]);
         let req = DipScanRequest::default();
@@ -721,7 +728,7 @@ mod tests {
     #[tokio::test]
     async fn margin_section_present_only_with_equity_and_journal_written() {
         let bars = bars_map();
-        let news = MockNewsSource(Ok(vec![]));
+        let news = MockNewsSource(Ok(Default::default()));
         let filings = MockFilingsSource(Ok(vec![]));
         let social = fixture_social();
         let movers = MockMoversSource(vec![row("GOOD", -8.0)]);
@@ -760,7 +767,7 @@ mod tests {
     #[tokio::test]
     async fn single_ticker_mode_caps_at_watch() {
         let bars = bars_map();
-        let news = MockNewsSource(Ok(vec![]));
+        let news = MockNewsSource(Ok(Default::default()));
         let filings = MockFilingsSource(Ok(vec![]));
         let social = fixture_social();
         let req = DipScanRequest::default();

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -2,6 +2,7 @@ pub mod analyze;
 pub mod dip;
 pub mod pulse;
 pub mod request;
+pub mod review;
 pub mod risk;
 
 pub use analyze::analyze;

--- a/src/application/review.rs
+++ b/src/application/review.rs
@@ -1,0 +1,413 @@
+//! dip --review orchestration: read the scan journal, fetch bar history for
+//! every journaled ticker plus the index proxy, grade forward returns, and
+//! aggregate by verdict. This is how the v0 dip weights earn (or lose) trust.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+
+use crate::application::dip::{EntryError, SPX_PROXY};
+use crate::domain::dip::{Session, Verdict};
+use crate::domain::dip_review::{
+    aggregate, forward_returns, pearson, ForwardReturns, GradedEntry, VerdictBucket,
+};
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::bar_source::BarSource;
+use crate::domain::values::bar::Bar;
+
+const CONCURRENCY: usize = 5;
+/// Below this graded sample size the report carries a not-meaningful note.
+const MEANINGFUL_N: usize = 30;
+
+pub const REVIEW_FRAMING: &str = "dip --review grades past scans against subsequent prices — \
+past setup conformance is not evidence of future returns. Small samples prove nothing.";
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "dip-review".into(),
+        message: message.into(),
+    }
+}
+
+// Owned mirror of the journal line the scan writes (application::dip).
+#[derive(Debug, Deserialize)]
+struct JournalLineIn {
+    generated_at: DateTime<Utc>,
+    session: Session,
+    candidates: Vec<JournalCandidateIn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JournalCandidateIn {
+    ticker: String,
+    price: f64,
+    score: f64,
+    verdict: Verdict,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DipReviewReport {
+    pub generated_at: DateTime<Utc>,
+    pub journal_path: String,
+    pub scans: usize,
+    pub entries_total: usize,
+    /// Entries with at least a 1-day forward return.
+    pub graded: usize,
+    /// Too recent — the market hasn't produced enough forward bars yet.
+    pub pending: usize,
+    /// Older than the available bar history (~3 months) — ungradable.
+    pub stale: usize,
+    pub deduped: usize,
+    pub skipped_lines: usize,
+    pub buckets: Vec<VerdictBucket>,
+    /// Pearson of composite score vs raw 5-day return across graded entries.
+    pub score_return_corr_d5: Option<f64>,
+    pub entries: Vec<GradedEntry>,
+    pub errors: Vec<EntryError>,
+    pub notes: Vec<String>,
+}
+
+struct PendingEntry {
+    ticker: String,
+    scanned_on: chrono::NaiveDate,
+    session: Session,
+    verdict: Verdict,
+    score: f64,
+    price: f64,
+}
+
+fn parse_journal(content: &str) -> (Vec<PendingEntry>, usize, usize, usize) {
+    let mut entries = Vec::new();
+    let mut scans = 0usize;
+    let mut skipped = 0usize;
+    let mut deduped = 0usize;
+    let mut seen: HashSet<(String, chrono::NaiveDate)> = HashSet::new();
+    for line in content.lines().filter(|l| !l.trim().is_empty()) {
+        let Ok(parsed) = serde_json::from_str::<JournalLineIn>(line) else {
+            skipped += 1;
+            continue;
+        };
+        scans += 1;
+        let scanned_on = parsed
+            .generated_at
+            .with_timezone(&chrono_tz::America::New_York)
+            .date_naive();
+        for c in parsed.candidates {
+            if !seen.insert((c.ticker.clone(), scanned_on)) {
+                deduped += 1;
+                continue;
+            }
+            entries.push(PendingEntry {
+                ticker: c.ticker,
+                scanned_on,
+                session: parsed.session,
+                verdict: c.verdict,
+                score: c.score,
+                price: c.price,
+            });
+        }
+    }
+    (entries, scans, skipped, deduped)
+}
+
+/// SPY's forward returns from its own close on the scan date — the baseline
+/// the entry's returns are adjusted against.
+fn index_forward(spy_bars: &[Bar], scanned_on: chrono::NaiveDate) -> ForwardReturns {
+    match spy_bars.iter().find(|b| b.date == scanned_on) {
+        Some(base) => forward_returns(scanned_on, base.close, spy_bars),
+        None => ForwardReturns::default(),
+    }
+}
+
+fn minus(raw: ForwardReturns, base: ForwardReturns) -> ForwardReturns {
+    let sub = |a: Option<f64>, b: Option<f64>| match (a, b) {
+        (Some(a), Some(b)) => Some(a - b),
+        _ => None,
+    };
+    ForwardReturns {
+        d1: sub(raw.d1, base.d1),
+        d5: sub(raw.d5, base.d5),
+        d10: sub(raw.d10, base.d10),
+    }
+}
+
+pub async fn dip_review(
+    journal_path: &Path,
+    bars_src: &dyn BarSource,
+    now: DateTime<Utc>,
+) -> Result<DipReviewReport, DomainError> {
+    let content = std::fs::read_to_string(journal_path).map_err(|e| {
+        fail(format!(
+            "no journal at {} ({e}) — run some scans first",
+            journal_path.display()
+        ))
+    })?;
+    let (pending_entries, scans, skipped_lines, deduped) = parse_journal(&content);
+    if pending_entries.is_empty() {
+        return Err(fail("journal has no gradable candidate entries"));
+    }
+
+    let mut tickers: Vec<String> = pending_entries
+        .iter()
+        .map(|e| e.ticker.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    tickers.sort();
+    tickers.push(SPX_PROXY.to_string());
+
+    let fetched: Vec<(String, Result<Vec<Bar>, DomainError>)> =
+        futures::stream::iter(tickers.into_iter().map(|symbol| async move {
+            let result = match Ticker::parse(&symbol) {
+                Ok(t) => bars_src.bars(&t).await,
+                Err(e) => Err(e),
+            };
+            (symbol, result)
+        }))
+        .buffer_unordered(CONCURRENCY)
+        .collect()
+        .await;
+
+    let mut history: HashMap<String, Vec<Bar>> = HashMap::new();
+    let mut errors: Vec<EntryError> = Vec::new();
+    for (symbol, result) in fetched {
+        match result {
+            Ok(bars) => {
+                history.insert(symbol, bars);
+            }
+            Err(e) => errors.push(EntryError {
+                ticker: symbol,
+                error: e.to_string(),
+            }),
+        }
+    }
+    let spy_bars = history.get(SPX_PROXY).cloned().unwrap_or_default();
+
+    let mut entries: Vec<GradedEntry> = Vec::new();
+    let (mut graded, mut pending, mut stale) = (0usize, 0usize, 0usize);
+    let entries_total = pending_entries.len();
+    for e in pending_entries {
+        let Some(bars) = history.get(&e.ticker) else {
+            continue; // fetch error already recorded
+        };
+        let returns = forward_returns(e.scanned_on, e.price, bars);
+        if returns.d1.is_some() {
+            graded += 1;
+        } else if bars.first().is_some_and(|b| e.scanned_on < b.date) {
+            stale += 1;
+            continue;
+        } else {
+            pending += 1;
+            continue;
+        }
+        let excess = minus(returns, index_forward(&spy_bars, e.scanned_on));
+        entries.push(GradedEntry {
+            ticker: e.ticker,
+            scanned_on: e.scanned_on,
+            session: e.session,
+            verdict: e.verdict,
+            score: e.score,
+            entry_price: e.price,
+            returns,
+            excess,
+        });
+    }
+
+    let buckets = aggregate(&entries);
+    let pairs: Vec<(f64, f64)> = entries
+        .iter()
+        .filter_map(|e| e.returns.d5.map(|r| (e.score, r)))
+        .collect();
+    let xs: Vec<f64> = pairs.iter().map(|p| p.0).collect();
+    let ys: Vec<f64> = pairs.iter().map(|p| p.1).collect();
+    let score_return_corr_d5 = pearson(&xs, &ys);
+
+    let mut notes: Vec<String> = Vec::new();
+    if graded < MEANINGFUL_N {
+        notes.push(format!(
+            "graded sample n={graded} < {MEANINGFUL_N} — NOT statistically meaningful; keep journaling"
+        ));
+    }
+    if stale > 0 {
+        notes.push(format!(
+            "{stale} entr{} older than available bar history (~3 months) — ungradable",
+            if stale == 1 { "y is" } else { "ies are" }
+        ));
+    }
+    if skipped_lines > 0 {
+        notes.push(format!("{skipped_lines} malformed journal line(s) skipped"));
+    }
+    if spy_bars.is_empty() {
+        notes.push(format!(
+            "index proxy {SPX_PROXY} history unavailable — excess returns not computed"
+        ));
+    }
+
+    Ok(DipReviewReport {
+        generated_at: now,
+        journal_path: journal_path.display().to_string(),
+        scans,
+        entries_total,
+        graded,
+        pending,
+        stale,
+        deduped,
+        skipped_lines,
+        buckets,
+        score_return_corr_d5,
+        entries,
+        errors,
+        notes,
+    })
+}
+
+/// Convenience for callers that grade the default journal location.
+pub fn default_journal_or_err() -> Result<PathBuf, DomainError> {
+    crate::application::dip::default_journal_path()
+        .ok_or_else(|| fail("cannot resolve a home directory for the journal path"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use chrono::NaiveDate;
+
+    fn d(day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 8, day).unwrap()
+    }
+
+    fn bar(day: u32, close: f64) -> Bar {
+        Bar {
+            date: d(day),
+            open: close,
+            high: close + 1.0,
+            low: close - 1.0,
+            close,
+        }
+    }
+
+    struct MapBars(HashMap<String, Vec<Bar>>);
+
+    #[async_trait]
+    impl BarSource for MapBars {
+        async fn bars(&self, t: &Ticker) -> Result<Vec<Bar>, DomainError> {
+            self.0.get(t.as_str()).cloned().ok_or(DomainError::NoData)
+        }
+    }
+
+    /// Two scans: one on the 10th (gradable), a duplicate GOOD entry on the
+    /// 10th (deduped), and one very recent scan (pending).
+    fn journal() -> String {
+        [
+            r#"{"generated_at":"2026-08-10T21:30:00Z","session":"post_close","spx_change_pct":-0.4,"candidates":[
+                {"ticker":"GOOD","change_pct":-8.0,"price":100.0,"score":70.0,"verdict":"high_confidence"},
+                {"ticker":"MEH","change_pct":-6.0,"price":50.0,"score":30.0,"verdict":"watch"}]}"#
+                .replace('\n', ""),
+            r#"{"generated_at":"2026-08-10T22:00:00Z","session":"post_close","spx_change_pct":-0.4,"candidates":[
+                {"ticker":"GOOD","change_pct":-8.0,"price":100.0,"score":70.0,"verdict":"high_confidence"}]}"#
+                .replace('\n', ""),
+            r#"{"generated_at":"2026-08-20T21:30:00Z","session":"post_close","spx_change_pct":0.1,"candidates":[
+                {"ticker":"GOOD","change_pct":-5.0,"price":90.0,"score":40.0,"verdict":"watch"}]}"#
+                .replace('\n', ""),
+            "not json at all".to_string(),
+        ]
+        .join("\n")
+    }
+
+    fn history() -> MapBars {
+        let mut m = HashMap::new();
+        // GOOD: bars through the 20th; scan on the 10th grades d1/d5, the
+        // scan on the 20th has no forward bars yet (pending)
+        m.insert(
+            "GOOD".to_string(),
+            (8..=20)
+                .map(|i| bar(i, 100.0 + (i as f64 - 10.0)))
+                .collect(),
+        );
+        // MEH drifts down
+        m.insert(
+            "MEH".to_string(),
+            (8..=20)
+                .map(|i| bar(i, 50.0 - (i as f64 - 10.0) * 0.5))
+                .collect(),
+        );
+        // SPY flat
+        m.insert(
+            SPX_PROXY.to_string(),
+            (8..=20).map(|i| bar(i, 500.0)).collect(),
+        );
+        MapBars(m)
+    }
+
+    #[tokio::test]
+    async fn review_grades_dedupes_and_flags_pending() {
+        let dir = std::env::temp_dir().join(format!("openintel-review-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("journal.jsonl");
+        std::fs::write(&path, journal()).unwrap();
+
+        let now = chrono::Utc::now();
+        let report = dip_review(&path, &history(), now).await.unwrap();
+
+        assert_eq!(report.scans, 3);
+        assert_eq!(report.skipped_lines, 1);
+        assert_eq!(report.deduped, 1);
+        assert_eq!(report.entries_total, 3); // GOOD@10, MEH@10, GOOD@20
+        assert_eq!(report.graded, 2);
+        assert_eq!(report.pending, 1); // the scan on the 20th
+        assert_eq!(report.stale, 0);
+
+        // buckets ordered strongest first, math spot-checked:
+        // GOOD@10 entry 100 -> d1 close 101 (+1%), d5 close 105 (+5%)
+        let hc = &report.buckets[0];
+        assert_eq!(hc.verdict, Verdict::HighConfidence);
+        assert!((hc.raw.d1.as_ref().unwrap().mean_pct - 1.0).abs() < 1e-9);
+        assert!((hc.raw.d5.as_ref().unwrap().mean_pct - 5.0).abs() < 1e-9);
+        // SPY flat -> excess == raw
+        assert!((hc.excess.d5.as_ref().unwrap().mean_pct - 5.0).abs() < 1e-9);
+        // MEH: entry 50 -> d1 close 49.5 (-1%)
+        let watch = &report.buckets[1];
+        assert_eq!(watch.verdict, Verdict::Watch);
+        assert!((watch.raw.d1.as_ref().unwrap().mean_pct + 1.0).abs() < 1e-9);
+
+        // small-n honesty note always present at n=2
+        assert!(report
+            .notes
+            .iter()
+            .any(|n| n.contains("NOT statistically meaningful")));
+        // corr needs >= 3 pairs -> None here
+        assert!(report.score_return_corr_d5.is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn review_handles_missing_journal_and_fetch_errors() {
+        let missing = std::env::temp_dir().join("openintel-no-such-journal.jsonl");
+        let err = dip_review(&missing, &history(), chrono::Utc::now())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("run some scans first"));
+
+        // a ticker with no bar history becomes a per-entry error, not a crash
+        let dir = std::env::temp_dir().join(format!("openintel-review-err-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("journal.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"generated_at":"2026-08-10T21:30:00Z","session":"post_close","candidates":[{"ticker":"GONE","change_pct":-8.0,"price":10.0,"score":70.0,"verdict":"watch"}]}"#,
+        )
+        .unwrap();
+        let report = dip_review(&path, &history(), chrono::Utc::now())
+            .await
+            .unwrap();
+        assert_eq!(report.graded, 0);
+        assert!(report.errors.iter().any(|e| e.ticker == "GONE"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -142,6 +142,10 @@ pub struct DipArgs {
     /// Evaluate one symbol instead of scanning the losers universe
     pub ticker: Option<String>,
 
+    /// Grade the scan journal against forward returns instead of scanning
+    #[arg(long, conflicts_with = "ticker")]
+    pub review: bool,
+
     /// Losers to pull from the screener (1-100)
     #[arg(long, default_value_t = 100)]
     pub count: usize,

--- a/src/cli/dip.rs
+++ b/src/cli/dip.rs
@@ -48,6 +48,14 @@ fn request_from(args: &DipArgs) -> DipScanRequest {
 
 pub async fn run(args: &DipArgs, credentials: &Credentials) -> Result<String, DomainError> {
     let yahoo = YahooMarketSource::new()?;
+    if args.review {
+        let path = crate::application::review::default_journal_or_err()?;
+        let report = crate::application::review::dip_review(&path, &yahoo, Utc::now()).await?;
+        return Ok(match args.format {
+            FormatArg::Table => render_review_table(&report),
+            FormatArg::Json => render_review_json(&report)?,
+        });
+    }
     let edgar = EdgarSource::new()?;
     let social = crate::adapters::sources::build_social_sources(credentials);
     let deps = DipDeps {
@@ -218,6 +226,80 @@ fn render_report_table(r: &DipScanReport) -> String {
         let _ = writeln!(out, "note: {n}");
     }
     let _ = writeln!(out, "\n{FRAMING_LINE}");
+    let _ = writeln!(out, "\n{DISCLAIMER}");
+    out
+}
+
+fn render_review_json(
+    report: &crate::application::review::DipReviewReport,
+) -> Result<String, DomainError> {
+    #[derive(serde::Serialize)]
+    struct Out<'a> {
+        report: &'a crate::application::review::DipReviewReport,
+        framing: &'static str,
+        disclaimer: &'static str,
+    }
+    serde_json::to_string_pretty(&Out {
+        report,
+        framing: crate::application::review::REVIEW_FRAMING,
+        disclaimer: DISCLAIMER,
+    })
+    .map_err(|e| DomainError::SourceFailure {
+        name: "dip-review".into(),
+        message: format!("render failed: {e}"),
+    })
+}
+
+fn render_review_table(r: &crate::application::review::DipReviewReport) -> String {
+    use crate::domain::dip_review::HorizonStats;
+    let mut out = String::new();
+    let _ = writeln!(out, "=== OpenIntel Dip Review — {} ===", r.journal_path);
+    let _ = writeln!(
+        out,
+        "scans: {} · entries: {} (graded {} · pending {} · stale {} · deduped {})\n",
+        r.scans, r.entries_total, r.graded, r.pending, r.stale, r.deduped
+    );
+    let mean = |s: &Option<HorizonStats>| {
+        s.as_ref()
+            .map_or_else(|| "n/a".to_string(), |v| format!("{:+.1}%", v.mean_pct))
+    };
+    let win = |s: &Option<HorizonStats>| {
+        s.as_ref().map_or_else(
+            || "n/a".to_string(),
+            |v| format!("{:.0}%", v.win_rate * 100.0),
+        )
+    };
+    let _ = writeln!(
+        out,
+        "{:<17} {:>4} {:>9} {:>9} {:>9} {:>8} {:>10}",
+        "verdict", "n", "d1 mean", "d5 mean", "d10 mean", "d5 win", "d5 xs-SPY"
+    );
+    for b in &r.buckets {
+        let _ = writeln!(
+            out,
+            "{:<17} {:>4} {:>9} {:>9} {:>9} {:>8} {:>10}",
+            format!("{:?}", b.verdict),
+            b.n,
+            mean(&b.raw.d1),
+            mean(&b.raw.d5),
+            mean(&b.raw.d10),
+            win(&b.raw.d5),
+            mean(&b.excess.d5),
+        );
+    }
+    let _ = writeln!(
+        out,
+        "\nscore↔d5 correlation: {}",
+        r.score_return_corr_d5
+            .map_or_else(|| "n/a".to_string(), |c| format!("{c:+.2}"))
+    );
+    for e in &r.errors {
+        let _ = writeln!(out, "error: {} — {}", e.ticker, e.error);
+    }
+    for n in &r.notes {
+        let _ = writeln!(out, "note: {n}");
+    }
+    let _ = writeln!(out, "\n{}", crate::application::review::REVIEW_FRAMING);
     let _ = writeln!(out, "\n{DISCLAIMER}");
     out
 }

--- a/src/cli/dip.rs
+++ b/src/cli/dip.rs
@@ -259,9 +259,13 @@ fn render_review_table(r: &crate::application::review::DipReviewReport) -> Strin
         "scans: {} · entries: {} (graded {} · pending {} · stale {} · deduped {})\n",
         r.scans, r.entries_total, r.graded, r.pending, r.stale, r.deduped
     );
+    // each horizon prints its OWN sample size — d5/d10 can grade fewer
+    // entries than d1 (recent scans haven't produced the forward bars yet)
     let mean = |s: &Option<HorizonStats>| {
-        s.as_ref()
-            .map_or_else(|| "n/a".to_string(), |v| format!("{:+.1}%", v.mean_pct))
+        s.as_ref().map_or_else(
+            || "n/a".to_string(),
+            |v| format!("{:+.1}% (n{})", v.mean_pct, v.n),
+        )
     };
     let win = |s: &Option<HorizonStats>| {
         s.as_ref().map_or_else(
@@ -271,13 +275,13 @@ fn render_review_table(r: &crate::application::review::DipReviewReport) -> Strin
     };
     let _ = writeln!(
         out,
-        "{:<17} {:>4} {:>9} {:>9} {:>9} {:>8} {:>10}",
+        "{:<17} {:>4} {:>13} {:>13} {:>13} {:>7} {:>13}",
         "verdict", "n", "d1 mean", "d5 mean", "d10 mean", "d5 win", "d5 xs-SPY"
     );
     for b in &r.buckets {
         let _ = writeln!(
             out,
-            "{:<17} {:>4} {:>9} {:>9} {:>9} {:>8} {:>10}",
+            "{:<17} {:>4} {:>13} {:>13} {:>13} {:>7} {:>13}",
             format!("{:?}", b.verdict),
             b.n,
             mean(&b.raw.d1),

--- a/src/domain/dip.rs
+++ b/src/domain/dip.rs
@@ -180,6 +180,72 @@ pub fn consecutive_down_closes(closes: &[f64]) -> usize {
     closes.windows(2).rev().take_while(|w| w[1] < w[0]).count()
 }
 
+/// Corporate suffix tokens stripped when deriving matchable company-name
+/// forms ("Ultra Clean Holdings, Inc." -> "ultra clean").
+const NAME_SUFFIXES: &[&str] = &[
+    "inc",
+    "incorporated",
+    "corp",
+    "corporation",
+    "ltd",
+    "limited",
+    "plc",
+    "co",
+    "company",
+    "holdings",
+    "holding",
+    "group",
+    "trust",
+    "sa",
+    "nv",
+    "ag",
+];
+
+fn normalize_words(text: &str) -> Vec<String> {
+    text.to_ascii_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Does this headline title clearly reference the company — by ticker symbol
+/// (whole word, ≥ 2 chars) or by a meaningful prefix of a known company name?
+/// Used to tell company news from generic market-roundup stories.
+pub fn headline_mentions_company(title: &str, ticker: &str, company_names: &[String]) -> bool {
+    let title_words = normalize_words(title);
+    let ticker_lower = ticker.to_ascii_lowercase();
+    if ticker.len() >= 2 && title_words.contains(&ticker_lower) {
+        return true;
+    }
+    // padded so forms only match on whole-word boundaries
+    let title_joined = format!(" {} ", title_words.join(" "));
+    for name in company_names {
+        let mut words = normalize_words(name);
+        while let Some(last) = words.last() {
+            if NAME_SUFFIXES.contains(&last.as_str()) {
+                words.pop();
+            } else {
+                break;
+            }
+        }
+        if words.first().map(|w| w.as_str()) == Some("the") {
+            words.remove(0);
+        }
+        let form = match words.len() {
+            0 => continue,
+            // single-word names need some length to avoid matching everywhere
+            1 if words[0].len() >= 4 => words[0].clone(),
+            1 => continue,
+            _ => words[..2].join(" "),
+        };
+        if title_joined.contains(&format!(" {form} ")) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Case-insensitive whole-word keyword hits across the given texts, deduped.
 pub fn catalyst_hits(texts: &[&str]) -> Vec<String> {
     let mut hits: Vec<String> = Vec::new();
@@ -373,6 +439,9 @@ pub struct DipInputs<'a> {
     pub filings: GateEvidence<Vec<Filing>>,
     /// Headlines already filtered to the drop day by the caller.
     pub headlines: GateEvidence<Vec<Headline>>,
+    /// Known company names for this ticker (headline gate discrimination).
+    /// Empty = treat every headline as potentially about the company.
+    pub company_names: Vec<String>,
     pub sentiment: Option<SentimentSummary>,
     pub session: Session,
     /// Floor result from the screener row (Unknown in single-ticker mode,
@@ -524,29 +593,56 @@ pub fn dip_signal(inputs: &DipInputs) -> Result<DipSignal, DomainError> {
         }
     };
 
+    // Keyword hits in a headline that clearly references the company CONFIRM
+    // a catalyst (Fail). Hits only in headlines that don't (market roundups,
+    // sector stories) are ambiguous — Unknown, capping at watch, never a
+    // false-positive kill. With no company names known, every headline is
+    // treated as potentially about the company (old, stricter behavior).
     let no_catalyst_headline = match &inputs.headlines {
         GateEvidence::Unavailable(reason) => GateStatus::Unknown(reason.clone()),
         GateEvidence::Available(headlines) => {
-            let titles: Vec<&str> = headlines.iter().map(|h| h.title.as_str()).collect();
-            let hits = catalyst_hits(&titles);
-            if hits.is_empty() {
-                GateStatus::Pass
-            } else {
-                for h in headlines {
-                    let title_hits = catalyst_hits(&[h.title.as_str()]);
-                    if !title_hits.is_empty() {
-                        catalyst_evidence.push(format!(
-                            "headline [{}]: \"{}\" (terms: {})",
-                            h.publisher,
-                            h.title,
-                            title_hits.join(", ")
-                        ));
+            let mut matched_hits: Vec<String> = Vec::new();
+            let mut unmatched_hits: Vec<String> = Vec::new();
+            for h in headlines {
+                let title_hits = catalyst_hits(&[h.title.as_str()]);
+                if title_hits.is_empty() {
+                    continue;
+                }
+                let about_company = inputs.company_names.is_empty()
+                    || headline_mentions_company(&h.title, inputs.ticker, &inputs.company_names);
+                if about_company {
+                    catalyst_evidence.push(format!(
+                        "headline [{}]: \"{}\" (terms: {})",
+                        h.publisher,
+                        h.title,
+                        title_hits.join(", ")
+                    ));
+                    for hit in title_hits {
+                        if !matched_hits.contains(&hit) {
+                            matched_hits.push(hit);
+                        }
+                    }
+                } else {
+                    for hit in title_hits {
+                        if !unmatched_hits.contains(&hit) {
+                            unmatched_hits.push(hit);
+                        }
                     }
                 }
+            }
+            if !matched_hits.is_empty() {
                 GateStatus::Fail(format!(
-                    "catalyst term(s) in headlines: {}",
-                    hits.join(", ")
+                    "catalyst term(s) in company headlines: {}",
+                    matched_hits.join(", ")
                 ))
+            } else if !unmatched_hits.is_empty() {
+                GateStatus::Unknown(format!(
+                    "catalyst term(s) only in headlines not clearly about {}: {}",
+                    inputs.ticker,
+                    unmatched_hits.join(", ")
+                ))
+            } else {
+                GateStatus::Pass
             }
         }
     };
@@ -789,6 +885,7 @@ mod tests {
             spx_change_pct: Some(-0.5),
             filings: GateEvidence::Available(vec![]),
             headlines: GateEvidence::Available(vec![]),
+            company_names: vec![],
             sentiment: Some(SentimentSummary {
                 net_sentiment: 0.2,
                 mentions: 25,
@@ -886,6 +983,90 @@ mod tests {
         let sig = dip_signal(&i).unwrap();
         assert_eq!(sig.verdict, Verdict::NoSetup);
         assert!(sig.catalyst_evidence[0].contains("guidance"));
+    }
+
+    #[test]
+    fn headline_company_matching() {
+        let names = vec!["Ultra Clean Holdings, Inc.".to_string()];
+        assert!(headline_mentions_company(
+            "Ultra Clean Shares Fall After $400 Million Offering",
+            "UCTT",
+            &names
+        ));
+        assert!(headline_mentions_company(
+            "Why UCTT dropped today",
+            "UCTT",
+            &names
+        ));
+        assert!(!headline_mentions_company(
+            "Target Stock Flies To New Highs As Earnings Approach",
+            "UCTT",
+            &names
+        ));
+        // word-boundary: "ultra cleanse" is not "ultra clean <word>"? it IS
+        // "ultra" + "cleanse" — the padded form " ultra clean " must not match
+        assert!(!headline_mentions_company(
+            "An ultra cleanse fad",
+            "UCTT",
+            &names
+        ));
+        // single-word name needs length; "the" prefix stripped
+        let viking = vec!["The Viking Holdings Ltd".to_string()];
+        assert!(headline_mentions_company(
+            "Viking slides on bookings",
+            "VIK",
+            &viking
+        ));
+        assert!(!headline_mentions_company(
+            "Norse history special",
+            "VIK",
+            &viking
+        ));
+    }
+
+    #[test]
+    fn roundup_headline_is_unknown_not_kill_when_names_known() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        // the VIK case: generic earnings-roundup headlines, none about VIK
+        let mut i = inputs(&prior, &w);
+        i.ticker = "VIK";
+        i.company_names = vec!["Viking Holdings Ltd".into()];
+        i.headlines = GateEvidence::Available(vec![Headline {
+            title: "Stock Market Week Ahead: Walmart, Target Lead Retail Earnings".into(),
+            publisher: "IBD".into(),
+            published_at: Some(chrono::Utc::now()),
+        }]);
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::Watch); // capped, NOT killed
+        assert!(matches!(
+            sig.gates.no_catalyst_headline,
+            GateStatus::Unknown(_)
+        ));
+        assert!(sig.catalyst_evidence.is_empty());
+
+        // same headline naming the company -> confirmed kill
+        let mut i = inputs(&prior, &w);
+        i.ticker = "VIK";
+        i.company_names = vec!["Viking Holdings Ltd".into()];
+        i.headlines = GateEvidence::Available(vec![Headline {
+            title: "Viking cuts guidance after weak bookings".into(),
+            publisher: "Wire".into(),
+            published_at: Some(chrono::Utc::now()),
+        }]);
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::NoSetup);
+        assert!(!sig.catalyst_evidence.is_empty());
+
+        // no names known -> old strict behavior: any hit kills
+        let mut i = inputs(&prior, &w);
+        i.headlines = GateEvidence::Available(vec![Headline {
+            title: "Retail earnings week ahead".into(),
+            publisher: "Wire".into(),
+            published_at: Some(chrono::Utc::now()),
+        }]);
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::NoSetup);
     }
 
     #[test]

--- a/src/domain/dip.rs
+++ b/src/domain/dip.rs
@@ -209,17 +209,12 @@ fn normalize_words(text: &str) -> Vec<String> {
         .collect()
 }
 
-/// Does this headline title clearly reference the company — by ticker symbol
-/// (whole word, ≥ 2 chars) or by a meaningful prefix of a known company name?
-/// Used to tell company news from generic market-roundup stories.
-pub fn headline_mentions_company(title: &str, ticker: &str, company_names: &[String]) -> bool {
-    let title_words = normalize_words(title);
-    let ticker_lower = ticker.to_ascii_lowercase();
-    if ticker.len() >= 2 && title_words.contains(&ticker_lower) {
-        return true;
-    }
-    // padded so forms only match on whole-word boundaries
-    let title_joined = format!(" {} ", title_words.join(" "));
+/// Matchable lowercase forms derived from company names (suffix-stripped,
+/// "the" dropped, first two words). Empty output means NO usable name exists
+/// — callers must then treat every headline as potentially about the company
+/// (blank or junk provider names must not weaken the gate).
+pub fn company_name_forms(company_names: &[String]) -> Vec<String> {
+    let mut forms = Vec::new();
     for name in company_names {
         let mut words = normalize_words(name);
         while let Some(last) = words.last() {
@@ -239,11 +234,27 @@ pub fn headline_mentions_company(title: &str, ticker: &str, company_names: &[Str
             1 => continue,
             _ => words[..2].join(" "),
         };
-        if title_joined.contains(&format!(" {form} ")) {
-            return true;
+        if !forms.contains(&form) {
+            forms.push(form);
         }
     }
-    false
+    forms
+}
+
+/// Does this headline title clearly reference the company — by ticker symbol
+/// (whole word, ≥ 2 chars) or by a `company_name_forms` match? Used to tell
+/// company news from generic market-roundup stories.
+pub fn headline_mentions_company(title: &str, ticker: &str, name_forms: &[String]) -> bool {
+    let title_words = normalize_words(title);
+    let ticker_lower = ticker.to_ascii_lowercase();
+    if ticker.len() >= 2 && title_words.contains(&ticker_lower) {
+        return true;
+    }
+    // padded so forms only match on whole-word boundaries
+    let title_joined = format!(" {} ", title_words.join(" "));
+    name_forms
+        .iter()
+        .any(|form| title_joined.contains(&format!(" {form} ")))
 }
 
 /// Case-insensitive whole-word keyword hits across the given texts, deduped.
@@ -601,6 +612,8 @@ pub fn dip_signal(inputs: &DipInputs) -> Result<DipSignal, DomainError> {
     let no_catalyst_headline = match &inputs.headlines {
         GateEvidence::Unavailable(reason) => GateStatus::Unknown(reason.clone()),
         GateEvidence::Available(headlines) => {
+            // blank/junk names derive no forms -> strict path, not a weaker gate
+            let name_forms = company_name_forms(&inputs.company_names);
             let mut matched_hits: Vec<String> = Vec::new();
             let mut unmatched_hits: Vec<String> = Vec::new();
             for h in headlines {
@@ -608,8 +621,8 @@ pub fn dip_signal(inputs: &DipInputs) -> Result<DipSignal, DomainError> {
                 if title_hits.is_empty() {
                     continue;
                 }
-                let about_company = inputs.company_names.is_empty()
-                    || headline_mentions_company(&h.title, inputs.ticker, &inputs.company_names);
+                let about_company = name_forms.is_empty()
+                    || headline_mentions_company(&h.title, inputs.ticker, &name_forms);
                 if about_company {
                     catalyst_evidence.push(format!(
                         "headline [{}]: \"{}\" (terms: {})",
@@ -987,31 +1000,31 @@ mod tests {
 
     #[test]
     fn headline_company_matching() {
-        let names = vec!["Ultra Clean Holdings, Inc.".to_string()];
+        let forms = company_name_forms(&["Ultra Clean Holdings, Inc.".to_string()]);
+        assert_eq!(forms, vec!["ultra clean".to_string()]);
         assert!(headline_mentions_company(
             "Ultra Clean Shares Fall After $400 Million Offering",
             "UCTT",
-            &names
+            &forms
         ));
         assert!(headline_mentions_company(
             "Why UCTT dropped today",
             "UCTT",
-            &names
+            &forms
         ));
         assert!(!headline_mentions_company(
             "Target Stock Flies To New Highs As Earnings Approach",
             "UCTT",
-            &names
+            &forms
         ));
-        // word-boundary: "ultra cleanse" is not "ultra clean <word>"? it IS
-        // "ultra" + "cleanse" — the padded form " ultra clean " must not match
+        // padded form " ultra clean " must not match inside "ultra cleanse"
         assert!(!headline_mentions_company(
             "An ultra cleanse fad",
             "UCTT",
-            &names
+            &forms
         ));
         // single-word name needs length; "the" prefix stripped
-        let viking = vec!["The Viking Holdings Ltd".to_string()];
+        let viking = company_name_forms(&["The Viking Holdings Ltd".to_string()]);
         assert!(headline_mentions_company(
             "Viking slides on bookings",
             "VIK",
@@ -1022,6 +1035,25 @@ mod tests {
             "VIK",
             &viking
         ));
+        // blank/junk names yield NO forms -- gate must fall back to strict
+        assert!(company_name_forms(&[" ".to_string()]).is_empty());
+        assert!(company_name_forms(&["Inc.".to_string()]).is_empty());
+    }
+
+    #[test]
+    fn blank_company_names_keep_strict_headline_behavior() {
+        let prior = prior();
+        let w = ScoreWeights::default();
+        let mut i = inputs(&prior, &w);
+        i.company_names = vec![" ".into()]; // junk from the provider
+        i.headlines = GateEvidence::Available(vec![Headline {
+            title: "Retail earnings week ahead".into(),
+            publisher: "Wire".into(),
+            published_at: Some(chrono::Utc::now()),
+        }]);
+        // no usable name -> every headline treated as about the company -> kill
+        let sig = dip_signal(&i).unwrap();
+        assert_eq!(sig.verdict, Verdict::NoSetup);
     }
 
     #[test]

--- a/src/domain/dip.rs
+++ b/src/domain/dip.rs
@@ -381,7 +381,7 @@ impl GateResults {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Verdict {
     NoSetup,
@@ -389,7 +389,7 @@ pub enum Verdict {
     HighConfidence,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Session {
     Intraday,

--- a/src/domain/dip_review.rs
+++ b/src/domain/dip_review.rs
@@ -1,0 +1,264 @@
+//! Pure grading math for the dip journal: forward returns per entry, stats
+//! per verdict bucket, and a score↔return correlation. This is the feedback
+//! loop that decides whether the v0 dip weights deserve trust — until it
+//! shows edge on a meaningful sample, `high_confidence` stays "clean setup",
+//! not "profitable setup". Synchronous, no IO, no clock.
+
+use chrono::NaiveDate;
+use serde::Serialize;
+
+use crate::domain::dip::{Session, Verdict};
+use crate::domain::values::bar::Bar;
+
+/// Grading horizons in trading days.
+pub const HORIZONS: [usize; 3] = [1, 5, 10];
+
+/// Raw percentage returns from the journaled price to the close of the Nth
+/// trading bar after the scan date. None = not enough forward bars yet.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct ForwardReturns {
+    pub d1: Option<f64>,
+    pub d5: Option<f64>,
+    pub d10: Option<f64>,
+}
+
+impl ForwardReturns {
+    pub fn get(&self, horizon: usize) -> Option<f64> {
+        match horizon {
+            1 => self.d1,
+            5 => self.d5,
+            10 => self.d10,
+            _ => None,
+        }
+    }
+}
+
+/// Forward returns for an entry against ascending daily bars. The first bar
+/// strictly after `entry_date` is trading day 1.
+pub fn forward_returns(entry_date: NaiveDate, entry_price: f64, bars: &[Bar]) -> ForwardReturns {
+    if !(entry_price.is_finite() && entry_price > 0.0) {
+        return ForwardReturns::default();
+    }
+    let Some(first_fwd) = bars.iter().position(|b| b.date > entry_date) else {
+        return ForwardReturns::default();
+    };
+    let ret = |n: usize| {
+        bars.get(first_fwd + n - 1)
+            .map(|b| (b.close - entry_price) / entry_price * 100.0)
+    };
+    ForwardReturns {
+        d1: ret(1),
+        d5: ret(5),
+        d10: ret(10),
+    }
+}
+
+/// One journal entry joined with its forward outcomes.
+#[derive(Debug, Clone, Serialize)]
+pub struct GradedEntry {
+    pub ticker: String,
+    pub scanned_on: NaiveDate,
+    pub session: Session,
+    pub verdict: Verdict,
+    pub score: f64,
+    pub entry_price: f64,
+    /// Raw forward returns in percent.
+    pub returns: ForwardReturns,
+    /// Returns minus the index proxy's same-horizon return (market-adjusted).
+    pub excess: ForwardReturns,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HorizonStats {
+    pub n: usize,
+    pub mean_pct: f64,
+    pub median_pct: f64,
+    /// Fraction of entries with a positive return.
+    pub win_rate: f64,
+}
+
+pub fn horizon_stats(values: &[f64]) -> Option<HorizonStats> {
+    if values.is_empty() {
+        return None;
+    }
+    let n = values.len();
+    let mean = values.iter().sum::<f64>() / n as f64;
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let median = if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+    };
+    let wins = values.iter().filter(|v| **v > 0.0).count();
+    Some(HorizonStats {
+        n,
+        mean_pct: mean,
+        median_pct: median,
+        win_rate: wins as f64 / n as f64,
+    })
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HorizonSet {
+    pub d1: Option<HorizonStats>,
+    pub d5: Option<HorizonStats>,
+    pub d10: Option<HorizonStats>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VerdictBucket {
+    pub verdict: Verdict,
+    pub n: usize,
+    pub raw: HorizonSet,
+    pub excess: HorizonSet,
+}
+
+fn horizon_set(
+    entries: &[&GradedEntry],
+    pick: impl Fn(&GradedEntry, usize) -> Option<f64>,
+) -> HorizonSet {
+    let collect = |h: usize| {
+        let vals: Vec<f64> = entries.iter().filter_map(|e| pick(e, h)).collect();
+        horizon_stats(&vals)
+    };
+    HorizonSet {
+        d1: collect(1),
+        d5: collect(5),
+        d10: collect(10),
+    }
+}
+
+/// Bucket graded entries by verdict, strongest claim first.
+pub fn aggregate(entries: &[GradedEntry]) -> Vec<VerdictBucket> {
+    [Verdict::HighConfidence, Verdict::Watch, Verdict::NoSetup]
+        .into_iter()
+        .filter_map(|verdict| {
+            let bucket: Vec<&GradedEntry> =
+                entries.iter().filter(|e| e.verdict == verdict).collect();
+            if bucket.is_empty() {
+                return None;
+            }
+            Some(VerdictBucket {
+                verdict,
+                n: bucket.len(),
+                raw: horizon_set(&bucket, |e, h| e.returns.get(h)),
+                excess: horizon_set(&bucket, |e, h| e.excess.get(h)),
+            })
+        })
+        .collect()
+}
+
+/// Pearson correlation; None below 3 pairs or with zero variance.
+pub fn pearson(xs: &[f64], ys: &[f64]) -> Option<f64> {
+    let n = xs.len();
+    if n != ys.len() || n < 3 {
+        return None;
+    }
+    let nf = n as f64;
+    let mx = xs.iter().sum::<f64>() / nf;
+    let my = ys.iter().sum::<f64>() / nf;
+    let (mut cov, mut vx, mut vy) = (0.0, 0.0, 0.0);
+    for (x, y) in xs.iter().zip(ys) {
+        cov += (x - mx) * (y - my);
+        vx += (x - mx).powi(2);
+        vy += (y - my).powi(2);
+    }
+    if vx == 0.0 || vy == 0.0 {
+        return None;
+    }
+    Some(cov / (vx.sqrt() * vy.sqrt()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn d(day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 8, day).unwrap()
+    }
+
+    fn bar(day: u32, close: f64) -> Bar {
+        Bar {
+            date: d(day),
+            open: close,
+            high: close + 1.0,
+            low: close - 1.0,
+            close,
+        }
+    }
+
+    #[test]
+    fn forward_returns_index_from_first_bar_after_entry() {
+        // entry on the 10th at 100; bars for 10th..21st (weekdays irrelevant here)
+        let bars: Vec<Bar> = (10..=21).map(|i| bar(i, 100.0 + i as f64)).collect();
+        let fr = forward_returns(d(10), 100.0, &bars);
+        assert!((fr.d1.unwrap() - 11.0).abs() < 1e-9); // close 111 on the 11th
+        assert!((fr.d5.unwrap() - 15.0).abs() < 1e-9); // close 115 on the 15th
+        assert!((fr.d10.unwrap() - 20.0).abs() < 1e-9);
+
+        // too recent: only 2 forward bars -> d5/d10 pending
+        let fr = forward_returns(d(19), 100.0, &bars);
+        assert!(fr.d1.is_some());
+        assert!(fr.d5.is_none() && fr.d10.is_none());
+
+        // stale/no coverage: entry after all bars
+        let fr = forward_returns(d(25), 100.0, &bars);
+        assert!(fr.d1.is_none());
+
+        // degenerate price
+        let fr = forward_returns(d(10), 0.0, &bars);
+        assert!(fr.d1.is_none());
+    }
+
+    #[test]
+    fn stats_mean_median_win() {
+        let s = horizon_stats(&[1.0, -2.0, 3.0, 4.0]).unwrap();
+        assert_eq!(s.n, 4);
+        assert!((s.mean_pct - 1.5).abs() < 1e-9);
+        assert!((s.median_pct - 2.0).abs() < 1e-9);
+        assert!((s.win_rate - 0.75).abs() < 1e-9);
+        assert!(horizon_stats(&[]).is_none());
+    }
+
+    #[test]
+    fn aggregate_buckets_by_verdict_in_order() {
+        let entry = |verdict, r1: f64| GradedEntry {
+            ticker: "T".into(),
+            scanned_on: d(10),
+            session: Session::PostClose,
+            verdict,
+            score: 50.0,
+            entry_price: 100.0,
+            returns: ForwardReturns {
+                d1: Some(r1),
+                d5: None,
+                d10: None,
+            },
+            excess: ForwardReturns::default(),
+        };
+        let entries = vec![
+            entry(Verdict::Watch, -1.0),
+            entry(Verdict::HighConfidence, 2.0),
+            entry(Verdict::Watch, 3.0),
+        ];
+        let buckets = aggregate(&entries);
+        assert_eq!(buckets.len(), 2); // no no_setup bucket
+        assert_eq!(buckets[0].verdict, Verdict::HighConfidence);
+        assert_eq!(buckets[0].n, 1);
+        assert_eq!(buckets[1].verdict, Verdict::Watch);
+        assert!((buckets[1].raw.d1.as_ref().unwrap().mean_pct - 1.0).abs() < 1e-9);
+        assert!(buckets[1].raw.d5.is_none());
+    }
+
+    #[test]
+    fn pearson_known_values() {
+        // perfectly correlated
+        assert!((pearson(&[1.0, 2.0, 3.0], &[2.0, 4.0, 6.0]).unwrap() - 1.0).abs() < 1e-9);
+        // perfectly anti-correlated
+        assert!((pearson(&[1.0, 2.0, 3.0], &[3.0, 2.0, 1.0]).unwrap() + 1.0).abs() < 1e-9);
+        // guards
+        assert!(pearson(&[1.0, 2.0], &[1.0, 2.0]).is_none()); // n < 3
+        assert!(pearson(&[1.0, 1.0, 1.0], &[1.0, 2.0, 3.0]).is_none()); // zero variance
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,4 +1,5 @@
 pub mod dip;
+pub mod dip_review;
 pub mod engine;
 pub mod entities;
 pub mod error;

--- a/src/domain/ports/news_source.rs
+++ b/src/domain/ports/news_source.rs
@@ -4,8 +4,18 @@ use crate::domain::entities::ticker::Ticker;
 use crate::domain::error::DomainError;
 use crate::domain::values::headline::Headline;
 
+/// A news lookup result: headlines plus the company names the provider knows
+/// for the ticker. Names let the catalyst gate tell "news about THIS company"
+/// from generic market-roundup stories; an empty list means the gate must
+/// treat every headline as potentially about the company.
+#[derive(Debug, Clone, Default)]
+pub struct NewsFetch {
+    pub headlines: Vec<Headline>,
+    pub company_names: Vec<String>,
+}
+
 /// Recent news headlines for a ticker (catalyst keyword heuristic input).
 #[async_trait]
 pub trait NewsSource: Send + Sync {
-    async fn headlines(&self, ticker: &Ticker, count: usize) -> Result<Vec<Headline>, DomainError>;
+    async fn headlines(&self, ticker: &Ticker, count: usize) -> Result<NewsFetch, DomainError>;
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -192,6 +192,24 @@ impl OpenIntelServer {
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
     }
+
+    #[tool(
+        description = "Grade the dip_scan journal (~/.openintel/dip_journal.jsonl) against \
+                       forward returns: 1/5/10-day raw and SPY-adjusted stats per verdict, \
+                       plus score↔return correlation. This is the evidence for whether \
+                       dip_scan's v0 score weights have any edge — until the graded sample is \
+                       meaningful (n≥30), treat verdicts as setup conformance only. Entries \
+                       older than ~3 months are ungradable (bar history limit). Read-only — \
+                       does not trade."
+    )]
+    async fn dip_review(&self) -> Result<CallToolResult, ErrorData> {
+        let out = tools::run_dip_review(&self.market)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let json = serde_json::to_string_pretty(&out)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    }
 }
 
 #[tool_handler(router = self.tool_router)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -559,6 +559,43 @@ fn dip_request_from(args: &DipScanArgs) -> crate::application::dip::DipScanReque
     }
 }
 
+#[derive(Debug, Serialize)]
+pub struct DipReviewOutput {
+    pub summary: String,
+    pub report: crate::application::review::DipReviewReport,
+    pub framing: &'static str,
+    pub disclaimer: &'static str,
+}
+
+/// Grade the default scan journal against forward returns. Path is fixed —
+/// this tool never reads caller-chosen files.
+pub async fn run_dip_review(
+    bars: &dyn crate::domain::ports::bar_source::BarSource,
+) -> Result<DipReviewOutput, DomainError> {
+    let path = crate::application::review::default_journal_or_err()?;
+    let report = crate::application::review::dip_review(&path, bars, Utc::now()).await?;
+    let top = report
+        .buckets
+        .first()
+        .and_then(|b| {
+            b.raw
+                .d5
+                .as_ref()
+                .map(|s| format!(" · {:?} d5 mean {:+.1}% (n={})", b.verdict, s.mean_pct, s.n))
+        })
+        .unwrap_or_default();
+    let summary = format!(
+        "{} scans · {} graded, {} pending{}",
+        report.scans, report.graded, report.pending, top
+    );
+    Ok(DipReviewOutput {
+        summary,
+        report,
+        framing: crate::application::review::REVIEW_FRAMING,
+        disclaimer: DISCLAIMER,
+    })
+}
+
 pub async fn run_dip_scan(
     args: DipScanArgs,
     movers: &dyn crate::domain::ports::movers_source::MoversSource,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1035,7 +1035,7 @@ mod tests {
         #[tokio::test]
         async fn scan_mode_summarizes_and_frames() {
             let bars = bars_map();
-            let news = MockNewsSource(Ok(vec![]));
+            let news = MockNewsSource(Ok(Default::default()));
             let filings = MockFilingsSource(Ok(vec![]));
             let social = fixture_social();
             let movers = MockMoversSource(vec![MoverRow {
@@ -1066,7 +1066,7 @@ mod tests {
         #[tokio::test]
         async fn single_ticker_mode_returns_signal() {
             let bars = bars_map();
-            let news = MockNewsSource(Ok(vec![]));
+            let news = MockNewsSource(Ok(Default::default()));
             let filings = MockFilingsSource(Ok(vec![]));
             let social = fixture_social();
             let movers = MockMoversSource(vec![]);
@@ -1130,7 +1130,7 @@ mod tests {
         #[tokio::test]
         async fn analyze_attaches_dip_signal_on_down_day() {
             let bars = bars_map();
-            let news = MockNewsSource(Ok(vec![]));
+            let news = MockNewsSource(Ok(Default::default()));
             let filings = MockFilingsSource(Ok(vec![]));
             let social = fixture_social();
             let deps = DipDeps {
@@ -1164,7 +1164,7 @@ mod tests {
         async fn analyze_dip_failure_degrades_to_note() {
             // AAPL has no bars in the map -> dip_check errors -> note, not failure
             let bars = bars_map();
-            let news = MockNewsSource(Ok(vec![]));
+            let news = MockNewsSource(Ok(Default::default()));
             let filings = MockFilingsSource(Ok(vec![]));
             let social = fixture_social();
             let deps = DipDeps {


### PR DESCRIPTION
## What

The two follow-ups named in #59:

**1. Headline gate discriminates company news from market roundups.** Yahoo's search quotes carry company names in the same call (quotesCount=2, matching symbol only). Keyword hit in a headline that references the company (ticker whole-word or company-name form, suffix-stripped, word-boundary matched) → confirmed catalyst, kill with evidence. Hits ONLY in headlines not clearly about the ticker (roundups, sector stories) → gate Unknown, caps at watch — no more false-positive kills, still fail-closed. No names known → old strict behavior. Verified live: VIK no longer dies on Walmart/Target roundup headlines (it now dies on a Zacks headline naming Viking's earnings — correct).

**2. `dip --review` / MCP `dip_review` — the journal grader.** Pure `domain/dip_review.rs`: forward returns at 1/5/10 trading days, per-verdict mean/median/win-rate, SPY-adjusted excess, score↔d5 Pearson. `application/review.rs`: parse journal, dedupe (ticker, day), classify graded/pending/stale (~3-month bar-history limit), per-ticker errors. Honest by construction: n<30 prints "NOT statistically meaningful; keep journaling"; MCP tool reads only the fixed default journal path.

Verified live: seeded today's journal with a real scan, `--review` correctly reports all entries pending with the small-n note.

Tests: 253 passing; clippy -D warnings clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--review` to evaluate scan journals using 1-, 5-, and 10-day raw and market-adjusted returns.
  * Review results include verdict statistics, win rates, score correlation, pending entries, errors, and data-quality notes.
  * Added the `dip_review` MCP tool with table and JSON output.
  * Improved headline analysis by distinguishing company-specific catalysts from generic market news.

* **Documentation**
  * Updated scan documentation with headline interpretation and review usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->