### PR TITLE
docs: sync docs with shipped reality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@ OPENINTEL_MARKET_API_KEY=
 OPENINTEL_BLUESKY_HANDLE=
 OPENINTEL_BLUESKY_APP_PASSWORD=
 
+# --- SEC EDGAR (dip_scan filings gate — optional, NOT a secret) ---
+# SEC's fair-access policy requires a User-Agent with an email-style contact
+# (URL-only contacts get 403). Defaults to the maintainer's email; set this
+# to identify YOUR deployment if you fork or redistribute.
+OPENINTEL_SEC_CONTACT=
+
 # --- X Pulse (paid API — optional) ---
 # Bearer token from https://developer.x.com (Projects & Apps → Keys and Tokens).
 # Pay-per-use: ~$0.005 per post read; openintel only calls X on an explicit

--- a/README.md
+++ b/README.md
@@ -165,10 +165,11 @@ Tools exposed (all **read-only** — OpenIntel never places trades):
 
 | Tool | What it does |
 |---|---|
-| `analyze_ticker` | One symbol → full speculation report (sentiment, speculation index, crowding, alignment) |
+| `analyze_ticker` | One symbol → full speculation report (sentiment, speculation index, crowding, alignment); carries `dip_signal` on ≤ −4% down days |
 | `scan_watchlist` | A list of symbols → reports, run concurrently |
 | `compare_tickers` | Rank a set by `crowding` / `speculation_index` / `net_sentiment` / `divergence` |
 | `list_sources` | Which data sources are available |
+| `x_pulse` | Catalyst posts from chosen high-impact X accounts (paid X API — opt-in, cost confirmed with you first) |
 | `risk_frame` | ATR stop + budget-capped size + R targets for one trade idea |
 | `dip_scan` | Day's biggest losers → gated dip-setup verdicts (`no_setup`/`watch`/`high_confidence`), optional margin-aware sizing; pass `ticker` for one symbol |
 | `dip_review` | Grade the dip journal against forward returns (raw + SPY-adjusted, per verdict) — the evidence check on dip_scan's v0 score |
@@ -213,10 +214,12 @@ approval. That boundary *is* the safety model; keep it.
 
 Hexagonal (ports & adapters). The domain is pure and synchronous; IO and the clock live at the edge.
 
-- `domain/` — entities, value objects, the pure `SpeculationEngine`, and port traits.
-- `adapters/` — `LexiconAnalyzer`, the `YahooMarketSource` (real, keyless), the `RedditSource` and `BlueskySource` (real, credential-gated — no mock sources).
+- `domain/` — entities, value objects, port traits, and the pure engines: `SpeculationEngine`, `risk` (ATR stop/size), `margin` (buying power, margin-call price), `dip` (gates + score + verdict), `dip_review` (forward-return grading).
+- `application/` — orchestration at the IO edge: `analyze`, `pulse`, `risk`, `dip` (scan/check + journal), `review` (journal grading). Clock and filesystem stamped here.
+- `adapters/` — `LexiconAnalyzer`; `YahooMarketSource` (keyless: chart bars/snapshot, `day_losers` screener, news+company names); `EdgarSource` (keyless SEC filings, ticker→CIK cached); `RedditSource`, `BlueskySource`, `XPulseSource` (credential-gated).
 - `config/` — secrets resolution (env + OS keychain, via `secrecy`) and runtime settings.
-- `cli/` — clap args, orchestration, rendering.
+- `cli/` — clap args, per-command leaves, rendering (only `main.rs` prints).
+- `mcp/` — the rmcp stdio server exposing the tools table above.
 
 Secrets come from environment variables (`OPENINTEL_REDDIT_CLIENT_ID`, `OPENINTEL_REDDIT_CLIENT_SECRET`, `OPENINTEL_BLUESKY_HANDLE`, `OPENINTEL_BLUESKY_APP_PASSWORD`, `OPENINTEL_MARKET_API_KEY`) or the OS keychain (written only by `openintel setup` after a live verify; env always wins), wrapped in `SecretString` — plaintext never touches disk, never logged.
 

