### PR TITLE
feat(journal): trade journal — frozen theses, graded record, cross-session memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,35 @@ not-holdable-overnight note. Single-position model; interest not modeled.
 Data: Yahoo screener + news (keyless, unofficial — failure mode is a clean error) and SEC
 EDGAR (keyless, official; identify yourself via `OPENINTEL_SEC_CONTACT` if you fork this).
 
+## Trade journal (frozen theses, graded record)
+
+An append-only journal at `~/.openintel/trade_journal.jsonl`: every trade is logged with
+its **thesis and plan frozen at entry** — they can never be retroactively edited to match
+the outcome. Amendments and closes append; a trade is a fold over its events.
+
+```bash
+openintel journal log NVDA --qty 10 --entry 178.50 --stop 172 \
+  --thesis "bounce off weekly support at 175" --tag sr-support-bounce \
+  --risk-usd 65 --wallet 5000                # equity; add --option call --strike/--expiry, or --crypto
+openintel journal amend NVDA-20260822-1 --note "trailing after 1R" --stop 178.50
+openintel journal close NVDA-20260822-1 --exit 191.20 --reason target
+openintel journal positions                  # every open trade with its thesis and plan
+openintel journal review                     # grade the whole record
+```
+
+The review grades realized **R vs the original stop** (amendments never soften the grade),
+win rates, **discipline flags** (widened stops, exits beyond the planned stop), and — for
+equities — 1/5/10-trading-day forward returns, raw and SPY-adjusted, bucketed by setup tag
+and instrument. Honesty gates: per-bucket numbers appear only at n ≥ 10 closed trades and
+overall conclusions need n ≥ 30 — below that the report calls itself anecdote. Options
+grade on realized P&L plus the underlying's direction (historical option prices aren't
+available keyless); crypto on realized P&L only. Long-only, matching what a broker's
+agentic account can hold.
+
+The MCP tools below are the primary surface: in an agent chat the entry is journaled in
+the same moment the user approves the trade — zero homework, and `open_positions` gives
+the next conversation the full context of what's held and why.
+
 ## Use with an AI agent (MCP)
 
 OpenIntel can run as a local **MCP server** so an AI agent can consult its analysis while
@@ -173,6 +202,10 @@ Tools exposed (all **read-only** — OpenIntel never places trades):
 | `risk_frame` | ATR stop + budget-capped size + R targets for one trade idea |
 | `dip_scan` | Day's biggest losers → gated dip-setup verdicts (`no_setup`/`watch`/`high_confidence`), optional margin-aware sizing; pass `ticker` for one symbol |
 | `dip_review` | Grade the dip journal against forward returns (raw + SPY-adjusted, per verdict) — the evidence check on dip_scan's v0 score |
+| `log_trade` | Journal an approved trade at the moment it's placed: frozen thesis, required stop, risk-of-wallet snapshot; same-day duplicate guard |
+| `update_trade` | Amend an open trade (note, move stop/target — original plan stays frozen) or close it with exit + reason |
+| `open_positions` | Every open trade with its frozen thesis, plan, and amendments — call first in a new chat; the cross-session memory |
+| `review_trades` | Grade the trade journal: R vs original stops, win rates, discipline flags, SPY-adjusted forward returns, per-setup buckets (honesty gates: n ≥ 10/bucket, n ≥ 30 overall) |
 
 ### ⚠️ Risk & responsibility — read before connecting a broker
 
@@ -214,7 +247,7 @@ approval. That boundary *is* the safety model; keep it.
 
 Hexagonal (ports & adapters). The domain is pure and synchronous; IO and the clock live at the edge.
 
-- `domain/` — entities, value objects, port traits, and the pure engines: `SpeculationEngine`, `risk` (ATR stop/size), `margin` (buying power, margin-call price), `dip` (gates + score + verdict), `dip_review` (forward-return grading).
+- `domain/` — entities, value objects, port traits, and the pure engines: `SpeculationEngine`, `risk` (ATR stop/size), `margin` (buying power, margin-call price), `dip` (gates + score + verdict), `dip_review` (forward-return grading), `trade_journal` (event fold, frozen theses), `trade_review` (R-multiples, discipline, buckets).
 - `application/` — orchestration at the IO edge: `analyze`, `pulse`, `risk`, `dip` (scan/check + journal), `review` (journal grading). Clock and filesystem stamped here.
 - `adapters/` — `LexiconAnalyzer`; `YahooMarketSource` (keyless: chart bars/snapshot, `day_losers` screener, news+company names); `EdgarSource` (keyless SEC filings, ticker→CIK cached); `RedditSource`, `BlueskySource`, `XPulseSource` (credential-gated).
 - `config/` — secrets resolution (env + OS keychain, via `secrecy`) and runtime settings.

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -4,6 +4,7 @@ pub mod pulse;
 pub mod request;
 pub mod review;
 pub mod risk;
+pub mod trade_journal;
 
 pub use analyze::analyze;
 pub use request::AnalysisRequest;

