### PR TITLE
feat(discover): movers discovery — screens with evidence, never picks

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,34 @@ not-holdable-overnight note. Single-position model; interest not modeled.
 Data: Yahoo screener + news (keyless, unofficial — failure mode is a clean error) and SEC
 EDGAR (keyless, official; identify yourself via `OPENINTEL_SEC_CONTACT` if you fork this).
 
+## Discover (movers with evidence, never picks)
+
+Answer "where are trades today?" without a ticker. `openintel discover` pulls Yahoo's
+predefined screens (gainers, losers, most actives — keyless), applies the same quality
+floor as `dip`, and annotates a bounded slice (default 9, `--deep`) with evidence:
+
+- **Tape:** day change, RVOL, ATR-stretch vs SMA20, RSI(14).
+- **Period extremes:** distance in ATRs to the 3-month and ~1-year high/low — a cheap
+  proxy for where the crowd's reference points sit, **not** support/resistance; real
+  levels are yours to draw. The output states the actual span covered, never assumes a
+  full year.
+- **Catalyst gates:** same-day SEC filings (EDGAR) and company-referencing catalyst
+  headlines, with the usual fail-closed `unknown` when evidence can't be fetched.
+- **Attention:** social mentions + net sentiment where sources are configured —
+  crowding context, not a signal.
+
+No ranking, no verdicts, no picks — the evidence is the product. Losers carry a pointer
+to `dip_scan` for the gated verdict instead of restating it.
+
+```bash
+openintel discover                          # all three screens
+openintel discover --screens losers --deep 5
+openintel discover --format json
+```
+
+Also exposed as the `discover` MCP tool. A chatter mode (mention velocity from a
+curated cross-platform listening set) is planned next.
+
 ## Trade journal (frozen theses, graded record)
 
 An append-only journal at `~/.openintel/trade_journal.jsonl`: every trade is logged with
@@ -202,6 +230,7 @@ Tools exposed (all **read-only** — OpenIntel never places trades):
 | `risk_frame` | ATR stop + budget-capped size + R targets for one trade idea |
 | `dip_scan` | Day's biggest losers → gated dip-setup verdicts (`no_setup`/`watch`/`high_confidence`), optional margin-aware sizing; pass `ticker` for one symbol |
 | `dip_review` | Grade the dip journal against forward returns (raw + SPY-adjusted, per verdict) — the evidence check on dip_scan's v0 score |
+| `discover` | Today's movers (gainers/losers/actives) with evidence attached: tape, period extremes in ATRs, catalyst gates, attention — no ranking, no picks |
 | `log_trade` | Journal an approved trade at the moment it's placed: frozen thesis, required stop, risk-of-wallet snapshot; same-day duplicate guard |
 | `update_trade` | Amend an open trade (note, move stop/target — original plan stays frozen) or close it with exit + reason |
 | `open_positions` | Every open trade with its frozen thesis, plan, and amendments — call first in a new chat; the cross-session memory |

--- a/src/adapters/market/mock_movers.rs
+++ b/src/adapters/market/mock_movers.rs
@@ -2,9 +2,9 @@ use async_trait::async_trait;
 
 use crate::domain::error::DomainError;
 use crate::domain::ports::movers_source::MoversSource;
-use crate::domain::values::mover::MoverRow;
+use crate::domain::values::mover::{MoverRow, ScreenKind};
 
-/// Test double: a fixed losers list (already worst-first).
+/// Test double: one fixed list served for every screen kind.
 pub struct MockMoversSource(pub Vec<MoverRow>);
 
 #[async_trait]
@@ -13,7 +13,7 @@ impl MoversSource for MockMoversSource {
         "mock-movers"
     }
 
-    async fn day_losers(&self, count: usize) -> Result<Vec<MoverRow>, DomainError> {
+    async fn screen(&self, _kind: ScreenKind, count: usize) -> Result<Vec<MoverRow>, DomainError> {
         Ok(self.0.iter().take(count).cloned().collect())
     }
 }