--- a/docs/superpowers/plans/2026-08-15-dip-scan.md
+++ b/docs/superpowers/plans/2026-08-15-dip-scan.md
@@ -133,3 +133,18 @@
 ### Task 9: Docs
 
 - [ ] README: tool table, usage, gate table, journal location/opt-out, endpoints (keyless/unofficial, clean-error failure mode), v0-weights honesty note, follow-up: `dip --review` forward-return grading
+
+---
+
+## Implementation outcome (merged 2026-08-15: PR #59, follow-ups PR #60)
+
+Shipped per this plan with these recorded deviations — the code is the source of truth:
+
+- **`Bar` also gained `date: NaiveDate`** (NY session date, stamped by the Yahoo adapter) — the exclude-today baseline rule needs real dates, not positions.
+- **Catalyst filing forms match by PREFIX** (`CATALYST_FORM_PREFIXES`), not exact strings — `8-K/A`, `6-K/A`, the whole `424B` family, `S-3/A`, `S-3ASR` all count (review finding).
+- **Headline gate discriminates company news from market roundups** (PR #60): Yahoo search quotes supply company names; keyword hits in company-referencing headlines kill, hits only in unmatched headlines → gate `Unknown` (watch cap). Blank/junk names derive no forms and keep the strict path.
+- **EDGAR parser fails closed** on malformed rows/column mismatch; undated headlines are kept and scanned, not dropped (review findings).
+- **`dip_check` returns `TickerDipReport`** (signal + optional risk/margin — `--equity` works in single-ticker mode) and accepts pre-computed sentiment so `analyze_ticker` doesn't refetch social.
+- **Task 8's CLI half was deliberately skipped:** `openintel analyze` tables don't render a dip section — `openintel dip TICKER` covers that surface; MCP `analyze_ticker` carries `dip_signal` as planned.
+- **`dip --review` / MCP `dip_review` shipped** (PR #60, was "named follow-up" here): `domain/dip_review.rs` forward returns at 1/5/10 trading days, per-verdict raw + SPY-adjusted stats, score↔d5 Pearson; graded/pending/stale classification; n<30 honesty note.
+- **`FRAMING` lives in `application::dip`** (single source, like `DISCLAIMER`); SEC UA defaults to the maintainer email (`OPENINTEL_SEC_CONTACT` overrides) — SEC 403s URL-only contacts.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -226,7 +226,9 @@ impl ServerHandler for OpenIntelServer {
             ))
             .with_instructions(
                 "OpenIntel — fuses social sentiment with market action into a speculation \
-                 report (crowding, divergence, sentiment). READ-ONLY: it never places trades.",
+                 report (crowding, divergence, sentiment), plus deterministic risk/margin \
+                 calculators and a gated dip-setup scanner with a forward-return review. \
+                 READ-ONLY: it never places trades.",
             )
     }
 }


### PR DESCRIPTION
- README: x_pulse row was missing from the MCP tools table; architecture
  section gains application/ and mcp/ and the filings/screener/news
  adapters; analyze_ticker row notes dip_signal
- .env.example: document OPENINTEL_SEC_CONTACT
- dip-scan plan: implementation-outcome addendum recording deviations
  (Bar date, form prefixes, headline discrimination, TickerDipReport,
  skipped CLI-analyze half, --review shipped in #60)
- MCP server instructions string mentions risk/dip/review tool families

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional SEC EDGAR contact configuration guidance using an email-style User-Agent.
  * Added the opt-in, cost-confirmed `x_pulse` tool.
  * Expanded ticker analysis with dip-signal results and forward-return review.
  * Updated available capabilities to include risk, margin, and dip-setup analysis.

* **Documentation**
  * Expanded documentation for market, SEC, and news analysis capabilities.
  * Documented dip-review behavior, filing handling, news classification, and configurable SEC contact settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->