--- a/src/application/trade_journal.rs
+++ b/src/application/trade_journal.rs
@@ -1,0 +1,525 @@
+//! IO edge for the trade journal: append/read the JSONL, stamp timestamps and
+//! trade ids, fetch bars for the review. The domain fold and grading stay pure.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+use serde::Serialize;
+
+use crate::application::dip::SPX_PROXY;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::bar_source::BarSource;
+use crate::domain::trade_journal::{
+    find_duplicate, fold, open_event, CloseReason, Instrument, RiskSnapshot, Trade, TradeEvent,
+};
+use crate::domain::trade_review::{aggregate, grade, Bucket, GradedTrade, MIN_OVERALL_SAMPLE};
+
+const CONCURRENCY: usize = 4;
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "trade_journal".into(),
+        message: message.into(),
+    }
+}
+
+/// `~/.openintel/trade_journal.jsonl`, or None when no home dir resolves.
+pub fn default_path() -> Option<PathBuf> {
+    std::env::home_dir().map(|h| h.join(".openintel").join("trade_journal.jsonl"))
+}
+
+pub fn default_path_or_err() -> Result<PathBuf, DomainError> {
+    default_path().ok_or_else(|| fail("cannot resolve a home directory for the journal"))
+}
+
+fn append(path: &Path, event: &TradeEvent) -> Result<(), DomainError> {
+    use std::io::Write as _;
+    let json = serde_json::to_string(event).map_err(|e| fail(e.to_string()))?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| fail(e.to_string()))?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| fail(e.to_string()))?;
+    writeln!(file, "{json}").map_err(|e| fail(e.to_string()))
+}
+
+/// Tolerant read: unparseable lines are counted, never fatal.
+fn read_events(path: &Path) -> (Vec<TradeEvent>, usize) {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return (Vec::new(), 0);
+    };
+    let mut events = Vec::new();
+    let mut skipped = 0usize;
+    for line in content.lines().filter(|l| !l.trim().is_empty()) {
+        match serde_json::from_str::<TradeEvent>(line) {
+            Ok(e) => events.push(e),
+            Err(_) => skipped += 1,
+        }
+    }
+    (events, skipped)
+}
+
+#[derive(Debug, Clone)]
+pub struct LogTradeRequest {
+    pub source: String,
+    pub instrument: Instrument,
+    pub qty: f64,
+    pub entry: f64,
+    pub thesis: String,
+    pub setup_tag: String,
+    pub planned_stop: f64,
+    pub planned_target: Option<f64>,
+    /// Both or neither: risk USD and the wallet size right now.
+    pub risk_usd: Option<f64>,
+    pub wallet_usd: Option<f64>,
+    /// Skip the same-day duplicate guard.
+    pub allow_duplicate: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LogOutcome {
+    pub trade_id: String,
+    pub logged: bool,
+    /// Set when the duplicate guard fired: the id of the existing trade.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duplicate_of: Option<String>,
+}
+
+/// Append an `opened` event. The trade id is `{SYMBOL}-{yyyymmdd}-{n}`,
+/// numbered per symbol per day; a same-day open matching instrument + qty +
+/// entry is rejected as a retry unless `allow_duplicate`.
+pub fn log_trade(
+    path: &Path,
+    req: LogTradeRequest,
+    now: DateTime<Utc>,
+) -> Result<LogOutcome, DomainError> {
+    let (events, _) = read_events(path);
+    let outcome = fold(&events);
+
+    if !req.allow_duplicate {
+        if let Some(existing) = find_duplicate(
+            &outcome.trades,
+            &req.instrument,
+            req.qty,
+            req.entry,
+            now.date_naive(),
+        ) {
+            return Ok(LogOutcome {
+                trade_id: existing.id.clone(),
+                logged: false,
+                duplicate_of: Some(existing.id.clone()),
+            });
+        }
+    }
+
+    let risk = match (req.risk_usd, req.wallet_usd) {
+        (Some(r), Some(w)) => Some(RiskSnapshot::new(r, w)?),
+        (None, None) => None,
+        _ => {
+            return Err(fail(
+                "risk_usd and wallet_usd go together — pass both or neither",
+            ))
+        }
+    };
+
+    let symbol = req.instrument.symbol().to_ascii_uppercase();
+    let day = now.format("%Y%m%d");
+    let prefix = format!("{symbol}-{day}-");
+    let n = outcome
+        .trades
+        .iter()
+        .filter(|t| t.id.starts_with(&prefix))
+        .count()
+        + 1;
+    let trade_id = format!("{prefix}{n}");
+
+    let event = open_event(
+        trade_id.clone(),
+        now,
+        req.source,
+        req.instrument,
+        req.qty,
+        req.entry,
+        req.thesis,
+        req.setup_tag,
+        req.planned_stop,
+        req.planned_target,
+        risk,
+    )?;
+    append(path, &event)?;
+    Ok(LogOutcome {
+        trade_id,
+        logged: true,
+        duplicate_of: None,
+    })
+}
+
+#[derive(Debug, Clone)]
+pub enum TradeUpdate {
+    Amend {
+        note: String,
+        new_stop: Option<f64>,
+        new_target: Option<f64>,
+    },
+    Close {
+        exit: f64,
+        reason: CloseReason,
+        note: Option<String>,
+    },
+}
+
+/// Append an `amended` or `closed` event after checking the trade exists and
+/// is still open.
+pub fn update_trade(
+    path: &Path,
+    trade_id: &str,
+    update: TradeUpdate,
+    now: DateTime<Utc>,
+) -> Result<(), DomainError> {
+    let (events, _) = read_events(path);
+    let outcome = fold(&events);
+    let trade = outcome
+        .trades
+        .iter()
+        .find(|t| t.id == trade_id)
+        .ok_or_else(|| fail(format!("no trade {trade_id} in the journal")))?;
+    if !trade.is_open() {
+        return Err(fail(format!("trade {trade_id} is already closed")));
+    }
+    let event = match update {
+        TradeUpdate::Amend {
+            note,
+            new_stop,
+            new_target,
+        } => {
+            if note.trim().is_empty() {
+                return Err(fail("an amendment needs a note — say why"));
+            }
+            TradeEvent::Amended {
+                trade_id: trade_id.to_string(),
+                at: now,
+                note: note.trim().to_string(),
+                new_stop,
+                new_target,
+            }
+        }
+        TradeUpdate::Close { exit, reason, note } => {
+            if !(exit.is_finite() && exit > 0.0) {
+                return Err(fail("exit must be a positive price"));
+            }
+            TradeEvent::Closed {
+                trade_id: trade_id.to_string(),
+                at: now,
+                exit,
+                reason,
+                note,
+            }
+        }
+    };
+    append(path, &event)
+}
+
+#[derive(Debug, Serialize)]
+pub struct PositionsReport {
+    pub journal_path: String,
+    pub open: Vec<Trade>,
+    pub closed_count: usize,
+    pub skipped_lines: usize,
+    pub errors: Vec<String>,
+}
+
+/// The cross-session memory: every open trade with its frozen thesis and plan.
+pub fn open_positions(path: &Path) -> PositionsReport {
+    let (events, skipped_lines) = read_events(path);
+    let outcome = fold(&events);
+    let (open, closed): (Vec<Trade>, Vec<Trade>) =
+        outcome.trades.into_iter().partition(|t| t.is_open());
+    PositionsReport {
+        journal_path: path.display().to_string(),
+        open,
+        closed_count: closed.len(),
+        skipped_lines,
+        errors: outcome.errors,
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct TradeReviewReport {
+    pub generated_at: DateTime<Utc>,
+    pub journal_path: String,
+    pub trades_total: usize,
+    pub closed: usize,
+    pub open: usize,
+    pub by_setup: Vec<Bucket>,
+    pub by_instrument: Vec<Bucket>,
+    pub trades: Vec<GradedTrade>,
+    pub skipped_lines: usize,
+    pub errors: Vec<String>,
+    pub notes: Vec<String>,
+}
+
+/// Grade the whole journal. Equity trades get forward returns (raw and
+/// SPY-adjusted); options grade on realized P&L plus the underlying's
+/// direction; crypto grades on realized P&L only (no bar path yet).
+pub async fn review_trades(
+    path: &Path,
+    bars_src: &dyn BarSource,
+    now: DateTime<Utc>,
+) -> Result<TradeReviewReport, DomainError> {
+    let (events, skipped_lines) = read_events(path);
+    if events.is_empty() {
+        return Err(fail(format!(
+            "no journal at {} — log a trade first",
+            path.display()
+        )));
+    }
+    let outcome = fold(&events);
+    let mut notes = Vec::new();
+    let mut errors = outcome.errors;
+
+    // Bars for every equity ticker and option underlying, plus SPY. Crypto
+    // symbols don't parse as tickers — skipped with a note, graded on P&L.
+    let mut symbols: HashSet<String> = HashSet::new();
+    for t in &outcome.trades {
+        match &t.instrument {
+            Instrument::Equity { .. } | Instrument::Option { .. } => {
+                symbols.insert(t.instrument.symbol().to_string());
+            }
+            Instrument::Crypto { symbol } => {
+                notes.push(format!(
+                    "{symbol}: crypto graded on realized P&L only — no bar path yet"
+                ));
+            }
+        }
+    }
+    let mut symbols: Vec<String> = symbols.into_iter().collect();
+    symbols.sort();
+    symbols.push(SPX_PROXY.to_string());
+
+    let fetched: Vec<(
+        String,
+        Result<Vec<crate::domain::values::bar::Bar>, DomainError>,
+    )> = futures::stream::iter(symbols.into_iter().map(|symbol| async move {
+        let result = match Ticker::parse(&symbol) {
+            Ok(t) => bars_src.bars(&t).await,
+            Err(e) => Err(e),
+        };
+        (symbol, result)
+    }))
+    .buffer_unordered(CONCURRENCY)
+    .collect()
+    .await;
+
+    let mut history = HashMap::new();
+    for (symbol, result) in fetched {
+        match result {
+            Ok(bars) => {
+                history.insert(symbol, bars);
+            }
+            Err(e) => errors.push(format!("{symbol}: bars unavailable: {e}")),
+        }
+    }
+    let spy_bars = history.get(SPX_PROXY).map(|b| b.as_slice());
+
+    let graded: Vec<GradedTrade> = outcome
+        .trades
+        .iter()
+        .map(|t| {
+            let bars = history.get(t.instrument.symbol()).map(|b| b.as_slice());
+            grade(t, bars, spy_bars)
+        })
+        .collect();
+
+    let closed = graded.iter().filter(|g| !g.open).count();
+    if closed < MIN_OVERALL_SAMPLE {
+        notes.push(format!(
+            "only {closed} closed trades — conclusions need {MIN_OVERALL_SAMPLE}; \
+             treat every number below as anecdote, not evidence"
+        ));
+    }
+
+    let (by_setup, by_instrument) = aggregate(&graded);
+    Ok(TradeReviewReport {
+        generated_at: now,
+        journal_path: path.display().to_string(),
+        trades_total: graded.len(),
+        closed,
+        open: graded.len() - closed,
+        by_setup,
+        by_instrument,
+        trades: graded,
+        skipped_lines,
+        errors,
+        notes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::values::bar::Bar;
+    use async_trait::async_trait;
+    use chrono::{NaiveDate, TimeZone};
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 21, 15, 0, 0).unwrap()
+    }
+
+    fn tmp_journal(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("openintel-tj-{tag}-{}", std::process::id()));
+        dir.join("trade_journal.jsonl")
+    }
+
+    fn equity_req(entry: f64) -> LogTradeRequest {
+        LogTradeRequest {
+            source: "cli".into(),
+            instrument: Instrument::Equity {
+                ticker: "NVDA".into(),
+            },
+            qty: 10.0,
+            entry,
+            thesis: "support bounce".into(),
+            setup_tag: "sr-support-bounce".into(),
+            planned_stop: entry - 5.0,
+            planned_target: None,
+            risk_usd: Some(50.0),
+            wallet_usd: Some(5000.0),
+            allow_duplicate: false,
+        }
+    }
+
+    struct FixedBars(Vec<Bar>);
+
+    #[async_trait]
+    impl BarSource for FixedBars {
+        async fn bars(&self, _t: &Ticker) -> Result<Vec<Bar>, DomainError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn log_ids_number_per_symbol_per_day_and_guard_duplicates() {
+        let path = tmp_journal("log");
+        let a = log_trade(&path, equity_req(100.0), now()).unwrap();
+        assert_eq!(a.trade_id, "NVDA-20260821-1");
+        assert!(a.logged);
+
+        let dup = log_trade(&path, equity_req(100.0), now()).unwrap();
+        assert!(!dup.logged);
+        assert_eq!(dup.duplicate_of, Some("NVDA-20260821-1".into()));
+
+        let b = log_trade(&path, equity_req(101.0), now()).unwrap();
+        assert_eq!(b.trade_id, "NVDA-20260821-2");
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn update_flows_amend_then_close_then_reject() {
+        let path = tmp_journal("update");
+        let id = log_trade(&path, equity_req(100.0), now()).unwrap().trade_id;
+        update_trade(
+            &path,
+            &id,
+            TradeUpdate::Amend {
+                note: "trailing".into(),
+                new_stop: Some(98.0),
+                new_target: None,
+            },
+            now(),
+        )
+        .unwrap();
+        update_trade(
+            &path,
+            &id,
+            TradeUpdate::Close {
+                exit: 108.0,
+                reason: CloseReason::Discretion,
+                note: None,
+            },
+            now(),
+        )
+        .unwrap();
+        let again = update_trade(
+            &path,
+            &id,
+            TradeUpdate::Close {
+                exit: 109.0,
+                reason: CloseReason::Discretion,
+                note: None,
+            },
+            now(),
+        );
+        assert!(again.unwrap_err().to_string().contains("already closed"));
+        assert!(update_trade(
+            &path,
+            "GHOST-1",
+            TradeUpdate::Amend {
+                note: "x".into(),
+                new_stop: None,
+                new_target: None,
+            },
+            now()
+        )
+        .is_err());
+
+        let positions = open_positions(&path);
+        assert!(positions.open.is_empty());
+        assert_eq!(positions.closed_count, 1);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn risk_fields_go_together() {
+        let path = tmp_journal("risk");
+        let mut req = equity_req(100.0);
+        req.wallet_usd = None;
+        assert!(log_trade(&path, req, now()).is_err());
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn review_grades_closed_trade_and_notes_small_sample() {
+        let path = tmp_journal("review");
+        let id = log_trade(&path, equity_req(100.0), now()).unwrap().trade_id;
+        update_trade(
+            &path,
+            &id,
+            TradeUpdate::Close {
+                exit: 110.0,
+                reason: CloseReason::Target,
+                note: None,
+            },
+            now(),
+        )
+        .unwrap();
+
+        let bars: Vec<Bar> = (22..=28)
+            .map(|d| Bar {
+                date: NaiveDate::from_ymd_opt(2026, 8, d).unwrap(),
+                open: 100.0,
+                high: 111.0,
+                low: 99.0,
+                close: 104.0,
+            })
+            .collect();
+        let report = review_trades(&path, &FixedBars(bars), now()).await.unwrap();
+        assert_eq!(report.closed, 1);
+        assert_eq!(report.trades[0].realized_r, Some(2.0));
+        assert!(report.trades[0].forward.is_some());
+        assert!(report.notes.iter().any(|n| n.contains("anecdote")));
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn review_of_missing_journal_is_clean_error() {
+        let path = tmp_journal("missing");
+        let err = review_trades(&path, &FixedBars(vec![]), now()).await;
+        assert!(err.unwrap_err().to_string().contains("log a trade first"));
+    }
+}

--- a/src/application/trade_journal.rs
+++ b/src/application/trade_journal.rs
@@ -101,11 +101,12 @@ pub fn log_trade(
 ) -> Result<LogOutcome, DomainError> {
     let (events, _) = read_events(path);
     let outcome = fold(&events);
+    let instrument = req.instrument.normalized()?;
 
     if !req.allow_duplicate {
         if let Some(existing) = find_duplicate(
             &outcome.trades,
-            &req.instrument,
+            &instrument,
             req.qty,
             req.entry,
             now.date_naive(),
@@ -128,9 +129,8 @@ pub fn log_trade(
         }
     };
 
-    let symbol = req.instrument.symbol().to_ascii_uppercase();
     let day = now.format("%Y%m%d");
-    let prefix = format!("{symbol}-{day}-");
+    let prefix = format!("{}-{day}-", instrument.symbol());
     let n = outcome
         .trades
         .iter()
@@ -143,7 +143,7 @@ pub fn log_trade(
         trade_id.clone(),
         now,
         req.source,
-        req.instrument,
+        instrument,
         req.qty,
         req.entry,
         req.thesis,
@@ -210,8 +210,9 @@ pub fn update_trade(
             }
         }
         TradeUpdate::Close { exit, reason, note } => {
-            if !(exit.is_finite() && exit > 0.0) {
-                return Err(fail("exit must be a positive price"));
+            // Zero is legal: an out-of-the-money option expires worthless.
+            if !(exit.is_finite() && exit >= 0.0) {
+                return Err(fail("exit must be a non-negative price"));
             }
             TradeEvent::Closed {
                 trade_id: trade_id.to_string(),
@@ -373,6 +374,7 @@ mod tests {
 
     fn tmp_journal(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!("openintel-tj-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir); // a prior failed run must not leak state in
         dir.join("trade_journal.jsonl")
     }
 
@@ -468,6 +470,48 @@ mod tests {
         )
         .is_err());
 
+        let positions = open_positions(&path);
+        assert!(positions.open.is_empty());
+        assert_eq!(positions.closed_count, 1);
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn lowercase_symbols_normalize_and_cannot_dodge_the_duplicate_guard() {
+        let path = tmp_journal("normalize");
+        let mut req = equity_req(100.0);
+        req.instrument = Instrument::Equity {
+            ticker: "nvda".into(),
+        };
+        let a = log_trade(&path, req, now()).unwrap();
+        assert_eq!(a.trade_id, "NVDA-20260821-1");
+
+        let dup = log_trade(&path, equity_req(100.0), now()).unwrap();
+        assert!(!dup.logged);
+
+        let mut junk = equity_req(100.0);
+        junk.instrument = Instrument::Equity {
+            ticker: "$$$".into(),
+        };
+        assert!(log_trade(&path, junk, now()).is_err());
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn worthless_expiry_closes_at_zero() {
+        let path = tmp_journal("expiry");
+        let id = log_trade(&path, equity_req(100.0), now()).unwrap().trade_id;
+        update_trade(
+            &path,
+            &id,
+            TradeUpdate::Close {
+                exit: 0.0,
+                reason: CloseReason::Expiry,
+                note: None,
+            },
+            now(),
+        )
+        .unwrap();
         let positions = open_positions(&path);
         assert!(positions.open.is_empty());
         assert_eq!(positions.closed_count, 1);

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -32,6 +32,9 @@ pub enum Command {
 
     /// Scan the day's biggest losers for gated dip setups (grades conformance, never advises)
     Dip(DipArgs),
+
+    /// Trade journal: log entries with a frozen thesis, track positions, grade the record
+    Journal(JournalArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -208,6 +211,140 @@ pub struct DipArgs {
 
     #[arg(long, value_enum, default_value_t = FormatArg::Table)]
     pub format: FormatArg,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct JournalArgs {
+    #[command(subcommand)]
+    pub command: JournalCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum JournalCommand {
+    /// Log an opened trade — thesis and plan are frozen at this moment
+    Log(JournalLogArgs),
+    /// Append a note to an open trade, optionally moving the stop or target
+    Amend(JournalAmendArgs),
+    /// Close an open trade with an exit price and reason
+    Close(JournalCloseArgs),
+    /// Every open trade with its frozen thesis and plan
+    Positions {
+        #[arg(long, value_enum, default_value_t = FormatArg::Table)]
+        format: FormatArg,
+    },
+    /// Grade the whole journal: R vs original stops, discipline, forward returns
+    Review {
+        #[arg(long, value_enum, default_value_t = FormatArg::Table)]
+        format: FormatArg,
+    },
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OptionKindArg {
+    Call,
+    Put,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct JournalLogArgs {
+    /// Ticker (equity), underlying (with --option), or symbol (with --crypto)
+    pub symbol: String,
+
+    /// Shares / contracts / units
+    #[arg(long)]
+    pub qty: f64,
+
+    /// Fill price of the traded instrument (premium per contract for options)
+    #[arg(long)]
+    pub entry: f64,
+
+    /// Exit-if price of the traded instrument, strictly below entry
+    #[arg(long)]
+    pub stop: f64,
+
+    /// Why this trade, in your own words — frozen forever
+    #[arg(long)]
+    pub thesis: String,
+
+    /// Setup label, e.g. sr-support-bounce
+    #[arg(long)]
+    pub tag: String,
+
+    /// Optional target price, above entry
+    #[arg(long)]
+    pub target: Option<f64>,
+
+    /// USD at risk on this trade (pair with --wallet)
+    #[arg(long = "risk-usd", requires = "wallet")]
+    pub risk_usd: Option<f64>,
+
+    /// Wallet size right now, for the %-of-wallet snapshot (pair with --risk-usd)
+    #[arg(long, requires = "risk_usd")]
+    pub wallet: Option<f64>,
+
+    /// The instrument is a long option on SYMBOL
+    #[arg(long, value_enum)]
+    pub option: Option<OptionKindArg>,
+
+    /// Option strike price
+    #[arg(long, requires = "option")]
+    pub strike: Option<f64>,
+
+    /// Option expiry, YYYY-MM-DD
+    #[arg(long, requires = "option")]
+    pub expiry: Option<String>,
+
+    /// The instrument is crypto
+    #[arg(long, conflicts_with_all = ["option", "strike", "expiry"])]
+    pub crypto: bool,
+
+    /// Skip the same-day duplicate guard
+    #[arg(long = "allow-duplicate")]
+    pub allow_duplicate: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct JournalAmendArgs {
+    /// Trade id, e.g. NVDA-20260821-1
+    pub trade_id: String,
+
+    /// Why — required for every amendment
+    #[arg(long)]
+    pub note: String,
+
+    /// New stop price (widened stops are reported by review)
+    #[arg(long)]
+    pub stop: Option<f64>,
+
+    /// New target price
+    #[arg(long)]
+    pub target: Option<f64>,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JournalCloseReasonArg {
+    Stop,
+    Target,
+    Discretion,
+    Expiry,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct JournalCloseArgs {
+    /// Trade id, e.g. NVDA-20260821-1
+    pub trade_id: String,
+
+    /// Exit fill price
+    #[arg(long)]
+    pub exit: f64,
+
+    /// What ended it
+    #[arg(long, value_enum)]
+    pub reason: JournalCloseReasonArg,
+
+    /// Optional context
+    #[arg(long)]
+    pub note: Option<String>,
 }
 
 pub fn to_app_config(args: &AnalyzeArgs) -> AppConfig {

--- a/src/cli/journal.rs
+++ b/src/cli/journal.rs
@@ -1,0 +1,304 @@
+//! CLI leaf for `openintel journal` — the manual fallback for the trade
+//! journal (the MCP tools are the primary surface). Returns rendered Strings;
+//! main prints.
+
+use chrono::Utc;
+
+use crate::application::trade_journal::{
+    default_path_or_err, log_trade, open_positions, review_trades, update_trade, LogTradeRequest,
+    TradeReviewReport, TradeUpdate,
+};
+use crate::application::DISCLAIMER;
+use crate::cli::args::{FormatArg, JournalArgs, JournalCloseReasonArg, JournalCommand};
+use crate::domain::error::DomainError;
+use crate::domain::trade_journal::{CloseReason, Instrument, OptionKind, Trade};
+use crate::domain::trade_review::Bucket;
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "trade_journal".into(),
+        message: message.into(),
+    }
+}
+
+pub async fn run(args: &JournalArgs) -> Result<String, DomainError> {
+    let path = default_path_or_err()?;
+    match &args.command {
+        JournalCommand::Log(log) => {
+            let instrument = match (&log.option, log.crypto) {
+                (Some(_), true) => return Err(fail("--option and --crypto are exclusive")),
+                (None, true) => Instrument::Crypto {
+                    symbol: log.symbol.to_ascii_uppercase(),
+                },
+                (None, false) => Instrument::Equity {
+                    ticker: log.symbol.to_ascii_uppercase(),
+                },
+                (Some(kind), false) => Instrument::Option {
+                    underlying: log.symbol.to_ascii_uppercase(),
+                    strike: log.strike.ok_or_else(|| fail("--option needs --strike"))?,
+                    expiry: log
+                        .expiry
+                        .as_deref()
+                        .and_then(|e| e.parse().ok())
+                        .ok_or_else(|| fail("--option needs --expiry YYYY-MM-DD"))?,
+                    kind: match kind {
+                        crate::cli::args::OptionKindArg::Call => OptionKind::Call,
+                        crate::cli::args::OptionKindArg::Put => OptionKind::Put,
+                    },
+                },
+            };
+            let outcome = log_trade(
+                &path,
+                LogTradeRequest {
+                    source: "cli".into(),
+                    instrument,
+                    qty: log.qty,
+                    entry: log.entry,
+                    thesis: log.thesis.clone(),
+                    setup_tag: log.tag.clone(),
+                    planned_stop: log.stop,
+                    planned_target: log.target,
+                    risk_usd: log.risk_usd,
+                    wallet_usd: log.wallet,
+                    allow_duplicate: log.allow_duplicate,
+                },
+                Utc::now(),
+            )?;
+            Ok(if outcome.logged {
+                format!(
+                    "logged {} — thesis and plan are now frozen",
+                    outcome.trade_id
+                )
+            } else {
+                format!(
+                    "not logged: same-day duplicate of {} (use --allow-duplicate if this is \
+                     really a second trade)",
+                    outcome.trade_id
+                )
+            })
+        }
+        JournalCommand::Amend(amend) => {
+            update_trade(
+                &path,
+                &amend.trade_id,
+                TradeUpdate::Amend {
+                    note: amend.note.clone(),
+                    new_stop: amend.stop,
+                    new_target: amend.target,
+                },
+                Utc::now(),
+            )?;
+            Ok(format!("amended {}", amend.trade_id))
+        }
+        JournalCommand::Close(close) => {
+            update_trade(
+                &path,
+                &close.trade_id,
+                TradeUpdate::Close {
+                    exit: close.exit,
+                    reason: match close.reason {
+                        JournalCloseReasonArg::Stop => CloseReason::Stop,
+                        JournalCloseReasonArg::Target => CloseReason::Target,
+                        JournalCloseReasonArg::Discretion => CloseReason::Discretion,
+                        JournalCloseReasonArg::Expiry => CloseReason::Expiry,
+                    },
+                    note: close.note.clone(),
+                },
+                Utc::now(),
+            )?;
+            Ok(format!("closed {}", close.trade_id))
+        }
+        JournalCommand::Positions { format } => {
+            let report = open_positions(&path);
+            Ok(match format {
+                FormatArg::Json => serde_json::to_string_pretty(&report)
+                    .map_err(|e| fail(format!("render failed: {e}")))?,
+                FormatArg::Table => render_positions(&report.open, report.closed_count),
+            })
+        }
+        JournalCommand::Review { format } => {
+            let bars = crate::adapters::market::yahoo::YahooMarketSource::new()?;
+            let report = review_trades(&path, &bars, Utc::now()).await?;
+            Ok(match format {
+                FormatArg::Json => serde_json::to_string_pretty(&report)
+                    .map_err(|e| fail(format!("render failed: {e}")))?,
+                FormatArg::Table => render_review(&report),
+            })
+        }
+    }
+}
+
+fn render_positions(open: &[Trade], closed_count: usize) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "=== OpenIntel Trade Journal — {} open, {closed_count} closed ===\n",
+        open.len()
+    );
+    if open.is_empty() {
+        let _ = writeln!(out, "  no open trades");
+    }
+    for t in open {
+        let _ = writeln!(
+            out,
+            "  {}  {}  qty {} @ {:.2}  stop {:.2}{}  [{}]",
+            t.id,
+            t.instrument.describe(),
+            t.qty,
+            t.entry,
+            t.current_stop,
+            t.current_target
+                .map(|x| format!("  target {x:.2}"))
+                .unwrap_or_default(),
+            t.setup_tag,
+        );
+        let _ = writeln!(out, "    thesis: {}", t.thesis);
+        if t.stop_widened {
+            let _ = writeln!(out, "    ⚠ stop widened from {:.2}", t.original_stop);
+        }
+        for a in &t.amendments {
+            let _ = writeln!(out, "    amended {}: {}", a.at.date_naive(), a.note);
+        }
+    }
+    let _ = writeln!(out, "\n{DISCLAIMER}");
+    out
+}
+
+fn render_bucket_rows(out: &mut String, title: &str, buckets: &[Bucket]) {
+    use std::fmt::Write as _;
+    let _ = writeln!(out, "{title}");
+    for b in buckets {
+        match &b.note {
+            Some(note) => {
+                let _ = writeln!(out, "  {:<24} n={:<3} {}", b.key, b.trades, note);
+            }
+            None => {
+                let _ = writeln!(
+                    out,
+                    "  {:<24} n={:<3} closed={:<3} win {}% · avg {}R · stops widened {}",
+                    b.key,
+                    b.trades,
+                    b.closed,
+                    b.win_rate_pct
+                        .map(|w| format!("{w:.0}"))
+                        .unwrap_or_default(),
+                    b.avg_realized_r
+                        .map(|r| format!("{r:+.2}"))
+                        .unwrap_or_default(),
+                    b.stops_widened,
+                );
+            }
+        }
+    }
+}
+
+fn render_review(r: &TradeReviewReport) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "=== OpenIntel Trade Review — {} trades ({} closed, {} open) ===\n",
+        r.trades_total, r.closed, r.open
+    );
+    render_bucket_rows(&mut out, "by setup:", &r.by_setup);
+    let _ = writeln!(out);
+    render_bucket_rows(&mut out, "by instrument:", &r.by_instrument);
+    let _ = writeln!(out, "\ntrades:");
+    for g in &r.trades {
+        let status = if g.open {
+            "open".to_string()
+        } else {
+            format!(
+                "{}R{}",
+                g.realized_r.map(|x| format!("{x:+.1}")).unwrap_or_default(),
+                g.close_reason
+                    .map(|c| format!(" ({c:?})").to_lowercase())
+                    .unwrap_or_default()
+            )
+        };
+        let _ = writeln!(out, "  {}  {}  {}", g.id, g.instrument, status);
+        for d in &g.discipline {
+            let _ = writeln!(out, "    ⚠ {d}");
+        }
+    }
+    for n in &r.notes {
+        let _ = writeln!(out, "\nnote: {n}");
+    }
+    for e in &r.errors {
+        let _ = writeln!(out, "error: {e}");
+    }
+    let _ = writeln!(out, "\n{DISCLAIMER}");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::trade_journal::{fold, open_event, RiskSnapshot, TradeEvent};
+    use crate::domain::trade_review::{aggregate, grade};
+    use chrono::TimeZone;
+
+    fn trades() -> Vec<Trade> {
+        let events = vec![
+            open_event(
+                "NVDA-20260821-1".into(),
+                Utc.with_ymd_and_hms(2026, 8, 21, 14, 0, 0).unwrap(),
+                "cli".into(),
+                Instrument::Equity {
+                    ticker: "NVDA".into(),
+                },
+                10.0,
+                100.0,
+                "weekly support at 98".into(),
+                "sr-support-bounce".into(),
+                95.0,
+                Some(110.0),
+                Some(RiskSnapshot::new(50.0, 5000.0).unwrap()),
+            )
+            .unwrap(),
+            TradeEvent::Amended {
+                trade_id: "NVDA-20260821-1".into(),
+                at: Utc.with_ymd_and_hms(2026, 8, 21, 16, 0, 0).unwrap(),
+                note: "giving it room".into(),
+                new_stop: Some(93.0),
+                new_target: None,
+            },
+        ];
+        fold(&events).trades
+    }
+
+    #[test]
+    fn positions_table_shows_thesis_and_widened_stop() {
+        let t = render_positions(&trades(), 3);
+        assert!(t.contains("1 open, 3 closed"));
+        assert!(t.contains("thesis: weekly support at 98"));
+        assert!(t.contains("stop widened from 95.00"));
+        assert!(t.contains("Not financial advice"));
+    }
+
+    #[test]
+    fn review_table_shows_buckets_and_discipline() {
+        let all = trades();
+        let graded: Vec<_> = all.iter().map(|t| grade(t, None, None)).collect();
+        let (by_setup, by_instrument) = aggregate(&graded);
+        let report = TradeReviewReport {
+            generated_at: Utc.with_ymd_and_hms(2026, 8, 21, 21, 0, 0).unwrap(),
+            journal_path: "/tmp/x".into(),
+            trades_total: graded.len(),
+            closed: 0,
+            open: graded.len(),
+            by_setup,
+            by_instrument,
+            trades: graded,
+            skipped_lines: 0,
+            errors: vec![],
+            notes: vec!["only 0 closed trades — anecdote".into()],
+        };
+        let t = render_review(&report);
+        assert!(t.contains("sr-support-bounce"));
+        assert!(t.contains("insufficient sample"));
+        assert!(t.contains("stop was widened after entry"));
+        assert!(t.contains("anecdote"));
+    }
+}

--- a/src/cli/journal.rs
+++ b/src/cli/journal.rs
@@ -6,12 +6,12 @@ use chrono::Utc;
 
 use crate::application::trade_journal::{
     default_path_or_err, log_trade, open_positions, review_trades, update_trade, LogTradeRequest,
-    TradeReviewReport, TradeUpdate,
+    PositionsReport, TradeReviewReport, TradeUpdate,
 };
 use crate::application::DISCLAIMER;
 use crate::cli::args::{FormatArg, JournalArgs, JournalCloseReasonArg, JournalCommand};
 use crate::domain::error::DomainError;
-use crate::domain::trade_journal::{CloseReason, Instrument, OptionKind, Trade};
+use crate::domain::trade_journal::{CloseReason, Instrument, OptionKind};
 use crate::domain::trade_review::Bucket;
 
 fn fail(message: impl Into<String>) -> DomainError {
@@ -113,7 +113,7 @@ pub async fn run(args: &JournalArgs) -> Result<String, DomainError> {
             Ok(match format {
                 FormatArg::Json => serde_json::to_string_pretty(&report)
                     .map_err(|e| fail(format!("render failed: {e}")))?,
-                FormatArg::Table => render_positions(&report.open, report.closed_count),
+                FormatArg::Table => render_positions(&report),
             })
         }
         JournalCommand::Review { format } => {
@@ -128,13 +128,15 @@ pub async fn run(args: &JournalArgs) -> Result<String, DomainError> {
     }
 }
 
-fn render_positions(open: &[Trade], closed_count: usize) -> String {
+fn render_positions(report: &PositionsReport) -> String {
     use std::fmt::Write as _;
+    let open = &report.open;
     let mut out = String::new();
     let _ = writeln!(
         out,
-        "=== OpenIntel Trade Journal — {} open, {closed_count} closed ===\n",
-        open.len()
+        "=== OpenIntel Trade Journal — {} open, {} closed ===\n",
+        open.len(),
+        report.closed_count
     );
     if open.is_empty() {
         let _ = writeln!(out, "  no open trades");
@@ -160,6 +162,16 @@ fn render_positions(open: &[Trade], closed_count: usize) -> String {
         for a in &t.amendments {
             let _ = writeln!(out, "    amended {}: {}", a.at.date_naive(), a.note);
         }
+    }
+    if report.skipped_lines > 0 {
+        let _ = writeln!(
+            out,
+            "\n⚠ {} unparseable journal line(s) skipped — the counts above may be incomplete",
+            report.skipped_lines
+        );
+    }
+    for e in &report.errors {
+        let _ = writeln!(out, "⚠ {e}");
     }
     let _ = writeln!(out, "\n{DISCLAIMER}");
     out
@@ -235,7 +247,7 @@ fn render_review(r: &TradeReviewReport) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::trade_journal::{fold, open_event, RiskSnapshot, TradeEvent};
+    use crate::domain::trade_journal::{fold, open_event, RiskSnapshot, Trade, TradeEvent};
     use crate::domain::trade_review::{aggregate, grade};
     use chrono::TimeZone;
 
@@ -270,7 +282,15 @@ mod tests {
 
     #[test]
     fn positions_table_shows_thesis_and_widened_stop() {
-        let t = render_positions(&trades(), 3);
+        let t = render_positions(&PositionsReport {
+            journal_path: "/tmp/x".into(),
+            open: trades(),
+            closed_count: 3,
+            skipped_lines: 2,
+            errors: vec!["close for unknown trade GHOST-1".into()],
+        });
+        assert!(t.contains("2 unparseable journal line(s) skipped"));
+        assert!(t.contains("close for unknown trade GHOST-1"));
         assert!(t.contains("1 open, 3 closed"));
         assert!(t.contains("thesis: weekly support at 98"));
         assert!(t.contains("stop widened from 95.00"));

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod args;
 pub mod dip;
+pub mod journal;
 pub mod pulse;
 pub mod risk;
 pub mod run;

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -6,4 +6,6 @@ pub mod error;
 pub mod margin;
 pub mod ports;
 pub mod risk;
+pub mod trade_journal;
+pub mod trade_review;
 pub mod values;

--- a/src/domain/trade_journal.rs
+++ b/src/domain/trade_journal.rs
@@ -1,0 +1,591 @@
+//! Append-only trade journal: events in, folded trades out. A trade is a fold
+//! over its `opened` / `amended` / `closed` events; the entry thesis and the
+//! original plan are frozen at open and can never be rewritten. Pure and
+//! synchronous — timestamps and trade ids are stamped at the application edge.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::error::DomainError;
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "trade_journal".into(),
+        message: message.into(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OptionKind {
+    Call,
+    Put,
+}
+
+/// What was traded. Matches the instruments a Robinhood agentic account can
+/// hold (long equities, long options, crypto). Schema is deliberately free of
+/// OpenIntel-specific fields so the journal can stand alone.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum Instrument {
+    Equity {
+        ticker: String,
+    },
+    Option {
+        underlying: String,
+        strike: f64,
+        expiry: NaiveDate,
+        kind: OptionKind,
+    },
+    Crypto {
+        symbol: String,
+    },
+}
+
+impl Instrument {
+    /// The symbol used for trade ids and bar lookups (underlying for options).
+    pub fn symbol(&self) -> &str {
+        match self {
+            Instrument::Equity { ticker } => ticker,
+            Instrument::Option { underlying, .. } => underlying,
+            Instrument::Crypto { symbol } => symbol,
+        }
+    }
+
+    pub fn kind_label(&self) -> &'static str {
+        match self {
+            Instrument::Equity { .. } => "equity",
+            Instrument::Option { .. } => "option",
+            Instrument::Crypto { .. } => "crypto",
+        }
+    }
+
+    pub fn describe(&self) -> String {
+        match self {
+            Instrument::Equity { ticker } => ticker.clone(),
+            Instrument::Option {
+                underlying,
+                strike,
+                expiry,
+                kind,
+            } => {
+                let k = match kind {
+                    OptionKind::Call => "call",
+                    OptionKind::Put => "put",
+                };
+                format!("{underlying} {strike} {k} {expiry}")
+            }
+            Instrument::Crypto { symbol } => symbol.clone(),
+        }
+    }
+}
+
+/// Risk snapshot taken at open — wallet size as it was that moment, so the
+/// percentage never goes stale.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct RiskSnapshot {
+    pub risk_usd: f64,
+    pub wallet_usd: f64,
+    pub pct_of_wallet: f64,
+}
+
+impl RiskSnapshot {
+    pub fn new(risk_usd: f64, wallet_usd: f64) -> Result<Self, DomainError> {
+        if !(risk_usd.is_finite() && risk_usd > 0.0 && wallet_usd.is_finite() && wallet_usd > 0.0) {
+            return Err(fail("risk and wallet must be positive numbers"));
+        }
+        Ok(Self {
+            risk_usd,
+            wallet_usd,
+            pct_of_wallet: risk_usd / wallet_usd * 100.0,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CloseReason {
+    Stop,
+    Target,
+    Discretion,
+    Expiry,
+}
+
+/// One journal line. `opened` freezes the thesis and plan; `amended` appends
+/// (never rewrites); `closed` ends the trade.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum TradeEvent {
+    Opened {
+        trade_id: String,
+        at: DateTime<Utc>,
+        /// Who logged it: "agent", "cli", later "dip_scan".
+        source: String,
+        instrument: Instrument,
+        qty: f64,
+        entry: f64,
+        thesis: String,
+        setup_tag: String,
+        /// Price of the traded instrument (premium for options), strictly
+        /// below entry — long-only, so risk-per-unit is always positive.
+        planned_stop: f64,
+        planned_target: Option<f64>,
+        risk: Option<RiskSnapshot>,
+    },
+    Amended {
+        trade_id: String,
+        at: DateTime<Utc>,
+        note: String,
+        new_stop: Option<f64>,
+        new_target: Option<f64>,
+    },
+    Closed {
+        trade_id: String,
+        at: DateTime<Utc>,
+        exit: f64,
+        reason: CloseReason,
+        note: Option<String>,
+    },
+}
+
+impl TradeEvent {
+    pub fn trade_id(&self) -> &str {
+        match self {
+            TradeEvent::Opened { trade_id, .. }
+            | TradeEvent::Amended { trade_id, .. }
+            | TradeEvent::Closed { trade_id, .. } => trade_id,
+        }
+    }
+}
+
+/// Validated constructor for an `opened` event. All plan fields are required
+/// except the target — no entry without a stop.
+#[allow(clippy::too_many_arguments)]
+pub fn open_event(
+    trade_id: String,
+    at: DateTime<Utc>,
+    source: String,
+    instrument: Instrument,
+    qty: f64,
+    entry: f64,
+    thesis: String,
+    setup_tag: String,
+    planned_stop: f64,
+    planned_target: Option<f64>,
+    risk: Option<RiskSnapshot>,
+) -> Result<TradeEvent, DomainError> {
+    if !(qty.is_finite() && qty > 0.0) {
+        return Err(fail("qty must be a positive number"));
+    }
+    if !(entry.is_finite() && entry > 0.0) {
+        return Err(fail("entry must be a positive price"));
+    }
+    if !(planned_stop.is_finite() && planned_stop > 0.0 && planned_stop < entry) {
+        return Err(fail(
+            "planned stop must be a positive price strictly below entry (long-only)",
+        ));
+    }
+    if let Some(t) = planned_target {
+        if !(t.is_finite() && t > entry) {
+            return Err(fail("planned target must be above entry"));
+        }
+    }
+    if thesis.trim().is_empty() {
+        return Err(fail("thesis is required — no entry without a written why"));
+    }
+    if setup_tag.trim().is_empty() {
+        return Err(fail("setup_tag is required (e.g. sr-support-bounce)"));
+    }
+    Ok(TradeEvent::Opened {
+        trade_id,
+        at,
+        source,
+        instrument,
+        qty,
+        entry,
+        thesis: thesis.trim().to_string(),
+        setup_tag: setup_tag.trim().to_string(),
+        planned_stop,
+        planned_target,
+        risk,
+    })
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Amendment {
+    pub at: DateTime<Utc>,
+    pub note: String,
+    pub new_stop: Option<f64>,
+    pub new_target: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Close {
+    pub at: DateTime<Utc>,
+    pub exit: f64,
+    pub reason: CloseReason,
+    pub note: Option<String>,
+}
+
+/// A trade folded from its events. Original plan fields are the frozen open
+/// values; `current_*` reflect amendments.
+#[derive(Debug, Clone, Serialize)]
+pub struct Trade {
+    pub id: String,
+    pub opened_at: DateTime<Utc>,
+    pub source: String,
+    pub instrument: Instrument,
+    pub qty: f64,
+    pub entry: f64,
+    pub thesis: String,
+    pub setup_tag: String,
+    pub original_stop: f64,
+    pub original_target: Option<f64>,
+    pub current_stop: f64,
+    pub current_target: Option<f64>,
+    /// True if any amendment moved the stop below its original level.
+    pub stop_widened: bool,
+    pub risk: Option<RiskSnapshot>,
+    pub amendments: Vec<Amendment>,
+    pub close: Option<Close>,
+}
+
+impl Trade {
+    pub fn is_open(&self) -> bool {
+        self.close.is_none()
+    }
+
+    /// entry − original stop, always positive by open validation.
+    pub fn risk_per_unit(&self) -> f64 {
+        self.entry - self.original_stop
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FoldOutcome {
+    pub trades: Vec<Trade>,
+    /// Per-event problems (unknown id, double close, amend-after-close).
+    /// A bad event never sinks the fold.
+    pub errors: Vec<String>,
+}
+
+/// Fold events (in file order) into trades. Order within a trade is the append
+/// order; events referencing unknown or closed trades become errors.
+pub fn fold(events: &[TradeEvent]) -> FoldOutcome {
+    let mut out = FoldOutcome::default();
+    for event in events {
+        match event {
+            TradeEvent::Opened {
+                trade_id,
+                at,
+                source,
+                instrument,
+                qty,
+                entry,
+                thesis,
+                setup_tag,
+                planned_stop,
+                planned_target,
+                risk,
+            } => {
+                if out.trades.iter().any(|t| &t.id == trade_id) {
+                    out.errors
+                        .push(format!("duplicate open for trade {trade_id}"));
+                    continue;
+                }
+                out.trades.push(Trade {
+                    id: trade_id.clone(),
+                    opened_at: *at,
+                    source: source.clone(),
+                    instrument: instrument.clone(),
+                    qty: *qty,
+                    entry: *entry,
+                    thesis: thesis.clone(),
+                    setup_tag: setup_tag.clone(),
+                    original_stop: *planned_stop,
+                    original_target: *planned_target,
+                    current_stop: *planned_stop,
+                    current_target: *planned_target,
+                    stop_widened: false,
+                    risk: *risk,
+                    amendments: Vec::new(),
+                    close: None,
+                });
+            }
+            TradeEvent::Amended {
+                trade_id,
+                at,
+                note,
+                new_stop,
+                new_target,
+            } => match out.trades.iter_mut().find(|t| &t.id == trade_id) {
+                None => out
+                    .errors
+                    .push(format!("amend for unknown trade {trade_id}")),
+                Some(t) if t.close.is_some() => out
+                    .errors
+                    .push(format!("amend after close for trade {trade_id}")),
+                Some(t) => {
+                    if let Some(s) = new_stop {
+                        if *s < t.original_stop {
+                            t.stop_widened = true;
+                        }
+                        t.current_stop = *s;
+                    }
+                    if new_target.is_some() {
+                        t.current_target = *new_target;
+                    }
+                    t.amendments.push(Amendment {
+                        at: *at,
+                        note: note.clone(),
+                        new_stop: *new_stop,
+                        new_target: *new_target,
+                    });
+                }
+            },
+            TradeEvent::Closed {
+                trade_id,
+                at,
+                exit,
+                reason,
+                note,
+            } => match out.trades.iter_mut().find(|t| &t.id == trade_id) {
+                None => out
+                    .errors
+                    .push(format!("close for unknown trade {trade_id}")),
+                Some(t) if t.close.is_some() => out
+                    .errors
+                    .push(format!("second close for trade {trade_id}")),
+                Some(t) => {
+                    t.close = Some(Close {
+                        at: *at,
+                        exit: *exit,
+                        reason: *reason,
+                        note: note.clone(),
+                    });
+                }
+            },
+        }
+    }
+    out
+}
+
+/// Retry guard: an open matching instrument + qty + entry on the same UTC day
+/// is almost certainly the same real trade logged twice.
+pub fn find_duplicate<'a>(
+    trades: &'a [Trade],
+    instrument: &Instrument,
+    qty: f64,
+    entry: f64,
+    day: NaiveDate,
+) -> Option<&'a Trade> {
+    trades.iter().find(|t| {
+        &t.instrument == instrument
+            && t.qty == qty
+            && t.entry == entry
+            && t.opened_at.date_naive() == day
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at(h: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 21, h, 0, 0).unwrap()
+    }
+
+    fn equity(ticker: &str) -> Instrument {
+        Instrument::Equity {
+            ticker: ticker.into(),
+        }
+    }
+
+    fn opened(id: &str) -> TradeEvent {
+        open_event(
+            id.into(),
+            at(14),
+            "agent".into(),
+            equity("NVDA"),
+            10.0,
+            100.0,
+            "bounce off weekly support at 98".into(),
+            "sr-support-bounce".into(),
+            95.0,
+            Some(110.0),
+            Some(RiskSnapshot::new(50.0, 5000.0).unwrap()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn open_validation_rejects_bad_plans() {
+        let bad_stop = open_event(
+            "x".into(),
+            at(14),
+            "agent".into(),
+            equity("NVDA"),
+            10.0,
+            100.0,
+            "t".into(),
+            "tag".into(),
+            100.0, // stop == entry
+            None,
+            None,
+        );
+        assert!(bad_stop.is_err());
+        let no_thesis = open_event(
+            "x".into(),
+            at(14),
+            "agent".into(),
+            equity("NVDA"),
+            10.0,
+            100.0,
+            "  ".into(),
+            "tag".into(),
+            95.0,
+            None,
+            None,
+        );
+        assert!(no_thesis.is_err());
+        let target_below_entry = open_event(
+            "x".into(),
+            at(14),
+            "agent".into(),
+            equity("NVDA"),
+            10.0,
+            100.0,
+            "t".into(),
+            "tag".into(),
+            95.0,
+            Some(99.0),
+            None,
+        );
+        assert!(target_below_entry.is_err());
+    }
+
+    #[test]
+    fn fold_builds_trade_and_tracks_amendments() {
+        let events = vec![
+            opened("NVDA-1"),
+            TradeEvent::Amended {
+                trade_id: "NVDA-1".into(),
+                at: at(15),
+                note: "trailing up after 1R".into(),
+                new_stop: Some(100.0),
+                new_target: None,
+            },
+            TradeEvent::Closed {
+                trade_id: "NVDA-1".into(),
+                at: at(20),
+                exit: 108.0,
+                reason: CloseReason::Discretion,
+                note: None,
+            },
+        ];
+        let out = fold(&events);
+        assert!(out.errors.is_empty());
+        let t = &out.trades[0];
+        assert_eq!(t.original_stop, 95.0);
+        assert_eq!(t.current_stop, 100.0);
+        assert!(!t.stop_widened);
+        assert!(!t.is_open());
+        assert_eq!(t.close.as_ref().unwrap().exit, 108.0);
+        assert_eq!(t.risk_per_unit(), 5.0);
+    }
+
+    #[test]
+    fn widened_stop_is_flagged() {
+        let events = vec![
+            opened("NVDA-1"),
+            TradeEvent::Amended {
+                trade_id: "NVDA-1".into(),
+                at: at(15),
+                note: "giving it room".into(),
+                new_stop: Some(92.0),
+                new_target: None,
+            },
+        ];
+        let out = fold(&events);
+        assert!(out.trades[0].stop_widened);
+    }
+
+    #[test]
+    fn bad_references_become_errors_not_panics() {
+        let events = vec![
+            TradeEvent::Closed {
+                trade_id: "GHOST".into(),
+                at: at(14),
+                exit: 1.0,
+                reason: CloseReason::Stop,
+                note: None,
+            },
+            opened("NVDA-1"),
+            TradeEvent::Closed {
+                trade_id: "NVDA-1".into(),
+                at: at(15),
+                exit: 96.0,
+                reason: CloseReason::Stop,
+                note: None,
+            },
+            TradeEvent::Closed {
+                trade_id: "NVDA-1".into(),
+                at: at(16),
+                exit: 97.0,
+                reason: CloseReason::Stop,
+                note: None,
+            },
+            TradeEvent::Amended {
+                trade_id: "NVDA-1".into(),
+                at: at(17),
+                note: "too late".into(),
+                new_stop: None,
+                new_target: None,
+            },
+        ];
+        let out = fold(&events);
+        assert_eq!(out.trades.len(), 1);
+        assert_eq!(out.errors.len(), 3);
+        assert_eq!(out.trades[0].close.as_ref().unwrap().exit, 96.0);
+    }
+
+    #[test]
+    fn duplicate_guard_matches_same_day_same_shape() {
+        let out = fold(&[opened("NVDA-1")]);
+        assert!(find_duplicate(
+            &out.trades,
+            &equity("NVDA"),
+            10.0,
+            100.0,
+            at(14).date_naive()
+        )
+        .is_some());
+        assert!(find_duplicate(
+            &out.trades,
+            &equity("NVDA"),
+            10.0,
+            101.0,
+            at(14).date_naive()
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn events_round_trip_through_jsonl() {
+        let e = opened("NVDA-1");
+        let line = serde_json::to_string(&e).unwrap();
+        let back: TradeEvent = serde_json::from_str(&line).unwrap();
+        assert_eq!(back.trade_id(), "NVDA-1");
+        let opt = Instrument::Option {
+            underlying: "TSLA".into(),
+            strike: 250.0,
+            expiry: NaiveDate::from_ymd_opt(2026, 9, 18).unwrap(),
+            kind: OptionKind::Call,
+        };
+        let line = serde_json::to_string(&opt).unwrap();
+        let back: Instrument = serde_json::from_str(&line).unwrap();
+        assert_eq!(back, opt);
+        assert_eq!(back.describe(), "TSLA 250 call 2026-09-18");
+    }
+}

--- a/src/domain/trade_journal.rs
+++ b/src/domain/trade_journal.rs
@@ -60,6 +60,37 @@ impl Instrument {
         }
     }
 
+    /// Canonical form for persistence: ticker-backed symbols validated and
+    /// uppercased via `Ticker::parse` (so a lowercase retry can't slip past
+    /// the duplicate guard, and review can always fetch bars), crypto trimmed
+    /// and uppercased.
+    pub fn normalized(self) -> Result<Instrument, DomainError> {
+        use crate::domain::entities::ticker::Ticker;
+        Ok(match self {
+            Instrument::Equity { ticker } => Instrument::Equity {
+                ticker: Ticker::parse(&ticker)?.as_str().to_string(),
+            },
+            Instrument::Option {
+                underlying,
+                strike,
+                expiry,
+                kind,
+            } => Instrument::Option {
+                underlying: Ticker::parse(&underlying)?.as_str().to_string(),
+                strike,
+                expiry,
+                kind,
+            },
+            Instrument::Crypto { symbol } => {
+                let symbol = symbol.trim().to_ascii_uppercase();
+                if symbol.is_empty() {
+                    return Err(fail("crypto symbol is required"));
+                }
+                Instrument::Crypto { symbol }
+            }
+        })
+    }
+
     pub fn describe(&self) -> String {
         match self {
             Instrument::Equity { ticker } => ticker.clone(),

--- a/src/domain/trade_review.rs
+++ b/src/domain/trade_review.rs
@@ -1,0 +1,333 @@
+//! Grade folded trades: R-multiples against the original plan, discipline
+//! metrics (did the exit honor the plan?), and forward returns for equities.
+//! Pure — bars are fetched at the application edge and passed in.
+//!
+//! Honesty gates: overall conclusions need n ≥ 30 closed trades, per-bucket
+//! stats need n ≥ 10; below that the review says "insufficient sample" and
+//! shows no number. Options and crypto grade on realized P&L only (historical
+//! option prices aren't available keyless; crypto has no bar path yet).
+
+use serde::Serialize;
+
+use crate::domain::dip_review::{forward_returns, horizon_stats, ForwardReturns, HorizonStats};
+use crate::domain::trade_journal::{CloseReason, Instrument, OptionKind, Trade};
+use crate::domain::values::bar::Bar;
+
+pub const MIN_OVERALL_SAMPLE: usize = 30;
+pub const MIN_BUCKET_SAMPLE: usize = 10;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GradedTrade {
+    pub id: String,
+    pub instrument: String,
+    pub instrument_kind: &'static str,
+    pub setup_tag: String,
+    pub open: bool,
+    /// Realized R vs the ORIGINAL stop — amendments never soften the grade.
+    pub realized_r: Option<f64>,
+    pub realized_pnl_usd: Option<f64>,
+    pub close_reason: Option<CloseReason>,
+    /// Equity only: 1/5/10-day forward returns from entry, raw and SPY-adjusted.
+    pub forward: Option<ForwardReturns>,
+    pub forward_vs_spy: Option<ForwardReturns>,
+    /// Options only: did the underlying move the thesis direction by day 5?
+    pub underlying_with_thesis: Option<bool>,
+    pub stop_widened: bool,
+    /// Plan-vs-actual flags, e.g. "exited 0.8R below the original stop".
+    pub discipline: Vec<String>,
+}
+
+/// Grade one trade. `underlying_bars` are ascending daily bars for the
+/// instrument's symbol (underlying for options); None when unavailable.
+pub fn grade(
+    trade: &Trade,
+    underlying_bars: Option<&[Bar]>,
+    spy_bars: Option<&[Bar]>,
+) -> GradedTrade {
+    let mut discipline = Vec::new();
+    let rpu = trade.risk_per_unit();
+
+    let (realized_r, realized_pnl_usd, close_reason) = match &trade.close {
+        None => (None, None, None),
+        Some(c) => {
+            let r = (c.exit - trade.entry) / rpu;
+            let pnl = (c.exit - trade.entry) * trade.qty;
+            if c.exit < trade.original_stop {
+                let overrun = (trade.original_stop - c.exit) / rpu;
+                discipline.push(format!("exited {overrun:.1}R below the original stop"));
+            }
+            (Some(r), Some(pnl), Some(c.reason))
+        }
+    };
+    if trade.stop_widened {
+        discipline.push("stop was widened after entry".into());
+    }
+
+    let entry_date = trade.opened_at.date_naive();
+    let is_equity = matches!(trade.instrument, Instrument::Equity { .. });
+    let forward = match (is_equity, underlying_bars) {
+        (true, Some(bars)) => Some(forward_returns(entry_date, trade.entry, bars)),
+        _ => None,
+    };
+    let forward_vs_spy = match (&forward, spy_bars) {
+        (Some(fwd), Some(spy)) => {
+            let base = spy
+                .iter()
+                .find(|b| b.date >= entry_date)
+                .map(|b| forward_returns(entry_date, b.close, spy));
+            base.map(|b| ForwardReturns {
+                d1: sub(fwd.d1, b.d1),
+                d5: sub(fwd.d5, b.d5),
+                d10: sub(fwd.d10, b.d10),
+            })
+        }
+        _ => None,
+    };
+
+    let underlying_with_thesis = match (&trade.instrument, underlying_bars) {
+        (Instrument::Option { kind, .. }, Some(bars)) => bars
+            .iter()
+            .find(|b| b.date >= entry_date)
+            .map(|base| forward_returns(entry_date, base.close, bars))
+            .and_then(|f| f.d5)
+            .map(|d5| match kind {
+                OptionKind::Call => d5 > 0.0,
+                OptionKind::Put => d5 < 0.0,
+            }),
+        _ => None,
+    };
+
+    GradedTrade {
+        id: trade.id.clone(),
+        instrument: trade.instrument.describe(),
+        instrument_kind: trade.instrument.kind_label(),
+        setup_tag: trade.setup_tag.clone(),
+        open: trade.is_open(),
+        realized_r,
+        realized_pnl_usd,
+        close_reason,
+        forward,
+        forward_vs_spy,
+        underlying_with_thesis,
+        stop_widened: trade.stop_widened,
+        discipline,
+    }
+}
+
+fn sub(a: Option<f64>, b: Option<f64>) -> Option<f64> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a - b),
+        _ => None,
+    }
+}
+
+/// Aggregate stats for one bucket (a setup tag or an instrument kind).
+/// Numbers appear only at n ≥ MIN_BUCKET_SAMPLE closed trades.
+#[derive(Debug, Clone, Serialize)]
+pub struct Bucket {
+    pub key: String,
+    pub trades: usize,
+    pub closed: usize,
+    pub open: usize,
+    pub stops_widened: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub win_rate_pct: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_realized_r: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub d5_forward: Option<HorizonStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+fn bucket(key: String, graded: &[&GradedTrade]) -> Bucket {
+    let closed: Vec<&&GradedTrade> = graded.iter().filter(|g| !g.open).collect();
+    let rs: Vec<f64> = closed.iter().filter_map(|g| g.realized_r).collect();
+    let d5s: Vec<f64> = graded
+        .iter()
+        .filter_map(|g| g.forward.as_ref()?.d5)
+        .collect();
+    let enough = closed.len() >= MIN_BUCKET_SAMPLE;
+    Bucket {
+        key,
+        trades: graded.len(),
+        closed: closed.len(),
+        open: graded.len() - closed.len(),
+        stops_widened: graded.iter().filter(|g| g.stop_widened).count(),
+        win_rate_pct: enough.then(|| {
+            let wins = closed
+                .iter()
+                .filter(|g| g.realized_pnl_usd.unwrap_or(0.0) > 0.0)
+                .count();
+            wins as f64 / closed.len() as f64 * 100.0
+        }),
+        avg_realized_r: (enough && !rs.is_empty())
+            .then(|| rs.iter().sum::<f64>() / rs.len() as f64),
+        d5_forward: if enough { horizon_stats(&d5s) } else { None },
+        note: (!enough).then(|| {
+            format!(
+                "insufficient sample — {} closed, need {MIN_BUCKET_SAMPLE}",
+                closed.len()
+            )
+        }),
+    }
+}
+
+/// Bucket graded trades by setup tag and by instrument kind.
+pub fn aggregate(graded: &[GradedTrade]) -> (Vec<Bucket>, Vec<Bucket>) {
+    let mut tags: Vec<String> = graded.iter().map(|g| g.setup_tag.clone()).collect();
+    tags.sort();
+    tags.dedup();
+    let by_tag = tags
+        .into_iter()
+        .map(|tag| {
+            let members: Vec<&GradedTrade> = graded.iter().filter(|g| g.setup_tag == tag).collect();
+            bucket(tag, &members)
+        })
+        .collect();
+
+    let mut kinds: Vec<&'static str> = graded.iter().map(|g| g.instrument_kind).collect();
+    kinds.sort();
+    kinds.dedup();
+    let by_kind = kinds
+        .into_iter()
+        .map(|kind| {
+            let members: Vec<&GradedTrade> = graded
+                .iter()
+                .filter(|g| g.instrument_kind == kind)
+                .collect();
+            bucket(kind.to_string(), &members)
+        })
+        .collect();
+    (by_tag, by_kind)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::trade_journal::{fold, open_event, RiskSnapshot, TradeEvent};
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    fn trade(id: &str, closed_at: Option<f64>) -> Trade {
+        let mut events = vec![open_event(
+            id.into(),
+            Utc.with_ymd_and_hms(2026, 8, 3, 14, 0, 0).unwrap(),
+            "agent".into(),
+            Instrument::Equity {
+                ticker: "NVDA".into(),
+            },
+            10.0,
+            100.0,
+            "thesis".into(),
+            "sr-support-bounce".into(),
+            95.0,
+            None,
+            Some(RiskSnapshot::new(50.0, 5000.0).unwrap()),
+        )
+        .unwrap()];
+        if let Some(exit) = closed_at {
+            events.push(TradeEvent::Closed {
+                trade_id: id.into(),
+                at: Utc.with_ymd_and_hms(2026, 8, 10, 20, 0, 0).unwrap(),
+                exit,
+                reason: CloseReason::Discretion,
+                note: None,
+            });
+        }
+        fold(&events).trades.remove(0)
+    }
+
+    fn bars_from(day: u32, closes: &[f64]) -> Vec<Bar> {
+        closes
+            .iter()
+            .enumerate()
+            .map(|(i, c)| Bar {
+                date: NaiveDate::from_ymd_opt(2026, 8, day + i as u32).unwrap(),
+                open: *c,
+                high: *c + 1.0,
+                low: *c - 1.0,
+                close: *c,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn realized_r_uses_original_stop() {
+        let g = grade(&trade("NVDA-1", Some(110.0)), None, None);
+        assert_eq!(g.realized_r, Some(2.0));
+        assert_eq!(g.realized_pnl_usd, Some(100.0));
+        assert!(g.discipline.is_empty());
+    }
+
+    #[test]
+    fn stop_overrun_is_reported_in_r() {
+        let g = grade(&trade("NVDA-1", Some(92.5)), None, None);
+        assert_eq!(g.realized_r, Some(-1.5));
+        assert_eq!(g.discipline, vec!["exited 0.5R below the original stop"]);
+    }
+
+    #[test]
+    fn equity_forward_returns_computed_from_entry_date() {
+        // entry Aug 3 @ 100; bars Aug 4..: d1 = 102
+        let bars = bars_from(4, &[102.0, 103.0, 104.0, 105.0, 106.0]);
+        let g = grade(&trade("NVDA-1", None), Some(&bars), None);
+        let fwd = g.forward.unwrap();
+        assert_eq!(fwd.d1, Some(2.0));
+        assert_eq!(fwd.d5, Some(6.0));
+        assert!(g.open);
+    }
+
+    #[test]
+    fn option_grades_underlying_direction_not_forward_returns() {
+        let opened = open_event(
+            "TSLA-1".into(),
+            Utc.with_ymd_and_hms(2026, 8, 3, 14, 0, 0).unwrap(),
+            "agent".into(),
+            Instrument::Option {
+                underlying: "TSLA".into(),
+                strike: 250.0,
+                expiry: NaiveDate::from_ymd_opt(2026, 9, 18).unwrap(),
+                kind: OptionKind::Put,
+            },
+            1.0,
+            4.20,
+            "rejection at resistance".into(),
+            "sr-resistance-reject".into(),
+            2.10,
+            None,
+            None,
+        )
+        .unwrap();
+        let t = fold(&[opened]).trades.remove(0);
+        let bars = bars_from(3, &[240.0, 238.0, 236.0, 235.0, 233.0, 231.0]);
+        let g = grade(&t, Some(&bars), None);
+        assert!(g.forward.is_none());
+        assert_eq!(g.underlying_with_thesis, Some(true));
+    }
+
+    #[test]
+    fn buckets_stay_silent_below_sample_floor() {
+        let graded: Vec<GradedTrade> = (0..5)
+            .map(|i| grade(&trade(&format!("NVDA-{i}"), Some(110.0)), None, None))
+            .collect();
+        let (by_tag, by_kind) = aggregate(&graded);
+        assert_eq!(by_tag.len(), 1);
+        assert!(by_tag[0].win_rate_pct.is_none());
+        assert!(by_tag[0].note.as_ref().unwrap().contains("insufficient"));
+        assert_eq!(by_kind[0].key, "equity");
+    }
+
+    #[test]
+    fn buckets_report_at_sample_floor() {
+        let graded: Vec<GradedTrade> = (0..MIN_BUCKET_SAMPLE)
+            .map(|i| {
+                let exit = if i % 2 == 0 { 110.0 } else { 96.0 };
+                grade(&trade(&format!("NVDA-{i}"), Some(exit)), None, None)
+            })
+            .collect();
+        let (by_tag, _) = aggregate(&graded);
+        assert_eq!(by_tag[0].win_rate_pct, Some(50.0));
+        assert!(by_tag[0].avg_realized_r.is_some());
+        assert!(by_tag[0].note.is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,16 @@ async fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
+        Command::Journal(args) => match openintel::cli::journal::run(&args).await {
+            Ok(rendered) => {
+                println!("{rendered}");
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                ExitCode::FAILURE
+            }
+        },
         Command::Dip(args) => {
             // Credentials resolve env-first, then the OS keychain (written by `openintel setup`).
             let store = KeychainStore::new();

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -210,6 +210,77 @@ impl OpenIntelServer {
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
     }
+
+    #[tool(
+        description = "Journal a trade the user just APPROVED — call this in the same moment \
+                       the order is placed, before the conversation moves on. The thesis must \
+                       be the user's why in their own words; planned_stop is required (no entry \
+                       without a stop) and refers to the traded instrument's price (premium for \
+                       options). Pass wallet_usd fresh from the broker with risk_usd so the \
+                       %-of-wallet snapshot never goes stale. A same-day duplicate (instrument \
+                       + qty + entry) is rejected with the existing id — a retry, not an error. \
+                       Writes only the local journal; never trades."
+    )]
+    async fn log_trade(
+        &self,
+        Parameters(args): Parameters<tools::LogTradeToolArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = tools::run_log_trade(args)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let json = serde_json::to_string_pretty(&out)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    }
+
+    #[tool(
+        description = "Amend an open journaled trade (append a note, move the stop or target — \
+                       the original plan stays frozen and widened stops are reported by \
+                       review_trades) or close it with an exit price and reason \
+                       (stop/target/discretion/expiry). Log the close in the same conversation \
+                       the exit happens. Writes only the local journal; never trades."
+    )]
+    async fn update_trade(
+        &self,
+        Parameters(args): Parameters<tools::UpdateTradeToolArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let out = tools::run_update_trade(args)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let json = serde_json::to_string_pretty(&out)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    }
+
+    #[tool(
+        description = "Every open journaled trade with its frozen thesis, plan, amendments, and \
+                       age — the cross-session memory. Call this FIRST in a new conversation \
+                       about trading, before proposing anything, so existing positions and \
+                       their reasoning are in context. Read-only."
+    )]
+    async fn open_positions(&self) -> Result<CallToolResult, ErrorData> {
+        let out = tools::run_open_positions()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let json = serde_json::to_string_pretty(&out)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    }
+
+    #[tool(
+        description = "Grade the whole trade journal: realized R vs the ORIGINAL stop, win \
+                       rates, discipline flags (widened stops, exits beyond the planned stop), \
+                       forward returns for equities (raw and SPY-adjusted), buckets by setup \
+                       tag and instrument. Options grade on realized P&L plus underlying \
+                       direction; crypto on realized P&L only. Honesty gates: numbers appear \
+                       only at n≥10 per bucket and conclusions need n≥30 closed trades — below \
+                       that, everything is anecdote and the report says so. Read-only."
+    )]
+    async fn review_trades(&self) -> Result<CallToolResult, ErrorData> {
+        let out = tools::run_review_trades(&self.market)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let json = serde_json::to_string_pretty(&out)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    }
 }
 
 #[tool_handler(router = self.tool_router)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -659,6 +659,256 @@ pub async fn run_dip_scan(
     }
 }
 
+// ------------------------------------------------------------ trade journal
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum InstrumentTypeArg {
+    Equity,
+    Option,
+    Crypto,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum OptionKindArg {
+    Call,
+    Put,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LogTradeToolArgs {
+    /// "equity", "option" (long only), or "crypto".
+    pub instrument_type: InstrumentTypeArg,
+    /// Ticker for equity, underlying for option, symbol for crypto.
+    pub symbol: String,
+    /// Option only: strike price.
+    pub strike: Option<f64>,
+    /// Option only: expiry as YYYY-MM-DD.
+    pub expiry: Option<String>,
+    /// Option only: "call" or "put".
+    pub option_kind: Option<OptionKindArg>,
+    /// Shares / contracts / units.
+    pub qty: f64,
+    /// Fill price of the traded instrument (premium per contract for options).
+    pub entry: f64,
+    /// The user's why, in their own words. Frozen forever at open.
+    pub thesis: String,
+    /// Free-form setup label, e.g. "sr-support-bounce".
+    pub setup_tag: String,
+    /// Exit-if price of the traded instrument, strictly below entry.
+    pub planned_stop: f64,
+    /// Optional target price, above entry.
+    pub planned_target: Option<f64>,
+    /// USD at risk on this trade (pass with wallet_usd).
+    pub risk_usd: Option<f64>,
+    /// Agentic wallet size right now, from the broker (pass with risk_usd).
+    pub wallet_usd: Option<f64>,
+    /// Skip the same-day duplicate guard (only after confirming it's a distinct trade).
+    pub allow_duplicate: Option<bool>,
+}
+
+fn instrument_from(
+    args: &LogTradeToolArgs,
+) -> Result<crate::domain::trade_journal::Instrument, DomainError> {
+    use crate::domain::trade_journal::{Instrument, OptionKind};
+    let bad = |m: &str| DomainError::SourceFailure {
+        name: "trade_journal".into(),
+        message: m.into(),
+    };
+    let symbol = args.symbol.trim().to_ascii_uppercase();
+    if symbol.is_empty() {
+        return Err(bad("symbol is required"));
+    }
+    match args.instrument_type {
+        InstrumentTypeArg::Equity => Ok(Instrument::Equity { ticker: symbol }),
+        InstrumentTypeArg::Crypto => Ok(Instrument::Crypto { symbol }),
+        InstrumentTypeArg::Option => {
+            let strike = args
+                .strike
+                .filter(|s| s.is_finite() && *s > 0.0)
+                .ok_or_else(|| bad("option needs a positive strike"))?;
+            let expiry = args
+                .expiry
+                .as_deref()
+                .and_then(|e| e.parse::<chrono::NaiveDate>().ok())
+                .ok_or_else(|| bad("option needs expiry as YYYY-MM-DD"))?;
+            let kind = match args
+                .option_kind
+                .as_ref()
+                .ok_or_else(|| bad("option needs option_kind: call or put"))?
+            {
+                OptionKindArg::Call => OptionKind::Call,
+                OptionKindArg::Put => OptionKind::Put,
+            };
+            Ok(Instrument::Option {
+                underlying: symbol,
+                strike,
+                expiry,
+                kind,
+            })
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct LogTradeOutput {
+    pub outcome: crate::application::trade_journal::LogOutcome,
+    pub framing: &'static str,
+    pub disclaimer: &'static str,
+}
+
+pub fn run_log_trade(args: LogTradeToolArgs) -> Result<LogTradeOutput, DomainError> {
+    let path = crate::application::trade_journal::default_path_or_err()?;
+    let instrument = instrument_from(&args)?;
+    let outcome = crate::application::trade_journal::log_trade(
+        &path,
+        crate::application::trade_journal::LogTradeRequest {
+            source: "agent".into(),
+            instrument,
+            qty: args.qty,
+            entry: args.entry,
+            thesis: args.thesis,
+            setup_tag: args.setup_tag,
+            planned_stop: args.planned_stop,
+            planned_target: args.planned_target,
+            risk_usd: args.risk_usd,
+            wallet_usd: args.wallet_usd,
+            allow_duplicate: args.allow_duplicate.unwrap_or(false),
+        },
+        chrono::Utc::now(),
+    )?;
+    Ok(LogTradeOutput {
+        outcome,
+        framing: "Journal entry only — nothing was traded. The thesis and plan are now frozen.",
+        disclaimer: DISCLAIMER,
+    })
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum UpdateActionArg {
+    Amend,
+    Close,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum CloseReasonArg {
+    Stop,
+    Target,
+    Discretion,
+    Expiry,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateTradeToolArgs {
+    /// Trade id returned by log_trade, e.g. "NVDA-20260821-1".
+    pub trade_id: String,
+    /// "amend" (note, optionally move stop/target) or "close".
+    pub action: UpdateActionArg,
+    /// Amend: why (required). Close: optional context.
+    pub note: Option<String>,
+    /// Amend only: new stop price. Widened stops are reported by review_trades.
+    pub new_stop: Option<f64>,
+    /// Amend only: new target price.
+    pub new_target: Option<f64>,
+    /// Close only: exit fill price.
+    pub exit: Option<f64>,
+    /// Close only: "stop", "target", "discretion", or "expiry".
+    pub reason: Option<CloseReasonArg>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateTradeOutput {
+    pub trade_id: String,
+    pub updated: &'static str,
+    pub disclaimer: &'static str,
+}
+
+pub fn run_update_trade(args: UpdateTradeToolArgs) -> Result<UpdateTradeOutput, DomainError> {
+    use crate::application::trade_journal::TradeUpdate;
+    use crate::domain::trade_journal::CloseReason;
+    let bad = |m: &str| DomainError::SourceFailure {
+        name: "trade_journal".into(),
+        message: m.into(),
+    };
+    let path = crate::application::trade_journal::default_path_or_err()?;
+    let (update, label) = match args.action {
+        UpdateActionArg::Amend => (
+            TradeUpdate::Amend {
+                note: args.note.unwrap_or_default(),
+                new_stop: args.new_stop,
+                new_target: args.new_target,
+            },
+            "amended",
+        ),
+        UpdateActionArg::Close => {
+            let exit = args.exit.ok_or_else(|| bad("close needs an exit price"))?;
+            let reason = match args
+                .reason
+                .ok_or_else(|| bad("close needs a reason: stop, target, discretion, or expiry"))?
+            {
+                CloseReasonArg::Stop => CloseReason::Stop,
+                CloseReasonArg::Target => CloseReason::Target,
+                CloseReasonArg::Discretion => CloseReason::Discretion,
+                CloseReasonArg::Expiry => CloseReason::Expiry,
+            };
+            (
+                TradeUpdate::Close {
+                    exit,
+                    reason,
+                    note: args.note,
+                },
+                "closed",
+            )
+        }
+    };
+    crate::application::trade_journal::update_trade(
+        &path,
+        &args.trade_id,
+        update,
+        chrono::Utc::now(),
+    )?;
+    Ok(UpdateTradeOutput {
+        trade_id: args.trade_id,
+        updated: label,
+        disclaimer: DISCLAIMER,
+    })
+}
+
+#[derive(Debug, Serialize)]
+pub struct OpenPositionsOutput {
+    pub report: crate::application::trade_journal::PositionsReport,
+    pub disclaimer: &'static str,
+}
+
+pub fn run_open_positions() -> Result<OpenPositionsOutput, DomainError> {
+    let path = crate::application::trade_journal::default_path_or_err()?;
+    Ok(OpenPositionsOutput {
+        report: crate::application::trade_journal::open_positions(&path),
+        disclaimer: DISCLAIMER,
+    })
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReviewTradesOutput {
+    pub report: crate::application::trade_journal::TradeReviewReport,
+    pub disclaimer: &'static str,
+}
+
+pub async fn run_review_trades(
+    bars: &dyn crate::domain::ports::bar_source::BarSource,
+) -> Result<ReviewTradesOutput, DomainError> {
+    let path = crate::application::trade_journal::default_path_or_err()?;
+    let report =
+        crate::application::trade_journal::review_trades(&path, bars, chrono::Utc::now()).await?;
+    Ok(ReviewTradesOutput {
+        report,
+        disclaimer: DISCLAIMER,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Closes #62. Plan (approved): https://fc9ipmy5qfk4.postplan.dev

## Problem

Nothing holds state between agent chat sessions. A trade placed through the agent + broker-MCP loop leaves no record of the thesis, the planned exit, or the risk frame that justified it — the next session starts blind, and there is never evidence of whether the edge is real.

## Solution

An append-only event journal at `~/.openintel/trade_journal.jsonl`. A trade is a fold over its `opened` / `amended` / `closed` events; the thesis and plan are frozen at open and can never be rewritten to match the outcome.

- **`domain/trade_journal.rs`** — instrument enum (equity / long option / crypto, matching what a Robinhood agentic account can hold), validated open events (no entry without a stop; stop strictly below entry so risk-per-unit is never zero), fold with per-event errors (unknown id, double close, amend-after-close never panic), same-day duplicate guard for agent retries.
- **`domain/trade_review.rs`** — realized R vs the **original** stop (amendments never soften the grade), discipline flags (widened stops, exits beyond the planned stop), SPY-adjusted 1/5/10-day forward returns for equities (reusing `dip_review` machinery), buckets by setup tag and instrument. Honesty gates: numbers at n ≥ 10 per bucket, conclusions at n ≥ 30 — below that the report calls itself anecdote. Options grade on realized P&L + underlying direction (historical option prices aren't keyless); crypto on realized P&L only.
- **`application/trade_journal.rs`** — IO edge: JSONL append/read, timestamp + `{SYMBOL}-{yyyymmdd}-{n}` id stamping, concurrent bar fetches for review.
- **MCP**: `log_trade` / `update_trade` / `open_positions` / `review_trades`, descriptions contracting the agent to journal at the moment of user approval and to call `open_positions` first in a new conversation.
- **CLI**: `openintel journal log | amend | close | positions | review` as the manual fallback.
- README: new section + four MCP table rows.

Tests: 21 new (domain fold/validation/grading/buckets, application flows against temp dirs, CLI rendering). Smoke-tested end to end against an isolated `HOME`, including a live-Yahoo `review`. `cargo test` (276), `clippy -D warnings`, `fmt` all green.

---
Changes made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a trade journal for recording, amending, closing, and tracking equity, options, and crypto trades.
  * Added validation, duplicate protection, risk tracking, and support for zero-value expiry exits.
  * Added open-position listings and performance reviews with realized results, forward returns, discipline warnings, and setup/instrument metrics.
  * Added `journal` CLI commands with table and JSON output.
  * Added trade-journal tools for MCP integrations.
* **Documentation**
  * Documented journal workflows, review metrics, commands, supported instruments, and available tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->