--- a/src/adapters/market/yahoo/mod.rs
+++ b/src/adapters/market/yahoo/mod.rs
@@ -47,8 +47,9 @@ impl YahooMarketSource {
     async fn fetch_chart(
         &self,
         ticker: &Ticker,
+        range: &str,
     ) -> Result<(reqwest::StatusCode, String), DomainError> {
-        let url = format!("{BASE_URL}/{}?range=3mo&interval=1d", ticker.as_str());
+        let url = format!("{BASE_URL}/{}?range={range}&interval=1d", ticker.as_str());
 
         let resp = self
             .client
@@ -70,8 +71,8 @@ impl YahooMarketSource {
 
     /// The chart body alone, for consumers (like `bars`) that don't need
     /// HTTP-status-aware error enrichment.
-    async fn fetch_chart_body(&self, ticker: &Ticker) -> Result<String, DomainError> {
-        self.fetch_chart(ticker).await.map(|(_, body)| body)
+    async fn fetch_chart_body(&self, ticker: &Ticker, range: &str) -> Result<String, DomainError> {
+        self.fetch_chart(ticker, range).await.map(|(_, body)| body)
     }
 
     async fn fetch_body(&self, name: &str, url: String) -> Result<String, DomainError> {
@@ -107,7 +108,7 @@ impl MarketDataSource for YahooMarketSource {
 
     async fn snapshot(&self, ticker: &Ticker) -> Result<MarketSnapshot, DomainError> {
         let fetched_at = Utc::now();
-        let (status, body) = self.fetch_chart(ticker).await?;
+        let (status, body) = self.fetch_chart(ticker, "3mo").await?;
         to_snapshot(status, &body, ticker, fetched_at)
     }
 }
@@ -115,7 +116,12 @@ impl MarketDataSource for YahooMarketSource {
 #[async_trait]
 impl BarSource for YahooMarketSource {
     async fn bars(&self, ticker: &Ticker) -> Result<Vec<Bar>, DomainError> {
-        let body = self.fetch_chart_body(ticker).await?;
+        let body = self.fetch_chart_body(ticker, "3mo").await?;
+        response::parse_bars(&body)
+    }
+
+    async fn bars_long(&self, ticker: &Ticker) -> Result<Vec<Bar>, DomainError> {
+        let body = self.fetch_chart_body(ticker, "1y").await?;
         response::parse_bars(&body)
     }
 }
@@ -126,9 +132,19 @@ impl MoversSource for YahooMarketSource {
         "yahoo-screener"
     }
 
-    async fn day_losers(&self, count: usize) -> Result<Vec<MoverRow>, DomainError> {
+    async fn screen(
+        &self,
+        kind: crate::domain::values::mover::ScreenKind,
+        count: usize,
+    ) -> Result<Vec<MoverRow>, DomainError> {
+        use crate::domain::values::mover::ScreenKind;
+        let scr_id = match kind {
+            ScreenKind::DayGainers => "day_gainers",
+            ScreenKind::DayLosers => "day_losers",
+            ScreenKind::MostActives => "most_actives",
+        };
         let count = count.clamp(1, MAX_SCREENER_ROWS);
-        let url = format!("{SCREENER_URL}?scrIds=day_losers&count={count}");
+        let url = format!("{SCREENER_URL}?scrIds={scr_id}&count={count}");
         let body = self.fetch_body("yahoo-screener", url).await?;
         screener::parse_movers(&body).map(|(rows, _skipped)| rows)
     }
@@ -209,7 +225,10 @@ mod tests {
     #[ignore = "hits live Yahoo (keyless, free); run with --ignored"]
     async fn live_day_losers_returns_rows() {
         let src = YahooMarketSource::new().unwrap();
-        let rows = src.day_losers(100).await.unwrap();
+        let rows = src
+            .screen(crate::domain::values::mover::ScreenKind::DayLosers, 100)
+            .await
+            .unwrap();
         assert!(rows.len() >= 50, "got {}", rows.len());
         assert!(rows.iter().all(|r| r.change_pct < 0.0));
     }

--- a/src/adapters/market/yahoo/screener.rs
+++ b/src/adapters/market/yahoo/screener.rs
@@ -1,4 +1,4 @@
-//! Parser for Yahoo's predefined `day_losers` screener (keyless, unofficial —
+//! Parser for Yahoo's predefined mover screeners (keyless, unofficial —
 //! failure mode is a clean error, never a partial silent result).
 
 use serde::Deserialize;

--- a/src/application/dip.rs
+++ b/src/application/dip.rs
@@ -172,7 +172,7 @@ async fn spx_change(bars_src: &dyn BarSource) -> Result<f64, DomainError> {
 
 /// Social-only sentiment for the divergence component. Any failure (including
 /// "no posts") degrades to None — the domain scores divergence 0 with a note.
-async fn sentiment_for(
+pub(crate) async fn sentiment_for(
     ticker: &str,
     social: &[Box<dyn SocialDataSource>],
 ) -> Option<SentimentSummary> {
@@ -353,7 +353,12 @@ pub async fn dip_scan(
     deps: &DipDeps<'_>,
     now: DateTime<Utc>,
 ) -> Result<DipScanReport, DomainError> {
-    let rows = movers.day_losers(req.count).await?;
+    let rows = movers
+        .screen(
+            crate::domain::values::mover::ScreenKind::DayLosers,
+            req.count,
+        )
+        .await?;
     let universe_size = rows.len();
     let mut notes: Vec<String> = Vec::new();
 

--- a/src/application/discover.rs
+++ b/src/application/discover.rs
@@ -234,8 +234,17 @@ pub async fn discover(
     let count = req.count.clamp(1, 100);
     let now_ms = now.timestamp_millis();
 
+    // Order-preserving dedupe: a repeated screen would double-fetch upstream
+    // and then collide on the index map below.
+    let mut screens: Vec<ScreenKind> = Vec::new();
+    for kind in &req.screens {
+        if !screens.contains(kind) {
+            screens.push(*kind);
+        }
+    }
+
     let fetched: Vec<(ScreenKind, Result<Vec<MoverRow>, DomainError>)> = futures::stream::iter(
-        req.screens
+        screens
             .clone()
             .into_iter()
             .map(|kind| async move { (kind, deps.movers.screen(kind, count).await) }),
@@ -247,7 +256,7 @@ pub async fn discover(
     let mut by_kind: BTreeMap<usize, (ScreenKind, Result<Vec<MoverRow>, DomainError>)> =
         BTreeMap::new();
     for entry in fetched {
-        let idx = req.screens.iter().position(|k| *k == entry.0).unwrap_or(0);
+        let idx = screens.iter().position(|k| *k == entry.0).unwrap_or(0);
         by_kind.insert(idx, entry);
     }
 
@@ -449,6 +458,27 @@ mod tests {
         assert!((both[0].rvol.unwrap() - 2.0).abs() < 1e-12);
         assert!(report.notes.iter().any(|n| n.contains("dip_scan")));
         assert!(report.notes.iter().any(|n| n.contains("no social sources")));
+    }
+
+    #[tokio::test]
+    async fn duplicate_screens_collapse_to_one_fetch() {
+        let news = quiet_news();
+        let filings = MockFilingsSource(Ok(vec![]));
+        let deps = DiscoverDeps {
+            movers: &ScreenedMovers,
+            bars: &FixedBars,
+            news: &news,
+            filings: &filings,
+            social: &[],
+        };
+        let req = DiscoverRequest {
+            screens: vec![ScreenKind::DayLosers, ScreenKind::DayLosers],
+            ..DiscoverRequest::default()
+        };
+        let report = discover(&req, &deps, now()).await.unwrap();
+        assert_eq!(report.screens.len(), 1);
+        assert_eq!(report.candidates.len(), 1);
+        assert_eq!(report.candidates[0].ticker, "DOWN");
     }
 
     #[tokio::test]

--- a/src/application/discover.rs
+++ b/src/application/discover.rs
@@ -1,0 +1,491 @@
+//! IO edge for `discover` movers mode: pull the predefined screens, floor the
+//! merged universe, and annotate a bounded slice with tape context, period
+//! extremes, catalyst gates, and social attention. Evidence only — no
+//! ranking, no verdicts; losers point at dip_scan for the gated verdict.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+use serde::Serialize;
+
+use crate::domain::dip::{
+    apply_floor, filing_gate, headline_gate, rsi_cutler, sma, GateEvidence, GateStatus,
+    QualityFloor, SentimentSummary,
+};
+use crate::domain::discover::{allocate_deep, period_extremes, PeriodExtremes};
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::bar_source::BarSource;
+use crate::domain::ports::filings_source::FilingsSource;
+use crate::domain::ports::movers_source::MoversSource;
+use crate::domain::ports::news_source::NewsSource;
+use crate::domain::ports::social_data_source::SocialDataSource;
+use crate::domain::risk::{atr, ATR_PERIOD};
+use crate::domain::values::mover::{MoverRow, ScreenKind};
+
+const CONCURRENCY: usize = 4;
+const HEADLINE_COUNT: usize = 20;
+const SMA_PERIOD: usize = 20;
+const RSI_PERIOD: usize = 14;
+const DAYS_3MO: usize = 63;
+const DAYS_1Y: usize = 252;
+
+pub const FRAMING: &str = "discover surfaces candidates with evidence — it never ranks, \
+     never predicts, and never recommends. For gated dip verdicts on losers, run dip_scan.";
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "discover".into(),
+        message: message.into(),
+    }
+}
+
+pub struct DiscoverDeps<'a> {
+    pub movers: &'a dyn MoversSource,
+    pub bars: &'a dyn BarSource,
+    pub news: &'a dyn NewsSource,
+    pub filings: &'a dyn FilingsSource,
+    pub social: &'a [Box<dyn SocialDataSource>],
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoverRequest {
+    pub screens: Vec<ScreenKind>,
+    /// Rows pulled per screen (1-100).
+    pub count: usize,
+    /// Total candidates deep-annotated, spread round-robin across screens.
+    pub deep: usize,
+    pub floor: QualityFloor,
+}
+
+impl Default for DiscoverRequest {
+    fn default() -> Self {
+        Self {
+            screens: vec![
+                ScreenKind::DayGainers,
+                ScreenKind::DayLosers,
+                ScreenKind::MostActives,
+            ],
+            count: 25,
+            deep: 9,
+            floor: QualityFloor::default(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScreenSummary {
+    pub screen: ScreenKind,
+    pub universe: usize,
+    pub floor_rejects: usize,
+    pub annotated: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CatalystCheck {
+    pub filings: GateStatus,
+    pub headlines: GateStatus,
+    pub evidence: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Candidate {
+    pub ticker: String,
+    /// Which screens surfaced it (a symbol can appear in more than one).
+    pub screens: Vec<ScreenKind>,
+    pub change_pct: f64,
+    pub price: f64,
+    /// Day volume over 3-month average.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rvol: Option<f64>,
+    /// (SMA20 − last) / ATR — positive = stretched below its mean.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stretch_atr: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rsi14: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extremes_3mo: Option<PeriodExtremes>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extremes_1y: Option<PeriodExtremes>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalyst: Option<CatalystCheck>,
+    /// Social attention where sources are configured — crowding context, not
+    /// a signal.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sentiment: Option<SentimentSummary>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DiscoverReport {
+    pub generated_at: DateTime<Utc>,
+    pub screens: Vec<ScreenSummary>,
+    pub candidates: Vec<Candidate>,
+    pub errors: Vec<String>,
+    pub notes: Vec<String>,
+}
+
+async fn annotate(row: &MoverRow, screens: Vec<ScreenKind>, deps: &DiscoverDeps<'_>) -> Candidate {
+    let mut notes = Vec::new();
+    let ticker = match Ticker::parse(&row.symbol) {
+        Ok(t) => t,
+        Err(e) => {
+            return Candidate {
+                ticker: row.symbol.clone(),
+                screens,
+                change_pct: row.change_pct,
+                price: row.price,
+                rvol: rvol_of(row),
+                stretch_atr: None,
+                rsi14: None,
+                extremes_3mo: None,
+                extremes_1y: None,
+                catalyst: None,
+                sentiment: None,
+                notes: vec![format!("unparseable symbol: {e}")],
+            }
+        }
+    };
+
+    let (mut stretch, mut rsi14, mut e3, mut e1y) = (None, None, None, None);
+    match deps.bars.bars_long(&ticker).await {
+        Err(e) => notes.push(format!("bars unavailable: {e}")),
+        Ok(bars) => {
+            let closes: Vec<f64> = bars.iter().map(|b| b.close).collect();
+            match atr(&bars, ATR_PERIOD).filter(|a| *a > 0.0) {
+                None => notes.push("not enough history for ATR — levels unscored".into()),
+                Some(atr14) => {
+                    stretch = sma(&closes, SMA_PERIOD).map(|s| (s - row.price) / atr14);
+                    e3 = period_extremes(&bars, row.price, atr14, DAYS_3MO);
+                    e1y = period_extremes(&bars, row.price, atr14, DAYS_1Y);
+                    // A real trading year is ~250 days; only flag a span that
+                    // is meaningfully shorter (young listing, thin history).
+                    if e1y.as_ref().is_some_and(|e| e.days < 200) {
+                        notes.push(format!(
+                            "long-range extremes cover only {} trading days, not a full year",
+                            e1y.as_ref().map(|e| e.days).unwrap_or(0)
+                        ));
+                    }
+                }
+            }
+            rsi14 = rsi_cutler(&closes, RSI_PERIOD);
+        }
+    }
+
+    let today = Utc::now()
+        .with_timezone(&chrono_tz::America::New_York)
+        .date_naive();
+    let since = today.pred_opt().unwrap_or(today);
+    let filings = match deps.filings.recent_filings(&ticker, since).await {
+        Ok(f) => GateEvidence::Available(f),
+        Err(e) => GateEvidence::Unavailable(e.to_string()),
+    };
+    let (headlines, company_names) = match deps.news.headlines(&ticker, HEADLINE_COUNT).await {
+        Ok(fetch) => (
+            GateEvidence::Available(fetch.headlines),
+            fetch.company_names,
+        ),
+        Err(e) => (GateEvidence::Unavailable(e.to_string()), Vec::new()),
+    };
+    let (filing_status, mut evidence) = filing_gate(&filings, since);
+    let (headline_status, headline_evidence) =
+        headline_gate(&headlines, ticker.as_str(), &company_names);
+    evidence.extend(headline_evidence);
+    let catalyst = Some(CatalystCheck {
+        filings: filing_status,
+        headlines: headline_status,
+        evidence,
+    });
+
+    let sentiment = crate::application::dip::sentiment_for(ticker.as_str(), deps.social).await;
+
+    Candidate {
+        ticker: ticker.as_str().to_string(),
+        screens,
+        change_pct: row.change_pct,
+        price: row.price,
+        rvol: rvol_of(row),
+        stretch_atr: stretch,
+        rsi14,
+        extremes_3mo: e3,
+        extremes_1y: e1y,
+        catalyst,
+        sentiment,
+        notes,
+    }
+}
+
+fn rvol_of(row: &MoverRow) -> Option<f64> {
+    match (row.day_volume, row.avg_volume_3mo) {
+        (Some(day), Some(avg)) if avg > 0 => Some(day as f64 / avg as f64),
+        _ => None,
+    }
+}
+
+pub async fn discover(
+    req: &DiscoverRequest,
+    deps: &DiscoverDeps<'_>,
+    now: DateTime<Utc>,
+) -> Result<DiscoverReport, DomainError> {
+    if req.screens.is_empty() {
+        return Err(fail("at least one screen is required"));
+    }
+    let count = req.count.clamp(1, 100);
+    let now_ms = now.timestamp_millis();
+
+    let fetched: Vec<(ScreenKind, Result<Vec<MoverRow>, DomainError>)> = futures::stream::iter(
+        req.screens
+            .clone()
+            .into_iter()
+            .map(|kind| async move { (kind, deps.movers.screen(kind, count).await) }),
+    )
+    .buffer_unordered(CONCURRENCY)
+    .collect()
+    .await;
+    // buffer_unordered scrambles completion order; restore request order.
+    let mut by_kind: BTreeMap<usize, (ScreenKind, Result<Vec<MoverRow>, DomainError>)> =
+        BTreeMap::new();
+    for entry in fetched {
+        let idx = req.screens.iter().position(|k| *k == entry.0).unwrap_or(0);
+        by_kind.insert(idx, entry);
+    }
+
+    let mut errors = Vec::new();
+    let mut summaries = Vec::new();
+    // Per screen: floored rows in provider order, minus symbols already taken
+    // by an earlier screen (first screen wins; later screens tag on).
+    let mut groups: Vec<(ScreenKind, Vec<MoverRow>)> = Vec::new();
+    let mut seen: Vec<String> = Vec::new();
+    let mut extra_tags: BTreeMap<String, Vec<ScreenKind>> = BTreeMap::new();
+
+    for (_, (kind, result)) in by_kind {
+        match result {
+            Err(e) => {
+                errors.push(format!("{}: screen failed: {e}", kind.label()));
+                summaries.push(ScreenSummary {
+                    screen: kind,
+                    universe: 0,
+                    floor_rejects: 0,
+                    annotated: 0,
+                });
+            }
+            Ok(rows) => {
+                let universe = rows.len();
+                let (passed, rejects) = apply_floor(&rows, &req.floor, now_ms);
+                let mut fresh = Vec::new();
+                for row in passed {
+                    if seen.contains(&row.symbol) {
+                        extra_tags.entry(row.symbol.clone()).or_default().push(kind);
+                    } else {
+                        seen.push(row.symbol.clone());
+                        fresh.push(row);
+                    }
+                }
+                summaries.push(ScreenSummary {
+                    screen: kind,
+                    universe,
+                    floor_rejects: rejects.len(),
+                    annotated: 0,
+                });
+                groups.push((kind, fresh));
+            }
+        }
+    }
+
+    let sizes: Vec<usize> = groups.iter().map(|(_, rows)| rows.len()).collect();
+    let alloc = allocate_deep(&sizes, req.deep.clamp(1, 25));
+
+    let mut picks: Vec<(ScreenKind, MoverRow)> = Vec::new();
+    for ((kind, rows), take) in groups.into_iter().zip(alloc) {
+        if let Some(s) = summaries.iter_mut().find(|s| s.screen == kind) {
+            s.annotated = take;
+        }
+        picks.extend(rows.into_iter().take(take).map(|r| (kind, r)));
+    }
+
+    let mut indexed: Vec<(usize, Candidate)> =
+        futures::stream::iter(picks.into_iter().enumerate().map(|(i, (kind, row))| {
+            let mut screens = vec![kind];
+            if let Some(extra) = extra_tags.get(&row.symbol) {
+                screens.extend(extra.iter().copied());
+            }
+            async move { (i, annotate(&row, screens, deps).await) }
+        }))
+        .buffer_unordered(CONCURRENCY)
+        .collect()
+        .await;
+    // Restore pick order after concurrent annotation.
+    indexed.sort_by_key(|(i, _)| *i);
+    let candidates: Vec<Candidate> = indexed.into_iter().map(|(_, c)| c).collect();
+
+    let mut notes = Vec::new();
+    if candidates
+        .iter()
+        .any(|c| c.screens.contains(&ScreenKind::DayLosers))
+    {
+        notes.push(
+            "losers shown here carry no verdict — run dip_scan for the gated dip-setup grading"
+                .into(),
+        );
+    }
+    if deps.social.is_empty() {
+        notes.push("no social sources configured — attention column unavailable".into());
+    }
+
+    Ok(DiscoverReport {
+        generated_at: now,
+        screens: summaries,
+        candidates,
+        errors,
+        notes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::filings::mock_filings::MockFilingsSource;
+    use crate::adapters::market::mock_news::MockNewsSource;
+    use crate::domain::ports::news_source::NewsFetch;
+    use crate::domain::values::bar::Bar;
+    use crate::domain::values::mover::MoverRow;
+    use async_trait::async_trait;
+    use chrono::{NaiveDate, TimeZone};
+
+    struct FixedBars;
+
+    #[async_trait]
+    impl BarSource for FixedBars {
+        async fn bars(&self, _t: &Ticker) -> Result<Vec<Bar>, DomainError> {
+            Ok((0..40)
+                .map(|i| Bar {
+                    date: NaiveDate::from_ymd_opt(2026, 6, 1)
+                        .unwrap()
+                        .checked_add_days(chrono::Days::new(i))
+                        .unwrap(),
+                    open: 55.0,
+                    high: 60.0,
+                    low: 50.0,
+                    close: 55.0,
+                })
+                .collect())
+        }
+    }
+
+    fn quiet_news() -> MockNewsSource {
+        MockNewsSource(Ok(NewsFetch {
+            headlines: vec![],
+            company_names: vec![],
+        }))
+    }
+
+    struct ScreenedMovers;
+
+    #[async_trait]
+    impl MoversSource for ScreenedMovers {
+        fn name(&self) -> &str {
+            "screened"
+        }
+        async fn screen(
+            &self,
+            kind: ScreenKind,
+            _count: usize,
+        ) -> Result<Vec<MoverRow>, DomainError> {
+            let row = |symbol: &str, change: f64| MoverRow {
+                symbol: symbol.into(),
+                change_pct: change,
+                price: 50.0,
+                market_cap: Some(2_000_000_000),
+                avg_volume_3mo: Some(5_000_000),
+                day_volume: Some(10_000_000),
+                exchange: "NYSE".into(),
+                first_trade_ms: Some(0),
+            };
+            Ok(match kind {
+                ScreenKind::DayGainers => vec![row("UPUP", 12.0), row("BOTH", 6.0)],
+                ScreenKind::DayLosers => vec![row("DOWN", -9.0)],
+                ScreenKind::MostActives => vec![row("BOTH", 6.0), row("BUSY", 1.0)],
+            })
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 21, 21, 0, 0).unwrap()
+    }
+
+    #[tokio::test]
+    async fn discover_merges_screens_dedupes_and_notes_losers() {
+        let news = quiet_news();
+        let filings = MockFilingsSource(Ok(vec![]));
+        let deps = DiscoverDeps {
+            movers: &ScreenedMovers,
+            bars: &FixedBars,
+            news: &news,
+            filings: &filings,
+            social: &[],
+        };
+        let report = discover(&DiscoverRequest::default(), &deps, now())
+            .await
+            .unwrap();
+
+        assert_eq!(report.screens.len(), 3);
+        let tickers: Vec<&str> = report
+            .candidates
+            .iter()
+            .map(|c| c.ticker.as_str())
+            .collect();
+        assert!(tickers.contains(&"UPUP"));
+        assert!(tickers.contains(&"DOWN"));
+        // BOTH appears once, tagged with both screens.
+        let both: Vec<&Candidate> = report
+            .candidates
+            .iter()
+            .filter(|c| c.ticker == "BOTH")
+            .collect();
+        assert_eq!(both.len(), 1);
+        assert!(both[0].screens.contains(&ScreenKind::DayGainers));
+        assert!(both[0].screens.contains(&ScreenKind::MostActives));
+        assert!((both[0].rvol.unwrap() - 2.0).abs() < 1e-12);
+        assert!(report.notes.iter().any(|n| n.contains("dip_scan")));
+        assert!(report.notes.iter().any(|n| n.contains("no social sources")));
+    }
+
+    #[tokio::test]
+    async fn screen_failure_is_an_error_not_a_sunk_run() {
+        struct HalfBroken;
+        #[async_trait]
+        impl MoversSource for HalfBroken {
+            fn name(&self) -> &str {
+                "half"
+            }
+            async fn screen(
+                &self,
+                kind: ScreenKind,
+                count: usize,
+            ) -> Result<Vec<MoverRow>, DomainError> {
+                match kind {
+                    ScreenKind::DayGainers => Err(DomainError::SourceFailure {
+                        name: "x".into(),
+                        message: "boom".into(),
+                    }),
+                    _ => ScreenedMovers.screen(kind, count).await,
+                }
+            }
+        }
+        let news = quiet_news();
+        let filings = MockFilingsSource(Ok(vec![]));
+        let deps = DiscoverDeps {
+            movers: &HalfBroken,
+            bars: &FixedBars,
+            news: &news,
+            filings: &filings,
+            social: &[],
+        };
+        let report = discover(&DiscoverRequest::default(), &deps, now())
+            .await
+            .unwrap();
+        assert!(report.errors.iter().any(|e| e.contains("gainers")));
+        assert!(!report.candidates.is_empty());
+    }
+}

--- a/src/application/discover.rs
+++ b/src/application/discover.rs
@@ -462,10 +462,26 @@ mod tests {
 
     #[tokio::test]
     async fn duplicate_screens_collapse_to_one_fetch() {
+        struct CountingMovers(std::sync::atomic::AtomicUsize);
+        #[async_trait]
+        impl MoversSource for CountingMovers {
+            fn name(&self) -> &str {
+                "counting"
+            }
+            async fn screen(
+                &self,
+                kind: ScreenKind,
+                count: usize,
+            ) -> Result<Vec<MoverRow>, DomainError> {
+                self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                ScreenedMovers.screen(kind, count).await
+            }
+        }
+        let movers = CountingMovers(std::sync::atomic::AtomicUsize::new(0));
         let news = quiet_news();
         let filings = MockFilingsSource(Ok(vec![]));
         let deps = DiscoverDeps {
-            movers: &ScreenedMovers,
+            movers: &movers,
             bars: &FixedBars,
             news: &news,
             filings: &filings,
@@ -476,6 +492,7 @@ mod tests {
             ..DiscoverRequest::default()
         };
         let report = discover(&req, &deps, now()).await.unwrap();
+        assert_eq!(movers.0.load(std::sync::atomic::Ordering::SeqCst), 1);
         assert_eq!(report.screens.len(), 1);
         assert_eq!(report.candidates.len(), 1);
         assert_eq!(report.candidates[0].ticker, "DOWN");

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,5 +1,6 @@
 pub mod analyze;
 pub mod dip;
+pub mod discover;
 pub mod pulse;
 pub mod request;
 pub mod review;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -35,6 +35,9 @@ pub enum Command {
 
     /// Trade journal: log entries with a frozen thesis, track positions, grade the record
     Journal(JournalArgs),
+
+    /// Surface today's movers with evidence attached (period extremes, catalyst gates — never picks)
+    Discover(DiscoverArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -208,6 +211,31 @@ pub struct DipArgs {
     /// Skip the scan journal (~/.openintel/dip_journal.jsonl)
     #[arg(long)]
     pub no_journal: bool,
+
+    #[arg(long, value_enum, default_value_t = FormatArg::Table)]
+    pub format: FormatArg,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScreenArg {
+    Gainers,
+    Losers,
+    Actives,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct DiscoverArgs {
+    /// Screens to pull, comma-separated (default: all three)
+    #[arg(long, value_enum, value_delimiter = ',')]
+    pub screens: Vec<ScreenArg>,
+
+    /// Rows pulled per screen (1-100)
+    #[arg(long, default_value_t = 25)]
+    pub count: usize,
+
+    /// Total candidates deep-annotated across screens (1-25)
+    #[arg(long, default_value_t = 9)]
+    pub deep: usize,
 
     #[arg(long, value_enum, default_value_t = FormatArg::Table)]
     pub format: FormatArg,

--- a/src/cli/discover.rs
+++ b/src/cli/discover.rs
@@ -1,0 +1,241 @@
+//! CLI leaf for `openintel discover` — returns rendered Strings; main prints.
+
+use std::fmt::Write as _;
+
+use chrono::Utc;
+
+use crate::adapters::filings::edgar::EdgarSource;
+use crate::adapters::market::yahoo::YahooMarketSource;
+use crate::application::discover::{
+    discover, Candidate, DiscoverDeps, DiscoverReport, DiscoverRequest, FRAMING,
+};
+use crate::application::DISCLAIMER;
+use crate::cli::args::{DiscoverArgs, FormatArg, ScreenArg};
+use crate::config::secrets::Credentials;
+use crate::domain::dip::GateStatus;
+use crate::domain::error::DomainError;
+
+pub async fn run(args: &DiscoverArgs, credentials: &Credentials) -> Result<String, DomainError> {
+    let yahoo = YahooMarketSource::new()?;
+    let edgar = EdgarSource::new()?;
+    let social = crate::adapters::sources::build_social_sources(credentials);
+    let deps = DiscoverDeps {
+        movers: &yahoo,
+        bars: &yahoo,
+        news: &yahoo,
+        filings: &edgar,
+        social: &social,
+    };
+    let mut req = DiscoverRequest {
+        count: args.count,
+        deep: args.deep,
+        ..DiscoverRequest::default()
+    };
+    if !args.screens.is_empty() {
+        req.screens = args.screens.iter().map(|s| s.kind()).collect();
+    }
+    let report = discover(&req, &deps, Utc::now()).await?;
+    Ok(match args.format {
+        FormatArg::Table => render_table(&report),
+        FormatArg::Json => render_json(&report)?,
+    })
+}
+
+impl ScreenArg {
+    pub fn kind(&self) -> crate::domain::values::mover::ScreenKind {
+        use crate::domain::values::mover::ScreenKind;
+        match self {
+            ScreenArg::Gainers => ScreenKind::DayGainers,
+            ScreenArg::Losers => ScreenKind::DayLosers,
+            ScreenArg::Actives => ScreenKind::MostActives,
+        }
+    }
+}
+
+fn render_json(report: &DiscoverReport) -> Result<String, DomainError> {
+    #[derive(serde::Serialize)]
+    struct Out<'a> {
+        report: &'a DiscoverReport,
+        framing: &'static str,
+        disclaimer: &'static str,
+    }
+    serde_json::to_string_pretty(&Out {
+        report,
+        framing: FRAMING,
+        disclaimer: DISCLAIMER,
+    })
+    .map_err(|e| DomainError::SourceFailure {
+        name: "discover".into(),
+        message: format!("render failed: {e}"),
+    })
+}
+
+fn gate_char(status: &GateStatus) -> &'static str {
+    match status {
+        GateStatus::Pass => "clear",
+        GateStatus::Fail(_) => "CONFIRMED",
+        GateStatus::Unknown(_) => "unknown",
+    }
+}
+
+fn render_candidate(out: &mut String, c: &Candidate) {
+    let screens: Vec<&str> = c.screens.iter().map(|s| s.label()).collect();
+    let _ = writeln!(
+        out,
+        "  {}  {:+.1}%  @ {:.2}  [{}]",
+        c.ticker,
+        c.change_pct,
+        c.price,
+        screens.join(", ")
+    );
+    let mut tape: Vec<String> = Vec::new();
+    if let Some(rvol) = c.rvol {
+        tape.push(format!("rvol {rvol:.1}"));
+    }
+    if let Some(s) = c.stretch_atr {
+        tape.push(format!("stretch {s:+.1} ATR"));
+    }
+    if let Some(r) = c.rsi14 {
+        tape.push(format!("rsi {r:.0}"));
+    }
+    if !tape.is_empty() {
+        let _ = writeln!(out, "    tape: {}", tape.join(" · "));
+    }
+    for (label, e) in [("3mo", &c.extremes_3mo), ("~1y", &c.extremes_1y)] {
+        if let Some(e) = e {
+            let _ = writeln!(
+                out,
+                "    {label} extremes ({}d): high {:.2} ({:.1} ATR above) · low {:.2} ({:.1} ATR below)",
+                e.days, e.high, e.dist_to_high_atr, e.low, e.dist_to_low_atr
+            );
+        }
+    }
+    if let Some(cat) = &c.catalyst {
+        let _ = writeln!(
+            out,
+            "    catalyst: filings {} · headlines {}",
+            gate_char(&cat.filings),
+            gate_char(&cat.headlines)
+        );
+        for e in &cat.evidence {
+            let _ = writeln!(out, "      {e}");
+        }
+    }
+    if let Some(s) = &c.sentiment {
+        let _ = writeln!(
+            out,
+            "    attention: {} mentions · net sentiment {:+.2}",
+            s.mentions, s.net_sentiment
+        );
+    }
+    for n in &c.notes {
+        let _ = writeln!(out, "    note: {n}");
+    }
+}
+
+fn render_table(report: &DiscoverReport) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "=== OpenIntel Discover — movers ===");
+    let screens: Vec<String> = report
+        .screens
+        .iter()
+        .map(|s| {
+            format!(
+                "{} {} (floor -{}, annotated {})",
+                s.universe,
+                s.screen.label(),
+                s.floor_rejects,
+                s.annotated
+            )
+        })
+        .collect();
+    let _ = writeln!(out, "{}\n", screens.join(" · "));
+    if report.candidates.is_empty() {
+        let _ = writeln!(out, "  no candidates survived the quality floor");
+    }
+    for c in &report.candidates {
+        render_candidate(&mut out, c);
+        let _ = writeln!(out);
+    }
+    for e in &report.errors {
+        let _ = writeln!(out, "error: {e}");
+    }
+    for n in &report.notes {
+        let _ = writeln!(out, "note: {n}");
+    }
+    let _ = writeln!(out, "\n{FRAMING}");
+    let _ = writeln!(out, "\n{DISCLAIMER}");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::discover::{CatalystCheck, ScreenSummary};
+    use crate::domain::discover::PeriodExtremes;
+    use crate::domain::values::mover::ScreenKind;
+    use chrono::TimeZone;
+
+    fn report() -> DiscoverReport {
+        DiscoverReport {
+            generated_at: Utc.with_ymd_and_hms(2026, 8, 21, 21, 0, 0).unwrap(),
+            screens: vec![ScreenSummary {
+                screen: ScreenKind::DayLosers,
+                universe: 25,
+                floor_rejects: 20,
+                annotated: 1,
+            }],
+            candidates: vec![Candidate {
+                ticker: "DOWN".into(),
+                screens: vec![ScreenKind::DayLosers],
+                change_pct: -9.0,
+                price: 50.0,
+                rvol: Some(2.0),
+                stretch_atr: Some(1.4),
+                rsi14: Some(31.0),
+                extremes_3mo: Some(PeriodExtremes {
+                    days: 63,
+                    high: 70.0,
+                    low: 48.0,
+                    dist_to_high_atr: 10.0,
+                    dist_to_low_atr: 1.0,
+                }),
+                extremes_1y: None,
+                catalyst: Some(CatalystCheck {
+                    filings: GateStatus::Pass,
+                    headlines: GateStatus::Unknown("news unavailable".into()),
+                    evidence: vec![],
+                }),
+                sentiment: None,
+                notes: vec![
+                    "long-range extremes cover only 63 trading days, not a full year".into(),
+                ],
+            }],
+            errors: vec![],
+            notes: vec![
+                "losers shown here carry no verdict — run dip_scan for the gated dip-setup grading"
+                    .into(),
+            ],
+        }
+    }
+
+    #[test]
+    fn table_shows_evidence_and_framing() {
+        let t = render_table(&report());
+        assert!(t.contains("DOWN  -9.0%"));
+        assert!(t.contains("rvol 2.0"));
+        assert!(t.contains("low 48.00 (1.0 ATR below)"));
+        assert!(t.contains("filings clear · headlines unknown"));
+        assert!(t.contains("run dip_scan"));
+        assert!(t.contains("never ranks"));
+        assert!(t.contains("Not financial advice"));
+    }
+
+    #[test]
+    fn json_carries_framing_and_disclaimer() {
+        let j = render_json(&report()).unwrap();
+        assert!(j.contains("\"ticker\": \"DOWN\""));
+        assert!(j.contains("never ranks"));
+        assert!(j.contains("Not financial advice"));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod args;
 pub mod dip;
+pub mod discover;
 pub mod journal;
 pub mod pulse;
 pub mod risk;

--- a/src/domain/dip.rs
+++ b/src/domain/dip.rs
@@ -424,7 +424,7 @@ impl Default for DropBand {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize)]
 pub struct SentimentSummary {
     pub net_sentiment: f64,
     pub mentions: usize,
@@ -489,6 +489,103 @@ pub struct DipSignal {
     pub gates: GateResults,
     pub catalyst_evidence: Vec<String>,
     pub notes: Vec<String>,
+}
+
+/// Catalyst-filing gate, shared by dip_signal and discover: SEC catalyst
+/// forms filed on/after `since` confirm a catalyst (Fail); unfetchable
+/// evidence is Unknown (fails closed). Returns the status plus evidence lines.
+pub fn filing_gate(
+    filings: &GateEvidence<Vec<Filing>>,
+    since: NaiveDate,
+) -> (GateStatus, Vec<String>) {
+    match filings {
+        GateEvidence::Unavailable(reason) => (GateStatus::Unknown(reason.clone()), Vec::new()),
+        GateEvidence::Available(filings) => {
+            let hits: Vec<&Filing> = filings
+                .iter()
+                .filter(|f| f.filed_on >= since && is_catalyst_form(&f.form))
+                .collect();
+            if hits.is_empty() {
+                (GateStatus::Pass, Vec::new())
+            } else {
+                let evidence = hits
+                    .iter()
+                    .map(|f| format!("SEC {} filed {}", f.form, f.filed_on))
+                    .collect();
+                (
+                    GateStatus::Fail(format!(
+                        "{} catalyst filing(s) on/around drop day",
+                        hits.len()
+                    )),
+                    evidence,
+                )
+            }
+        }
+    }
+}
+
+/// Catalyst-headline gate, shared by dip_signal and discover. Keyword hits in
+/// a headline that clearly references the company CONFIRM a catalyst (Fail).
+/// Hits only in headlines that don't (market roundups, sector stories) are
+/// ambiguous — Unknown, never a false-positive kill. With no company names
+/// known, every headline is treated as potentially about the company (the
+/// old, stricter behavior).
+pub fn headline_gate(
+    headlines: &GateEvidence<Vec<Headline>>,
+    ticker: &str,
+    company_names: &[String],
+) -> (GateStatus, Vec<String>) {
+    match headlines {
+        GateEvidence::Unavailable(reason) => (GateStatus::Unknown(reason.clone()), Vec::new()),
+        GateEvidence::Available(headlines) => {
+            // blank/junk names derive no forms -> strict path, not a weaker gate
+            let name_forms = company_name_forms(company_names);
+            let mut evidence: Vec<String> = Vec::new();
+            let mut matched_hits: Vec<String> = Vec::new();
+            let mut unmatched_hits: Vec<String> = Vec::new();
+            for h in headlines {
+                let title_hits = catalyst_hits(&[h.title.as_str()]);
+                if title_hits.is_empty() {
+                    continue;
+                }
+                let about_company = name_forms.is_empty()
+                    || headline_mentions_company(&h.title, ticker, &name_forms);
+                if about_company {
+                    evidence.push(format!(
+                        "headline [{}]: \"{}\" (terms: {})",
+                        h.publisher,
+                        h.title,
+                        title_hits.join(", ")
+                    ));
+                    for hit in title_hits {
+                        if !matched_hits.contains(&hit) {
+                            matched_hits.push(hit);
+                        }
+                    }
+                } else {
+                    for hit in title_hits {
+                        if !unmatched_hits.contains(&hit) {
+                            unmatched_hits.push(hit);
+                        }
+                    }
+                }
+            }
+            let status = if !matched_hits.is_empty() {
+                GateStatus::Fail(format!(
+                    "catalyst term(s) in company headlines: {}",
+                    matched_hits.join(", ")
+                ))
+            } else if !unmatched_hits.is_empty() {
+                GateStatus::Unknown(format!(
+                    "catalyst term(s) only in headlines not clearly about {ticker}: {}",
+                    unmatched_hits.join(", ")
+                ))
+            } else {
+                GateStatus::Pass
+            };
+            (status, evidence)
+        }
+    }
 }
 
 pub fn dip_signal(inputs: &DipInputs) -> Result<DipSignal, DomainError> {
@@ -583,82 +680,12 @@ pub fn dip_signal(inputs: &DipInputs) -> Result<DipSignal, DomainError> {
         };
 
     let since = inputs.drop_date.pred_opt().unwrap_or(inputs.drop_date);
-    let no_filing = match &inputs.filings {
-        GateEvidence::Unavailable(reason) => GateStatus::Unknown(reason.clone()),
-        GateEvidence::Available(filings) => {
-            let hits: Vec<&Filing> = filings
-                .iter()
-                .filter(|f| f.filed_on >= since && is_catalyst_form(&f.form))
-                .collect();
-            if hits.is_empty() {
-                GateStatus::Pass
-            } else {
-                for f in &hits {
-                    catalyst_evidence.push(format!("SEC {} filed {}", f.form, f.filed_on));
-                }
-                GateStatus::Fail(format!(
-                    "{} catalyst filing(s) on/around drop day",
-                    hits.len()
-                ))
-            }
-        }
-    };
+    let (no_filing, filing_evidence) = filing_gate(&inputs.filings, since);
+    catalyst_evidence.extend(filing_evidence);
 
-    // Keyword hits in a headline that clearly references the company CONFIRM
-    // a catalyst (Fail). Hits only in headlines that don't (market roundups,
-    // sector stories) are ambiguous — Unknown, capping at watch, never a
-    // false-positive kill. With no company names known, every headline is
-    // treated as potentially about the company (old, stricter behavior).
-    let no_catalyst_headline = match &inputs.headlines {
-        GateEvidence::Unavailable(reason) => GateStatus::Unknown(reason.clone()),
-        GateEvidence::Available(headlines) => {
-            // blank/junk names derive no forms -> strict path, not a weaker gate
-            let name_forms = company_name_forms(&inputs.company_names);
-            let mut matched_hits: Vec<String> = Vec::new();
-            let mut unmatched_hits: Vec<String> = Vec::new();
-            for h in headlines {
-                let title_hits = catalyst_hits(&[h.title.as_str()]);
-                if title_hits.is_empty() {
-                    continue;
-                }
-                let about_company = name_forms.is_empty()
-                    || headline_mentions_company(&h.title, inputs.ticker, &name_forms);
-                if about_company {
-                    catalyst_evidence.push(format!(
-                        "headline [{}]: \"{}\" (terms: {})",
-                        h.publisher,
-                        h.title,
-                        title_hits.join(", ")
-                    ));
-                    for hit in title_hits {
-                        if !matched_hits.contains(&hit) {
-                            matched_hits.push(hit);
-                        }
-                    }
-                } else {
-                    for hit in title_hits {
-                        if !unmatched_hits.contains(&hit) {
-                            unmatched_hits.push(hit);
-                        }
-                    }
-                }
-            }
-            if !matched_hits.is_empty() {
-                GateStatus::Fail(format!(
-                    "catalyst term(s) in company headlines: {}",
-                    matched_hits.join(", ")
-                ))
-            } else if !unmatched_hits.is_empty() {
-                GateStatus::Unknown(format!(
-                    "catalyst term(s) only in headlines not clearly about {}: {}",
-                    inputs.ticker,
-                    unmatched_hits.join(", ")
-                ))
-            } else {
-                GateStatus::Pass
-            }
-        }
-    };
+    let (no_catalyst_headline, headline_evidence) =
+        headline_gate(&inputs.headlines, inputs.ticker, &inputs.company_names);
+    catalyst_evidence.extend(headline_evidence);
 
     let idiosyncratic = match excess {
         None => GateStatus::Unknown("index change unavailable".into()),

--- a/src/domain/discover.rs
+++ b/src/domain/discover.rs
@@ -1,0 +1,122 @@
+//! Pure pieces of discovery: period-extreme levels, deep-slot allocation.
+//! Discovery surfaces candidates with evidence attached — it never ranks and
+//! never emits a verdict; the catalyst gates it reuses live in `dip`.
+
+use serde::Serialize;
+
+use crate::domain::values::bar::Bar;
+
+/// High/low of the last `days` daily bars, with distance from `last` in ATRs.
+/// These are PERIOD EXTREMES — a cheap proxy, not support/resistance; real
+/// levels are drawn by the trader.
+#[derive(Debug, Clone, Serialize)]
+pub struct PeriodExtremes {
+    /// Trading days actually covered (may be fewer than requested — reported,
+    /// never assumed).
+    pub days: usize,
+    pub high: f64,
+    pub low: f64,
+    pub dist_to_high_atr: f64,
+    pub dist_to_low_atr: f64,
+}
+
+pub fn period_extremes(
+    bars: &[Bar],
+    last_price: f64,
+    atr: f64,
+    days: usize,
+) -> Option<PeriodExtremes> {
+    if bars.is_empty() || days == 0 || !(atr.is_finite() && atr > 0.0) {
+        return None;
+    }
+    let window = &bars[bars.len().saturating_sub(days)..];
+    let high = window.iter().map(|b| b.high).fold(f64::MIN, f64::max);
+    let low = window.iter().map(|b| b.low).fold(f64::MAX, f64::min);
+    if !(high.is_finite() && low.is_finite()) {
+        return None;
+    }
+    Some(PeriodExtremes {
+        days: window.len(),
+        high,
+        low,
+        dist_to_high_atr: (high - last_price) / atr,
+        dist_to_low_atr: (last_price - low) / atr,
+    })
+}
+
+/// Spread `total` deep-annotation slots across screen groups round-robin, in
+/// group order, capped by each group's size. No ranking — provider order
+/// within a group is preserved by the caller.
+pub fn allocate_deep(group_sizes: &[usize], total: usize) -> Vec<usize> {
+    let mut alloc = vec![0usize; group_sizes.len()];
+    let mut remaining = total;
+    while remaining > 0 {
+        let mut progressed = false;
+        for (i, size) in group_sizes.iter().enumerate() {
+            if remaining == 0 {
+                break;
+            }
+            if alloc[i] < *size {
+                alloc[i] += 1;
+                remaining -= 1;
+                progressed = true;
+            }
+        }
+        if !progressed {
+            break;
+        }
+    }
+    alloc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn bar(day: u32, low: f64, high: f64) -> Bar {
+        Bar {
+            date: NaiveDate::from_ymd_opt(2026, 1, 1)
+                .unwrap()
+                .checked_add_days(chrono::Days::new(day as u64))
+                .unwrap(),
+            open: (low + high) / 2.0,
+            high,
+            low,
+            close: (low + high) / 2.0,
+        }
+    }
+
+    #[test]
+    fn extremes_report_actual_span_and_atr_distances() {
+        let bars: Vec<Bar> = (0..10)
+            .map(|d| bar(d, 90.0 + d as f64, 100.0 + d as f64))
+            .collect();
+        // Window of last 5: lows 95..99, highs 105..109.
+        let e = period_extremes(&bars, 100.0, 2.0, 5).unwrap();
+        assert_eq!(e.days, 5);
+        assert_eq!(e.high, 109.0);
+        assert_eq!(e.low, 95.0);
+        assert!((e.dist_to_high_atr - 4.5).abs() < 1e-12);
+        assert!((e.dist_to_low_atr - 2.5).abs() < 1e-12);
+
+        // Ask for more days than exist: span is honest.
+        let e = period_extremes(&bars, 100.0, 2.0, 250).unwrap();
+        assert_eq!(e.days, 10);
+    }
+
+    #[test]
+    fn extremes_refuse_bad_inputs() {
+        assert!(period_extremes(&[], 100.0, 2.0, 5).is_none());
+        assert!(period_extremes(&[bar(0, 90.0, 100.0)], 100.0, 0.0, 5).is_none());
+    }
+
+    #[test]
+    fn deep_allocation_is_round_robin_and_capped() {
+        assert_eq!(allocate_deep(&[5, 5, 5], 9), vec![3, 3, 3]);
+        assert_eq!(allocate_deep(&[1, 5, 5], 9), vec![1, 4, 4]);
+        assert_eq!(allocate_deep(&[0, 0, 2], 9), vec![0, 0, 2]);
+        assert_eq!(allocate_deep(&[4, 4], 3), vec![2, 1]);
+        assert_eq!(allocate_deep(&[], 5), Vec::<usize>::new());
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,5 +1,6 @@
 pub mod dip;
 pub mod dip_review;
+pub mod discover;
 pub mod engine;
 pub mod entities;
 pub mod error;

--- a/src/domain/ports/bar_source.rs
+++ b/src/domain/ports/bar_source.rs
@@ -9,4 +9,11 @@ use crate::domain::values::bar::Bar;
 #[async_trait]
 pub trait BarSource: Send + Sync {
     async fn bars(&self, ticker: &Ticker) -> Result<Vec<Bar>, DomainError>;
+
+    /// Longer daily history when the source can serve it (target ~1 year,
+    /// for period-extreme levels). Defaults to the standard window — callers
+    /// must report the span they actually received, never assume a year.
+    async fn bars_long(&self, ticker: &Ticker) -> Result<Vec<Bar>, DomainError> {
+        self.bars(ticker).await
+    }
 }

--- a/src/domain/ports/movers_source.rs
+++ b/src/domain/ports/movers_source.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
 
 use crate::domain::error::DomainError;
-use crate::domain::values::mover::MoverRow;
+use crate::domain::values::mover::{MoverRow, ScreenKind};
 
-/// The day's biggest percentage losers, worst first. Universe feed for
-/// dip_scan; symbol-scoped ports stay untouched.
+/// Predefined mover screens (gainers / losers / most active), magnitude-first
+/// as the provider ranks them. Universe feed for dip_scan and discover;
+/// symbol-scoped ports stay untouched.
 #[async_trait]
 pub trait MoversSource: Send + Sync {
     fn name(&self) -> &str;
-    async fn day_losers(&self, count: usize) -> Result<Vec<MoverRow>, DomainError>;
+    async fn screen(&self, kind: ScreenKind, count: usize) -> Result<Vec<MoverRow>, DomainError>;
 }

--- a/src/domain/values/mover.rs
+++ b/src/domain/values/mover.rs
@@ -1,3 +1,23 @@
+/// The predefined mover screens a provider can serve. Providers map these to
+/// their own screen ids; rows come back in the provider's magnitude order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScreenKind {
+    DayGainers,
+    DayLosers,
+    MostActives,
+}
+
+impl ScreenKind {
+    pub fn label(&self) -> &'static str {
+        match self {
+            ScreenKind::DayGainers => "gainers",
+            ScreenKind::DayLosers => "losers",
+            ScreenKind::MostActives => "most active",
+        }
+    }
+}
+
 /// One row of a "biggest movers" screener. Optional fields are optional
 /// because screeners omit them for some instruments — the quality floor
 /// treats a missing value as a reject, never a pass.

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,22 @@ async fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
+        Command::Discover(args) => {
+            // Credentials resolve env-first, then the OS keychain (written by `openintel setup`).
+            let store = KeychainStore::new();
+            let credentials = Credentials::load(&store);
+
+            match openintel::cli::discover::run(&args, &credentials).await {
+                Ok(rendered) => {
+                    println!("{rendered}");
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
         Command::Journal(args) => match openintel::cli::journal::run(&args).await {
             Ok(rendered) => {
                 println!("{rendered}");

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -212,6 +212,37 @@ impl OpenIntelServer {
     }
 
     #[tool(
+        description = "Answer \"where are trades today?\" without a ticker: pull Yahoo's \
+                       predefined screens (gainers / losers / most actives), apply the quality \
+                       floor, and annotate a bounded slice with evidence — day change, RVOL, \
+                       ATR-stretch, distance to 3-month and ~1-year period extremes (a proxy, \
+                       NOT support/resistance), same-day SEC-filing and catalyst-headline gates \
+                       (unverifiable evidence reads Unknown), and social attention where \
+                       configured. NO ranking, NO verdicts, NO picks — present the evidence and \
+                       let the user reason. For gated dip verdicts on losers run dip_scan; for \
+                       a deep read on one name run analyze_ticker; before any trade run \
+                       risk_frame and get explicit user approval. Read-only — does not trade."
+    )]
+    async fn discover(
+        &self,
+        Parameters(args): Parameters<tools::DiscoverToolArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let deps = crate::application::discover::DiscoverDeps {
+            movers: &self.market,
+            bars: &self.market,
+            news: &self.market,
+            filings: self.filings.as_ref(),
+            social: &self.social,
+        };
+        let out = tools::run_discover(args, &deps)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let json = serde_json::to_string_pretty(&out)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    }
+
+    #[tool(
         description = "Journal a trade the user just APPROVED — call this in the same moment \
                        the order is placed, before the conversation moves on. The thesis must \
                        be the user's why in their own words; planned_stop is required (no entry \

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -659,6 +659,74 @@ pub async fn run_dip_scan(
     }
 }
 
+// ------------------------------------------------------------ discover
+
+#[derive(Debug, Clone, Copy, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ScreenArg {
+    Gainers,
+    Losers,
+    Actives,
+}
+
+impl ScreenArg {
+    fn kind(self) -> crate::domain::values::mover::ScreenKind {
+        use crate::domain::values::mover::ScreenKind;
+        match self {
+            ScreenArg::Gainers => ScreenKind::DayGainers,
+            ScreenArg::Losers => ScreenKind::DayLosers,
+            ScreenArg::Actives => ScreenKind::MostActives,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DiscoverToolArgs {
+    /// Screens to pull: "gainers", "losers", "actives" (default: all three).
+    pub screens: Option<Vec<ScreenArg>>,
+    /// Rows pulled per screen (1-100, default 25).
+    pub count: Option<usize>,
+    /// Total candidates deep-annotated across screens (1-25, default 9).
+    pub deep: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DiscoverOutput {
+    pub summary: String,
+    pub report: crate::application::discover::DiscoverReport,
+    pub framing: &'static str,
+    pub disclaimer: &'static str,
+}
+
+pub async fn run_discover(
+    args: DiscoverToolArgs,
+    deps: &crate::application::discover::DiscoverDeps<'_>,
+) -> Result<DiscoverOutput, DomainError> {
+    let mut req = crate::application::discover::DiscoverRequest::default();
+    if let Some(screens) = args.screens {
+        req.screens = screens.into_iter().map(ScreenArg::kind).collect();
+    }
+    if let Some(count) = args.count {
+        req.count = count;
+    }
+    if let Some(deep) = args.deep {
+        req.deep = deep;
+    }
+    let report = crate::application::discover::discover(&req, deps, Utc::now()).await?;
+    let summary = format!(
+        "{} candidates annotated across {} screens ({} screen errors)",
+        report.candidates.len(),
+        report.screens.len(),
+        report.errors.len()
+    );
+    Ok(DiscoverOutput {
+        summary,
+        report,
+        framing: crate::application::discover::FRAMING,
+        disclaimer: DISCLAIMER,
+    })
+}
+
 // ------------------------------------------------------------ trade journal
 
 #[derive(Debug, Deserialize, JsonSchema)]


### PR DESCRIPTION
Part of #63 (PR 1 of 2; chatter mode follows). Plan (approved, v3): https://xurbod9eldbn.postplan.dev

## Problem

Only `dip_scan` could answer "where are trades today?" — every other tool needs a ticker the user already knows.

## Solution

`openintel discover` + a `discover` MCP tool. Pull Yahoo's predefined screens (gainers / losers / most actives), apply the existing quality floor to the merged, deduped universe, and annotate a bounded slice (default 9, round-robin across screens) with evidence — never a ranking, never a pick:

- **Tape:** day change, RVOL, ATR-stretch vs SMA20, RSI(14).
- **Period extremes:** distance in ATRs to the 3-month and ~1-year high/low, explicitly labeled a proxy (not support/resistance), with the actual span covered reported. Backed by a new `BarSource::bars_long` default method (Yahoo overrides with `range=1y`; the default falls back to the standard window so mocks and other sources keep working).
- **Catalyst gates:** the filing and headline gates are now extracted from `dip_signal` into shared `filing_gate` / `headline_gate` pub fns (verbatim logic, one source of truth — all 24 dip tests unchanged and green) and reused here with the usual fail-closed `Unknown`.
- **Attention:** social mentions + net sentiment where sources are configured.

`MoversSource::day_losers` generalized to `screen(kind, count)`; `dip` passes `DayLosers` and is otherwise untouched. Losers in discover output carry a note pointing at `dip_scan` for the gated verdict instead of restating it.

Live-smoked against real Yahoo + EDGAR: dedup tags a symbol appearing in two screens (HOOD gainers+actives), BABA's earnings headlines correctly CONFIRMED as catalyst, HUT surfaced 0.5 ATR above its 3-month low. Tests: 282 unit + 3 integration green, clippy `-D warnings`, fmt.

---
Changes made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `discover` command and MCP tool for exploring gainers, losers, and most-active movers.
  * Reports market activity, period extremes, catalysts, sentiment, social attention, and supporting evidence without rankings or trade verdicts.
  * Added table and JSON output, configurable screen limits, and bounded deep analysis.
  * Added longer historical chart data for period analysis.
  * Reports unavailable data and screen errors while preserving successful results.

* **Documentation**
  * Documented the `discover` command, examples, and MCP usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->