### PR TITLE
feat(discover): chatter mode — listening-set mention velocity with honest baselines

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ openintel pulse TSLA --accounts elonmusk --keywords tesla,robotaxi     # ≤ 20 
 
 Add `--keywords` with the company's own vocabulary — influencer posts say "Tesla", not "$TSLA".
 
-Note: X's API bills a minimum of 10 post reads per call, so even `--limit 1` costs ≈ $0.05.
+Note: billing is per post returned (deduped over a 24h UTC day, prepaid credits, no
+per-call minimum) — but the search endpoint's `max_results` floor is 10, so a call can
+return up to 10 posts even at `--limit 1`: budget ≈ $0.05 worst case per call.
 
 No `--accounts` → a small macro default list (POTUS, White House, Musk, the Fed).
 Via MCP, the `x_pulse` tool asks the agent to research which accounts matter for
@@ -166,8 +168,35 @@ openintel discover --screens losers --deep 5
 openintel discover --format json
 ```
 
-Also exposed as the `discover` MCP tool. A chatter mode (mention velocity from a
-curated cross-platform listening set) is planned next.
+Also exposed as the `discover` MCP tool (with a `mode` parameter for the chatter mode
+below).
+
+## Chatter (find it before the chart)
+
+`openintel discover --chatter` measures **mention velocity from your listening set** —
+the accounts and communities worth hearing, stored at `~/.openintel/listening.json`
+(seeded on first run with a macro default; edit it, or let your agent propose additions
+for you to approve). Legs, per what's configured:
+
+- **Bluesky** (free): author feeds of your listed accounts.
+- **Reddit** (optional): hot posts from your listed subreddits.
+- **X** (paid, strictly opt-in via `--x` / `include_x`): everything your listed accounts
+  posted in the window — ~$0.005 per post returned, deduped 24h, capped at `--x-limit`
+  (default 20 ≈ $0.10 max per run).
+
+Cashtag mentions are counted once per post and graded against a **baseline journal**
+(`~/.openintel/chatter_baseline.jsonl`, appended every run): velocity = today's mention
+*share* vs the trailing mean — set-size-independent, so growing your listening set can't
+fake a spike, and a changed set is flagged. **Honesty gates:** no velocity claim below
+5 mentions today and 3 prior baseline days; until then the report shows raw counts and
+says "baseline building". The headline flag is **chatter leading the chart**: velocity
+≥ 3× baseline while the day move is under 2% and RVOL is unremarkable.
+
+Influencers write "Tesla", not "$TSLA" — so the report also returns the recent posts
+themselves for you (or your agent) to read. Attention is the signal being measured, not
+information: chatter never ranks, never predicts, and is exactly the kind of thing
+crowding vetoes exist for. Run it daily (a scheduled agent session works well) — the
+baseline only matures with regular runs.
 
 ## Trade journal (frozen theses, graded record)
 
@@ -230,7 +259,7 @@ Tools exposed (all **read-only** — OpenIntel never places trades):
 | `risk_frame` | ATR stop + budget-capped size + R targets for one trade idea |
 | `dip_scan` | Day's biggest losers → gated dip-setup verdicts (`no_setup`/`watch`/`high_confidence`), optional margin-aware sizing; pass `ticker` for one symbol |
 | `dip_review` | Grade the dip journal against forward returns (raw + SPY-adjusted, per verdict) — the evidence check on dip_scan's v0 score |
-| `discover` | Today's movers (gainers/losers/actives) with evidence attached: tape, period extremes in ATRs, catalyst gates, attention — no ranking, no picks |
+| `discover` | Movers with evidence (tape, period extremes, catalyst gates) or — `mode: chatter` — mention velocity from the listening set with honesty-gated baselines; `include_x` spends real money and requires user confirmation first. No ranking, no picks |
 | `log_trade` | Journal an approved trade at the moment it's placed: frozen thesis, required stop, risk-of-wallet snapshot; same-day duplicate guard |
 | `update_trade` | Amend an open trade (note, move stop/target — original plan stays frozen) or close it with exit + reason |
 | `open_positions` | Every open trade with its frozen thesis, plan, and amendments — call first in a new chat; the cross-session memory |

--- a/src/adapters/sources/bluesky/mod.rs
+++ b/src/adapters/sources/bluesky/mod.rs
@@ -141,6 +141,88 @@ impl SocialDataSource for BlueskySource {
     }
 }
 
+#[async_trait]
+impl crate::domain::ports::listening_feed::ListeningFeed for BlueskySource {
+    fn platform(&self) -> &'static str {
+        "bluesky"
+    }
+
+    fn paid(&self) -> bool {
+        false
+    }
+
+    async fn listening_posts(
+        &self,
+        handles: &[String],
+        hours_back: u32,
+        limit: usize,
+    ) -> Result<crate::domain::ports::listening_feed::ListeningFetch, DomainError> {
+        use crate::domain::entities::pulse::PulsePost;
+        let fail = |m: String| DomainError::SourceFailure {
+            name: "bluesky".into(),
+            message: m,
+        };
+        if handles.is_empty() || limit == 0 {
+            return Ok(crate::domain::ports::listening_feed::ListeningFetch {
+                posts: Vec::new(),
+                posts_returned: 0,
+            });
+        }
+        let bearer = self.ensure_token().await?;
+        let fetched_at = Utc::now();
+        let cutoff = fetched_at - chrono::Duration::hours(i64::from(hours_back.max(1)));
+        let per_handle = (limit / handles.len()).clamp(1, 100).to_string();
+
+        let mut posts: Vec<PulsePost> = Vec::new();
+        let mut returned: u32 = 0;
+        for handle in handles {
+            let mut url =
+                reqwest::Url::parse(&format!("{PDS_BASE}/xrpc/app.bsky.feed.getAuthorFeed"))
+                    .map_err(|e| fail(format!("bad feed url: {e}")))?;
+            url.query_pairs_mut()
+                .append_pair("actor", handle)
+                .append_pair("filter", "posts_no_replies")
+                .append_pair("limit", &per_handle);
+            let resp = self
+                .client
+                .get(url)
+                .bearer_auth(bearer.expose_secret())
+                .header(reqwest::header::USER_AGENT, &self.user_agent)
+                .send()
+                .await
+                .map_err(|e| fail(format!("feed request failed: {e}")))?;
+            let status = resp.status();
+            let body = resp
+                .text()
+                .await
+                .map_err(|e| fail(format!("feed body failed (HTTP {status}): {e}")))?;
+            if !status.is_success() {
+                return Err(fail(format!("feed HTTP {status} for {handle}")));
+            }
+            let fetched = response::parse_author_feed(&body, limit, fetched_at)?;
+            returned = returned.saturating_add(fetched.len() as u32);
+            posts.extend(
+                fetched
+                    .into_iter()
+                    .filter(|p| p.created_at >= cutoff)
+                    .map(|p| PulsePost {
+                        id: p.id,
+                        author: p.author,
+                        text: p.text,
+                        created_at: p.created_at,
+                        engagement: p.engagement,
+                    }),
+            );
+        }
+        posts.sort_by_key(|p| std::cmp::Reverse(p.created_at));
+        posts.truncate(limit);
+        Ok(crate::domain::ports::listening_feed::ListeningFetch {
+            posts,
+            posts_returned: returned,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/adapters/sources/bluesky/response.rs
+++ b/src/adapters/sources/bluesky/response.rs
@@ -56,6 +56,40 @@ fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
         .map(|dt| dt.with_timezone(&Utc))
 }
 
+fn view_to_post(view: PostView, fetched_at: DateTime<Utc>) -> Option<SocialPost> {
+    let id = match view.uri {
+        Some(u) if !u.is_empty() => u,
+        _ => return None,
+    };
+    let record = view.record.unwrap_or_default();
+    // empty/whitespace text -> skip, not fatal
+    let text = PostText::parse(&record.text.unwrap_or_default()).ok()?;
+    let created_at = record
+        .created_at
+        .as_deref()
+        .and_then(parse_rfc3339)
+        .or_else(|| view.indexed_at.as_deref().and_then(parse_rfc3339))
+        .unwrap_or(fetched_at);
+    let engagement = [view.like_count, view.repost_count, view.reply_count]
+        .iter()
+        .map(|c| c.unwrap_or(0).max(0) as u64)
+        .sum::<u64>()
+        .min(u32::MAX as u64) as u32;
+
+    Some(SocialPost {
+        id,
+        source: SourceKind::Bluesky,
+        author: view
+            .author
+            .unwrap_or_default()
+            .handle
+            .unwrap_or_else(|| "[unknown]".to_string()),
+        text,
+        created_at,
+        engagement,
+    })
+}
+
 pub(crate) fn parse_posts(
     body: &str,
     limit: usize,
@@ -70,39 +104,42 @@ pub(crate) fn parse_posts(
 
     let mut posts = Vec::new();
     for view in resp.posts {
-        let id = match view.uri {
-            Some(u) if !u.is_empty() => u,
-            _ => continue,
-        };
-        let record = view.record.unwrap_or_default();
-        let text = match PostText::parse(&record.text.unwrap_or_default()) {
-            Ok(t) => t,
-            Err(_) => continue, // empty/whitespace text -> skip, not fatal
-        };
-        let created_at = record
-            .created_at
-            .as_deref()
-            .and_then(parse_rfc3339)
-            .or_else(|| view.indexed_at.as_deref().and_then(parse_rfc3339))
-            .unwrap_or(fetched_at);
-        let engagement = [view.like_count, view.repost_count, view.reply_count]
-            .iter()
-            .map(|c| c.unwrap_or(0).max(0) as u64)
-            .sum::<u64>()
-            .min(u32::MAX as u64) as u32;
+        if let Some(post) = view_to_post(view, fetched_at) {
+            posts.push(post);
+        }
+        if posts.len() >= limit {
+            break;
+        }
+    }
+    Ok(posts)
+}
 
-        posts.push(SocialPost {
-            id,
-            source: SourceKind::Bluesky,
-            author: view
-                .author
-                .unwrap_or_default()
-                .handle
-                .unwrap_or_else(|| "[unknown]".to_string()),
-            text,
-            created_at,
-            engagement,
-        });
+#[derive(Debug, Deserialize)]
+struct AuthorFeedResponse {
+    #[serde(default)]
+    feed: Vec<FeedItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FeedItem {
+    #[serde(default)]
+    post: Option<PostView>,
+}
+
+/// `app.bsky.feed.getAuthorFeed` wraps each post one level deeper than
+/// searchPosts; the per-post mapping is shared.
+pub(crate) fn parse_author_feed(
+    body: &str,
+    limit: usize,
+    fetched_at: DateTime<Utc>,
+) -> Result<Vec<SocialPost>, DomainError> {
+    let resp: AuthorFeedResponse =
+        serde_json::from_str(body).map_err(|e| fail(format!("malformed feed response: {e}")))?;
+    let mut posts = Vec::new();
+    for item in resp.feed {
+        if let Some(post) = item.post.and_then(|v| view_to_post(v, fetched_at)) {
+            posts.push(post);
+        }
         if posts.len() >= limit {
             break;
         }

--- a/src/adapters/sources/mod.rs
+++ b/src/adapters/sources/mod.rs
@@ -43,6 +43,34 @@ pub fn build_social_sources(credentials: &Credentials) -> Vec<Box<dyn SocialData
     social
 }
 
+/// Assemble the FREE listening feeds for chatter discovery (Bluesky author
+/// feeds, Reddit subreddit hot) from the same credentials. The paid X feed is
+/// wired separately by each composition root — it needs its own opt-in.
+pub fn build_free_listening_feeds(
+    credentials: &Credentials,
+) -> Vec<Box<dyn crate::domain::ports::listening_feed::ListeningFeed>> {
+    let mut feeds: Vec<Box<dyn crate::domain::ports::listening_feed::ListeningFeed>> = Vec::new();
+    if let (Some(handle), Some(password)) = (
+        credentials.bluesky_handle.clone(),
+        credentials.bluesky_app_password.clone(),
+    ) {
+        match bluesky::BlueskySource::new(handle, password) {
+            Ok(src) => feeds.push(Box::new(src)),
+            Err(e) => eprintln!("warning: bluesky listening disabled: {e}"),
+        }
+    }
+    if let (Some(id), Some(secret)) = (
+        credentials.reddit_client_id.clone(),
+        credentials.reddit_client_secret.clone(),
+    ) {
+        match reddit::RedditSource::new(id, secret) {
+            Ok(src) => feeds.push(Box::new(src)),
+            Err(e) => eprintln!("warning: reddit listening disabled: {e}"),
+        }
+    }
+    feeds
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/adapters/sources/reddit/mod.rs
+++ b/src/adapters/sources/reddit/mod.rs
@@ -139,6 +139,80 @@ impl SocialDataSource for RedditSource {
     }
 }
 
+#[async_trait]
+impl crate::domain::ports::listening_feed::ListeningFeed for RedditSource {
+    fn platform(&self) -> &'static str {
+        "reddit"
+    }
+
+    fn paid(&self) -> bool {
+        false
+    }
+
+    async fn listening_posts(
+        &self,
+        handles: &[String],
+        hours_back: u32,
+        limit: usize,
+    ) -> Result<crate::domain::ports::listening_feed::ListeningFetch, DomainError> {
+        use crate::domain::entities::pulse::PulsePost;
+        let fail = |m: String| DomainError::SourceFailure {
+            name: "reddit".into(),
+            message: m,
+        };
+        if handles.is_empty() || limit == 0 {
+            return Ok(crate::domain::ports::listening_feed::ListeningFetch {
+                posts: Vec::new(),
+                posts_returned: 0,
+            });
+        }
+        let bearer = self.ensure_token().await?;
+        let fetched_at = Utc::now();
+        let cutoff = fetched_at - chrono::Duration::hours(i64::from(hours_back.max(1)));
+        // Multireddit syntax: one request covers the whole subreddit list.
+        let subs = handles.join("+");
+        let mut url = reqwest::Url::parse(&format!("{API_BASE}/r/{subs}/hot"))
+            .map_err(|e| fail(format!("bad hot url: {e}")))?;
+        url.query_pairs_mut()
+            .append_pair("limit", &limit.min(100).to_string())
+            .append_pair("raw_json", "1");
+
+        let resp = self
+            .client
+            .get(url)
+            .bearer_auth(bearer.expose_secret())
+            .header(reqwest::header::USER_AGENT, &self.user_agent)
+            .send()
+            .await
+            .map_err(|e| fail(format!("hot request failed: {e}")))?;
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| fail(format!("hot body failed (HTTP {status}): {e}")))?;
+        if !status.is_success() {
+            return Err(fail(format!("hot HTTP {status}")));
+        }
+        let fetched = response::parse_posts(&body, limit, fetched_at)?;
+        let returned = fetched.len() as u32;
+        let posts: Vec<PulsePost> = fetched
+            .into_iter()
+            .filter(|p| p.created_at >= cutoff)
+            .map(|p| PulsePost {
+                id: p.id,
+                author: p.author,
+                text: p.text,
+                created_at: p.created_at,
+                engagement: p.engagement,
+            })
+            .collect();
+        Ok(crate::domain::ports::listening_feed::ListeningFetch {
+            posts,
+            posts_returned: returned,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/adapters/sources/x/mod.rs
+++ b/src/adapters/sources/x/mod.rs
@@ -76,29 +76,30 @@ impl XPulseSource {
     }
 }
 
-#[async_trait]
-impl InfluencerFeed for XPulseSource {
-    async fn pulse(
+/// Author-only query for chatter listening: everything these accounts posted,
+/// no ticker terms. Same operator-safety posture as `build_query`.
+pub(crate) fn build_listening_query(accounts: &[String]) -> String {
+    let from = accounts
+        .iter()
+        .map(|a| format!("from:{a}"))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    format!("({from}) -is:retweet")
+}
+
+impl XPulseSource {
+    /// Shared paid search: everything from the window stamp to the parse.
+    /// Both entry points guard `limit == 0` before calling (nothing billed).
+    async fn run_search(
         &self,
-        ticker: &Ticker,
-        accounts: &[String],
-        keywords: &[String],
+        query: &str,
         hours_back: u32,
         limit: usize,
     ) -> Result<PulseFetch, DomainError> {
-        if limit == 0 {
-            // No request made, nothing billed.
-            return Ok(PulseFetch {
-                posts: Vec::new(),
-                posts_returned: 0,
-            });
-        }
         let fetched_at = Utc::now();
         let start_time = (fetched_at - Duration::hours(i64::from(hours_back)))
             .to_rfc3339_opts(SecondsFormat::Secs, true);
-        let max_results = limit.clamp(10, 100).to_string(); // API minimum is 10
-
-        let query = build_query(ticker, accounts, keywords);
+        let max_results = limit.clamp(10, 100).to_string(); // max_results floor is 10
         if query.chars().count() > MAX_QUERY_CHARS {
             return Err(fail(format!(
                 "query too long ({} chars, max {MAX_QUERY_CHARS}) — use fewer accounts/keywords",
@@ -109,7 +110,7 @@ impl InfluencerFeed for XPulseSource {
         // `.query()` is behind reqwest's un-enabled `query` feature; build manually.
         let mut url = reqwest::Url::parse(SEARCH_URL).map_err(|e| fail(format!("bad url: {e}")))?;
         url.query_pairs_mut()
-            .append_pair("query", &query)
+            .append_pair("query", query)
             .append_pair("start_time", &start_time)
             .append_pair("max_results", &max_results)
             .append_pair("tweet.fields", "created_at,public_metrics")
@@ -155,6 +156,60 @@ impl InfluencerFeed for XPulseSource {
             return Err(fail(format!("search HTTP {status}")));
         }
         response::parse_posts(&body, limit, fetched_at)
+    }
+}
+
+#[async_trait]
+impl InfluencerFeed for XPulseSource {
+    async fn pulse(
+        &self,
+        ticker: &Ticker,
+        accounts: &[String],
+        keywords: &[String],
+        hours_back: u32,
+        limit: usize,
+    ) -> Result<PulseFetch, DomainError> {
+        if limit == 0 {
+            // No request made, nothing billed.
+            return Ok(PulseFetch {
+                posts: Vec::new(),
+                posts_returned: 0,
+            });
+        }
+        let query = build_query(ticker, accounts, keywords);
+        self.run_search(&query, hours_back, limit).await
+    }
+}
+
+#[async_trait]
+impl crate::domain::ports::listening_feed::ListeningFeed for XPulseSource {
+    fn platform(&self) -> &'static str {
+        "x"
+    }
+
+    fn paid(&self) -> bool {
+        true
+    }
+
+    async fn listening_posts(
+        &self,
+        handles: &[String],
+        hours_back: u32,
+        limit: usize,
+    ) -> Result<crate::domain::ports::listening_feed::ListeningFetch, DomainError> {
+        if handles.is_empty() || limit == 0 {
+            // No request made, nothing billed.
+            return Ok(crate::domain::ports::listening_feed::ListeningFetch {
+                posts: Vec::new(),
+                posts_returned: 0,
+            });
+        }
+        let query = build_listening_query(handles);
+        let fetch = self.run_search(&query, hours_back, limit).await?;
+        Ok(crate::domain::ports::listening_feed::ListeningFetch {
+            posts: fetch.posts,
+            posts_returned: fetch.posts_returned,
+        })
     }
 }
 

--- a/src/application/chatter.rs
+++ b/src/application/chatter.rs
@@ -1,0 +1,419 @@
+//! IO edge for `discover --chatter`: fetch the listening set's recent posts
+//! per platform, count cashtag mentions, compute velocity against the
+//! baseline journal, append today's baseline line, and annotate surfaced
+//! tickers with the tape (change, RVOL) for the before-the-chart read.
+//! Attention is the signal being measured — the output says so and never
+//! ranks or recommends.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::config::listening::ListeningSet;
+use crate::domain::chatter::{
+    before_the_chart, count_mentions, velocity, BaselineLine, MentionCounts, Velocity,
+    MIN_REPORT_MENTIONS,
+};
+use crate::domain::entities::pulse::PulsePost;
+use crate::domain::entities::ticker::Ticker;
+use crate::domain::error::DomainError;
+use crate::domain::ports::listening_feed::ListeningFeed;
+use crate::domain::ports::market_data_source::MarketDataSource;
+
+pub const FRAMING: &str = "chatter measures ATTENTION, not information — one platform's \
+     voices, easily brigaded. It never ranks, never predicts, never recommends. \
+     Cross-check anything interesting with analyze_ticker and the catalyst gates.";
+
+/// Default paid-read ceiling for the X leg — ~$0.10 at $0.005/read.
+pub const DEFAULT_X_READ_CAP: usize = 20;
+pub const DEFAULT_FREE_LIMIT: usize = 100;
+pub const DEFAULT_HOURS: u32 = 24;
+/// Recent posts included per platform for the agent to read — names beat
+/// cashtags in influencer language, and the reader connects them.
+const TOP_POSTS: usize = 10;
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "chatter".into(),
+        message: message.into(),
+    }
+}
+
+/// `~/.openintel/chatter_baseline.jsonl`, or None when no home dir resolves.
+pub fn default_baseline_path() -> Option<PathBuf> {
+    std::env::home_dir().map(|h| h.join(".openintel").join("chatter_baseline.jsonl"))
+}
+
+pub struct ChatterRequest {
+    pub listening: ListeningSet,
+    pub hours: u32,
+    /// Post cap for free platforms.
+    pub free_limit: usize,
+    /// Paid-read ceiling for X — every returned post bills ~$0.005.
+    pub x_read_cap: usize,
+    /// None = no baseline read or write (velocity reports "baseline building").
+    pub baseline_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TickerChatter {
+    pub ticker: String,
+    pub velocity: Velocity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub change_pct: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rvol: Option<f64>,
+    /// Elevated chatter while the tape is quiet. None = tape unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_the_chart: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PlatformChatter {
+    pub platform: String,
+    pub handles: Vec<String>,
+    pub posts_scanned: usize,
+    pub posts_returned: u32,
+    /// Real money spent on this leg (paid platforms only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub estimated_cost_usd: Option<f64>,
+    pub tickers: Vec<TickerChatter>,
+    pub recent_posts: Vec<PulsePost>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChatterReport {
+    pub generated_at: DateTime<Utc>,
+    pub hours: u32,
+    pub listening_fingerprint: String,
+    pub platforms: Vec<PlatformChatter>,
+    pub errors: Vec<String>,
+    pub notes: Vec<String>,
+}
+
+fn read_baseline(path: &Path) -> Vec<BaselineLine> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect()
+}
+
+fn append_baseline(path: &Path, line: &BaselineLine) -> Result<(), DomainError> {
+    use std::io::Write as _;
+    let json = serde_json::to_string(line).map_err(|e| fail(e.to_string()))?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| fail(e.to_string()))?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| fail(e.to_string()))?;
+    writeln!(file, "{json}").map_err(|e| fail(e.to_string()))
+}
+
+async fn tape_for(
+    ticker: &str,
+    market: Option<&dyn MarketDataSource>,
+) -> (Option<f64>, Option<f64>) {
+    let Some(market) = market else {
+        return (None, None);
+    };
+    let Ok(parsed) = Ticker::parse(ticker) else {
+        return (None, None);
+    };
+    match market.snapshot(&parsed).await {
+        Ok(snap) => {
+            let change = (snap.previous_close > 0.0)
+                .then(|| (snap.last_price - snap.previous_close) / snap.previous_close * 100.0);
+            let rvol = (snap.avg_volume > 0).then(|| snap.volume as f64 / snap.avg_volume as f64);
+            (change, rvol)
+        }
+        Err(_) => (None, None),
+    }
+}
+
+/// One platform leg: fetch, count, grade velocity, journal, surface.
+async fn platform_leg(
+    feed: &dyn ListeningFeed,
+    req: &ChatterRequest,
+    fingerprint: &str,
+    market: Option<&dyn MarketDataSource>,
+    now: DateTime<Utc>,
+) -> Result<PlatformChatter, DomainError> {
+    let platform = feed.platform().to_string();
+    let handles = req.listening.handles_for(&platform).to_vec();
+    let limit = if feed.paid() {
+        req.x_read_cap.min(100)
+    } else {
+        req.free_limit.min(100)
+    };
+    let mut notes = Vec::new();
+
+    let fetch = feed.listening_posts(&handles, req.hours, limit).await?;
+    let texts: Vec<&str> = fetch.posts.iter().map(|p| p.text.as_str()).collect();
+    let counts: MentionCounts = count_mentions(&texts);
+
+    let today = now
+        .with_timezone(&chrono_tz::America::New_York)
+        .date_naive();
+    let history: Vec<BaselineLine> = match &req.baseline_path {
+        Some(path) => read_baseline(path)
+            .into_iter()
+            .filter(|l| l.platform == platform && l.date < today)
+            .collect(),
+        None => Vec::new(),
+    };
+
+    let mut tickers = Vec::new();
+    for (sym, n) in &counts.counts {
+        if *n < MIN_REPORT_MENTIONS {
+            continue;
+        }
+        let v = velocity(sym, &counts, &history, fingerprint);
+        let (change_pct, rvol) = tape_for(sym, market).await;
+        let btc = before_the_chart(v.elevated, change_pct, rvol);
+        tickers.push(TickerChatter {
+            ticker: sym.clone(),
+            velocity: v,
+            change_pct,
+            rvol,
+            before_the_chart: btc,
+        });
+    }
+    if tickers.is_empty() && counts.total_posts > 0 {
+        notes.push(format!(
+            "no ticker reached {MIN_REPORT_MENTIONS} cashtag mentions in {} posts — read the recent posts instead; influencer language names companies, not cashtags",
+            counts.total_posts
+        ));
+    }
+
+    if let Some(path) = &req.baseline_path {
+        let line = BaselineLine {
+            date: today,
+            platform: platform.clone(),
+            fingerprint: fingerprint.to_string(),
+            total_posts: counts.total_posts,
+            counts: counts.counts.clone(),
+        };
+        if let Err(e) = append_baseline(path, &line) {
+            notes.push(format!("baseline write failed: {e}"));
+        }
+    }
+
+    let mut recent = fetch.posts.clone();
+    recent.sort_by_key(|p| std::cmp::Reverse(p.created_at));
+    recent.truncate(TOP_POSTS);
+
+    Ok(PlatformChatter {
+        estimated_cost_usd: feed.paid().then(|| {
+            f64::from(fetch.posts_returned) * crate::application::pulse::X_COST_PER_READ_USD
+        }),
+        platform,
+        handles,
+        posts_scanned: fetch.posts.len(),
+        posts_returned: fetch.posts_returned,
+        tickers,
+        recent_posts: recent,
+        notes,
+    })
+}
+
+pub async fn chatter(
+    req: &ChatterRequest,
+    feeds: &[&dyn ListeningFeed],
+    market: Option<&dyn MarketDataSource>,
+    now: DateTime<Utc>,
+) -> Result<ChatterReport, DomainError> {
+    if feeds.is_empty() {
+        return Err(fail(
+            "no listening feeds available — configure bluesky/reddit (openintel setup) or opt in to x",
+        ));
+    }
+    let fingerprint = req.listening.fingerprint();
+    let mut platforms = Vec::new();
+    let mut errors = Vec::new();
+    // Sequential: at most 3 legs, and the paid leg must never race a failure.
+    for feed in feeds {
+        match platform_leg(*feed, req, &fingerprint, market, now).await {
+            Ok(p) => platforms.push(p),
+            Err(e) => errors.push(format!("{}: {e}", feed.platform())),
+        }
+    }
+
+    let mut notes = Vec::new();
+    if platforms
+        .iter()
+        .all(|p| p.tickers.iter().all(|t| t.velocity.ratio.is_none()))
+    {
+        notes.push(
+            "no velocity claims yet — the baseline matures with daily runs; raw counts and posts only"
+                .into(),
+        );
+    }
+
+    Ok(ChatterReport {
+        generated_at: now,
+        hours: req.hours,
+        listening_fingerprint: fingerprint,
+        platforms,
+        errors,
+        notes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::entities::social_post::PostText;
+    use async_trait::async_trait;
+    use chrono::TimeZone;
+
+    struct FixedFeed {
+        platform: &'static str,
+        paid: bool,
+        texts: Vec<&'static str>,
+    }
+
+    #[async_trait]
+    impl ListeningFeed for FixedFeed {
+        fn platform(&self) -> &'static str {
+            self.platform
+        }
+        fn paid(&self) -> bool {
+            self.paid
+        }
+        async fn listening_posts(
+            &self,
+            _handles: &[String],
+            _hours: u32,
+            _limit: usize,
+        ) -> Result<crate::domain::ports::listening_feed::ListeningFetch, DomainError> {
+            let posts = self
+                .texts
+                .iter()
+                .enumerate()
+                .map(|(i, t)| PulsePost {
+                    id: format!("{}-{i}", self.platform),
+                    author: "someone".into(),
+                    text: PostText::parse(t).unwrap(),
+                    created_at: Utc.with_ymd_and_hms(2026, 8, 21, 12, 0, 0).unwrap(),
+                    engagement: 1,
+                })
+                .collect::<Vec<_>>();
+            let returned = posts.len() as u32;
+            Ok(crate::domain::ports::listening_feed::ListeningFetch {
+                posts,
+                posts_returned: returned,
+            })
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 21, 21, 0, 0).unwrap()
+    }
+
+    fn req(baseline: Option<PathBuf>) -> ChatterRequest {
+        ChatterRequest {
+            listening: ListeningSet::default(),
+            hours: 24,
+            free_limit: 100,
+            x_read_cap: 20,
+            baseline_path: baseline,
+        }
+    }
+
+    #[tokio::test]
+    async fn cold_start_reports_counts_without_velocity_and_journals_baseline() {
+        let dir = std::env::temp_dir().join(format!("openintel-chatter-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("baseline.jsonl");
+
+        let feed = FixedFeed {
+            platform: "bluesky",
+            paid: false,
+            texts: vec!["$NVDA one", "$NVDA two", "$NVDA three", "nothing"],
+        };
+        let report = chatter(&req(Some(path.clone())), &[&feed], None, now())
+            .await
+            .unwrap();
+
+        let p = &report.platforms[0];
+        assert_eq!(p.tickers.len(), 1);
+        assert_eq!(p.tickers[0].velocity.mentions, 3);
+        assert!(p.tickers[0].velocity.ratio.is_none());
+        assert!(p.estimated_cost_usd.is_none());
+        assert!(report.notes.iter().any(|n| n.contains("baseline matures")));
+
+        let line: BaselineLine = serde_json::from_str(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .lines()
+                .next()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(line.platform, "bluesky");
+        assert_eq!(line.counts["NVDA"], 3);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn paid_leg_reports_cost_and_no_cashtags_notes_the_language_gap() {
+        let feed = FixedFeed {
+            platform: "x",
+            paid: true,
+            texts: vec!["Tesla robotaxi approval coming", "Tariffs on chips"],
+        };
+        let report = chatter(&req(None), &[&feed], None, now()).await.unwrap();
+        let p = &report.platforms[0];
+        assert_eq!(p.estimated_cost_usd, Some(2.0 * 0.005));
+        assert!(p.tickers.is_empty());
+        assert!(p.notes.iter().any(|n| n.contains("influencer language")));
+        assert_eq!(p.recent_posts.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn failed_leg_is_an_error_not_a_sunk_run() {
+        struct Broken;
+        #[async_trait]
+        impl ListeningFeed for Broken {
+            fn platform(&self) -> &'static str {
+                "reddit"
+            }
+            fn paid(&self) -> bool {
+                false
+            }
+            async fn listening_posts(
+                &self,
+                _h: &[String],
+                _hours: u32,
+                _l: usize,
+            ) -> Result<crate::domain::ports::listening_feed::ListeningFetch, DomainError>
+            {
+                Err(fail("boom"))
+            }
+        }
+        let ok = FixedFeed {
+            platform: "bluesky",
+            paid: false,
+            texts: vec!["$NVDA a", "$NVDA b", "$NVDA c"],
+        };
+        let report = chatter(&req(None), &[&Broken, &ok], None, now())
+            .await
+            .unwrap();
+        assert_eq!(report.platforms.len(), 1);
+        assert!(report.errors.iter().any(|e| e.contains("reddit")));
+    }
+
+    #[tokio::test]
+    async fn no_feeds_is_a_clean_error() {
+        assert!(chatter(&req(None), &[], None, now()).await.is_err());
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,4 +1,5 @@
 pub mod analyze;
+pub mod chatter;
 pub mod dip;
 pub mod discover;
 pub mod pulse;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -105,7 +105,8 @@ pub struct PulseArgs {
     #[arg(long, default_value_t = 24)]
     pub hours: u32,
 
-    /// Max posts to read — each costs ~$0.005; X bills a minimum of 10 reads per call (1-100)
+    /// Max posts to read — ~$0.005 per post returned (deduped over 24h); the
+    /// search floor can return up to 10 even for smaller limits (1-100)
     #[arg(long, default_value_t = 20)]
     pub limit: usize,
 
@@ -225,15 +226,32 @@ pub enum ScreenArg {
 
 #[derive(clap::Args, Debug)]
 pub struct DiscoverArgs {
-    /// Screens to pull, comma-separated (default: all three)
-    #[arg(long, value_enum, value_delimiter = ',')]
+    /// Chatter mode: cashtag mention velocity from the listening set
+    /// (~/.openintel/listening.json) instead of the movers screens
+    #[arg(long)]
+    pub chatter: bool,
+
+    /// Chatter: include the paid X leg — ~$0.005 per post returned, capped by --x-limit
+    #[arg(long, requires = "chatter")]
+    pub x: bool,
+
+    /// Chatter: lookback window in hours (1-167)
+    #[arg(long, default_value_t = 24, requires = "chatter")]
+    pub hours: u32,
+
+    /// Chatter: max X posts returned (each bills ~$0.005; the search floor can return up to 10)
+    #[arg(long = "x-limit", default_value_t = 20, requires = "x")]
+    pub x_limit: usize,
+
+    /// Movers: screens to pull, comma-separated (default: all three)
+    #[arg(long, value_enum, value_delimiter = ',', conflicts_with = "chatter")]
     pub screens: Vec<ScreenArg>,
 
-    /// Rows pulled per screen (1-100)
+    /// Movers: rows pulled per screen (1-100)
     #[arg(long, default_value_t = 25)]
     pub count: usize,
 
-    /// Total candidates deep-annotated across screens (1-25)
+    /// Movers: total candidates deep-annotated across screens (1-25)
     #[arg(long, default_value_t = 9)]
     pub deep: usize,
 

--- a/src/cli/discover.rs
+++ b/src/cli/discover.rs
@@ -6,6 +6,7 @@ use chrono::Utc;
 
 use crate::adapters::filings::edgar::EdgarSource;
 use crate::adapters::market::yahoo::YahooMarketSource;
+use crate::application::chatter::{chatter, ChatterReport, ChatterRequest, DEFAULT_FREE_LIMIT};
 use crate::application::discover::{
     discover, Candidate, DiscoverDeps, DiscoverReport, DiscoverRequest, FRAMING,
 };
@@ -17,6 +18,9 @@ use crate::domain::error::DomainError;
 
 pub async fn run(args: &DiscoverArgs, credentials: &Credentials) -> Result<String, DomainError> {
     let yahoo = YahooMarketSource::new()?;
+    if args.chatter {
+        return run_chatter(args, credentials, &yahoo).await;
+    }
     let edgar = EdgarSource::new()?;
     let social = crate::adapters::sources::build_social_sources(credentials);
     let deps = DiscoverDeps {
@@ -50,6 +54,154 @@ impl ScreenArg {
             ScreenArg::Actives => ScreenKind::MostActives,
         }
     }
+}
+
+async fn run_chatter(
+    args: &DiscoverArgs,
+    credentials: &Credentials,
+    yahoo: &YahooMarketSource,
+) -> Result<String, DomainError> {
+    let listening_path =
+        crate::config::listening::default_path().ok_or_else(|| DomainError::SourceFailure {
+            name: "chatter".into(),
+            message: "cannot resolve a home directory".into(),
+        })?;
+    let (listening, created) = crate::config::listening::load_or_seed(&listening_path)?;
+
+    let free = crate::adapters::sources::build_free_listening_feeds(credentials);
+    let x_feed = if args.x {
+        match credentials.x_bearer.clone() {
+            Some(bearer) => Some(crate::adapters::sources::x::XPulseSource::new(bearer)?),
+            None => {
+                return Err(DomainError::SourceFailure {
+                    name: "chatter".into(),
+                    message: "--x needs X credentials — run `openintel setup x`".into(),
+                })
+            }
+        }
+    } else {
+        None
+    };
+    let mut feeds: Vec<&dyn crate::domain::ports::listening_feed::ListeningFeed> =
+        free.iter().map(|f| f.as_ref()).collect();
+    if let Some(x) = &x_feed {
+        feeds.push(x);
+    }
+
+    let req = ChatterRequest {
+        listening,
+        hours: args.hours.clamp(1, 167),
+        free_limit: DEFAULT_FREE_LIMIT,
+        x_read_cap: args.x_limit.clamp(1, 100),
+        baseline_path: crate::application::chatter::default_baseline_path(),
+    };
+    let report = chatter(&req, &feeds, Some(yahoo), Utc::now()).await?;
+    let mut out = match args.format {
+        FormatArg::Table => render_chatter_table(&report),
+        FormatArg::Json => render_chatter_json(&report)?,
+    };
+    if created && args.format == FormatArg::Table {
+        out.push_str(&format!(
+            "
+seeded {} with the macro defaults — edit it to curate your listening set
+",
+            listening_path.display()
+        ));
+    }
+    Ok(out)
+}
+
+fn render_chatter_json(report: &ChatterReport) -> Result<String, DomainError> {
+    #[derive(serde::Serialize)]
+    struct Out<'a> {
+        report: &'a ChatterReport,
+        framing: &'static str,
+        disclaimer: &'static str,
+    }
+    serde_json::to_string_pretty(&Out {
+        report,
+        framing: crate::application::chatter::FRAMING,
+        disclaimer: DISCLAIMER,
+    })
+    .map_err(|e| DomainError::SourceFailure {
+        name: "chatter".into(),
+        message: format!("render failed: {e}"),
+    })
+}
+
+fn render_chatter_table(r: &ChatterReport) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "=== OpenIntel Discover — chatter ({}h window) ===
+",
+        r.hours
+    );
+    for p in &r.platforms {
+        let cost = p
+            .estimated_cost_usd
+            .map(|c| format!(" · cost ≈ ${c:.2}"))
+            .unwrap_or_default();
+        let _ = writeln!(
+            out,
+            "[{}] {} posts scanned ({} returned){cost}",
+            p.platform, p.posts_scanned, p.posts_returned
+        );
+        for t in &p.tickers {
+            let ratio = t
+                .velocity
+                .ratio
+                .map(|x| format!("{x:.1}x baseline"))
+                .unwrap_or_else(|| "no velocity claim".into());
+            let tape = match (t.change_pct, t.rvol) {
+                (Some(c), Some(v)) => format!(" · day {c:+.1}% rvol {v:.1}"),
+                _ => String::new(),
+            };
+            let btc = match t.before_the_chart {
+                Some(true) => "  ← chatter leading the chart",
+                _ => "",
+            };
+            let _ = writeln!(
+                out,
+                "  {}  {} mentions ({:.0}% of posts) · {ratio}{tape}{btc}",
+                t.ticker,
+                t.velocity.mentions,
+                t.velocity.share * 100.0
+            );
+            for f in &t.velocity.flags {
+                let _ = writeln!(out, "    note: {f}");
+            }
+        }
+        for n in &p.notes {
+            let _ = writeln!(out, "  note: {n}");
+        }
+        if !p.recent_posts.is_empty() {
+            let _ = writeln!(out, "  recent posts:");
+            for post in &p.recent_posts {
+                let text: String = post.text.as_str().chars().take(120).collect();
+                let _ = writeln!(out, "    @{}: {}", post.author, text);
+            }
+        }
+        let _ = writeln!(out);
+    }
+    for e in &r.errors {
+        let _ = writeln!(out, "error: {e}");
+    }
+    for n in &r.notes {
+        let _ = writeln!(out, "note: {n}");
+    }
+    let _ = writeln!(
+        out,
+        "
+{}",
+        crate::application::chatter::FRAMING
+    );
+    let _ = writeln!(
+        out,
+        "
+{DISCLAIMER}"
+    );
+    out
 }
 
 fn render_json(report: &DiscoverReport) -> Result<String, DomainError> {

--- a/src/config/listening.rs
+++ b/src/config/listening.rs
@@ -1,0 +1,141 @@
+//! The chatter listening set: who is worth hearing, per platform. Lives at
+//! `~/.openintel/listening.json`, hand-editable; created with the macro seed
+//! on first use. Not a secret — no keychain involvement.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::application::pulse::DEFAULT_PULSE_ACCOUNTS;
+use crate::domain::error::DomainError;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListeningSet {
+    #[serde(default)]
+    pub x_accounts: Vec<String>,
+    #[serde(default)]
+    pub bluesky_accounts: Vec<String>,
+    #[serde(default)]
+    pub subreddits: Vec<String>,
+}
+
+impl Default for ListeningSet {
+    fn default() -> Self {
+        Self {
+            x_accounts: DEFAULT_PULSE_ACCOUNTS
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            bluesky_accounts: Vec::new(),
+            subreddits: vec![
+                "wallstreetbets".into(),
+                "stocks".into(),
+                "StockMarket".into(),
+            ],
+        }
+    }
+}
+
+impl ListeningSet {
+    pub fn handles_for(&self, platform: &str) -> &[String] {
+        match platform {
+            "x" => &self.x_accounts,
+            "bluesky" => &self.bluesky_accounts,
+            "reddit" => &self.subreddits,
+            _ => &[],
+        }
+    }
+
+    /// Deterministic identity of the set, stored on every baseline line so
+    /// velocity against a changed set is flagged, never silently claimed.
+    /// Deliberately not a hash — std hashing isn't stable across runs.
+    pub fn fingerprint(&self) -> String {
+        let part = |label: &str, list: &[String]| {
+            let mut sorted: Vec<String> = list.iter().map(|s| s.to_lowercase()).collect();
+            sorted.sort();
+            format!("{label}:{}", sorted.join(","))
+        };
+        [
+            part("x", &self.x_accounts),
+            part("bsky", &self.bluesky_accounts),
+            part("r", &self.subreddits),
+        ]
+        .join("|")
+    }
+}
+
+pub fn default_path() -> Option<PathBuf> {
+    std::env::home_dir().map(|h| h.join(".openintel").join("listening.json"))
+}
+
+fn fail(message: impl Into<String>) -> DomainError {
+    DomainError::SourceFailure {
+        name: "listening".into(),
+        message: message.into(),
+    }
+}
+
+/// Load the set, seeding the file with defaults on first use. `created` tells
+/// the caller to mention the file so the user knows where to curate.
+pub fn load_or_seed(path: &Path) -> Result<(ListeningSet, bool), DomainError> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => {
+            let set = serde_json::from_str(&content)
+                .map_err(|e| fail(format!("bad listening.json ({e}) — fix or delete it")))?;
+            Ok((set, false))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let set = ListeningSet::default();
+            if let Some(dir) = path.parent() {
+                std::fs::create_dir_all(dir).map_err(|e| fail(e.to_string()))?;
+            }
+            let json = serde_json::to_string_pretty(&set).map_err(|e| fail(e.to_string()))?;
+            std::fs::write(path, json).map_err(|e| fail(e.to_string()))?;
+            Ok((set, true))
+        }
+        Err(e) => Err(fail(format!("cannot read {}: {e}", path.display()))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_then_load_round_trips() {
+        let dir = std::env::temp_dir().join(format!("openintel-listen-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("listening.json");
+
+        let (set, created) = load_or_seed(&path).unwrap();
+        assert!(created);
+        assert_eq!(set.x_accounts.len(), 4);
+        assert_eq!(set.subreddits[0], "wallstreetbets");
+
+        let (again, created) = load_or_seed(&path).unwrap();
+        assert!(!created);
+        assert_eq!(again.fingerprint(), set.fingerprint());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fingerprint_is_order_insensitive_but_content_sensitive() {
+        let a = ListeningSet {
+            x_accounts: vec!["Alpha".into(), "beta".into()],
+            bluesky_accounts: vec![],
+            subreddits: vec![],
+        };
+        let b = ListeningSet {
+            x_accounts: vec!["BETA".into(), "alpha".into()],
+            bluesky_accounts: vec![],
+            subreddits: vec![],
+        };
+        assert_eq!(a.fingerprint(), b.fingerprint());
+        let c = ListeningSet {
+            x_accounts: vec!["alpha".into()],
+            bluesky_accounts: vec![],
+            subreddits: vec![],
+        };
+        assert_ne!(a.fingerprint(), c.fingerprint());
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,4 @@
+pub mod listening;
 pub mod secrets;
 pub mod settings;
 pub mod store;

--- a/src/domain/chatter.rs
+++ b/src/domain/chatter.rs
@@ -1,0 +1,309 @@
+//! Pure chatter math: cashtag extraction, mention counting, and velocity
+//! against a baseline journal. Honesty gates throughout: velocity claims need
+//! ≥ MIN_VELOCITY_MENTIONS today and ≥ MIN_BASELINE_DAYS of prior baseline
+//! from an unchanged listening set — below that, raw counts only, labeled.
+
+use std::collections::BTreeMap;
+
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+
+use crate::domain::entities::ticker::Ticker;
+
+/// A ticker must be cashtagged at least this often (across a platform's scan)
+/// to appear in the report at all — single mentions are noise.
+pub const MIN_REPORT_MENTIONS: usize = 3;
+/// Velocity (a ratio claim) needs more: this many mentions today…
+pub const MIN_VELOCITY_MENTIONS: usize = 5;
+/// …and this many prior baseline days for the same platform + listening set.
+pub const MIN_BASELINE_DAYS: usize = 3;
+/// "Elevated" = today's mention share at least this multiple of the baseline
+/// mean share.
+pub const ELEVATED_RATIO: f64 = 3.0;
+
+/// Valid cashtags in `text` ($NVDA → NVDA), deduplicated per call — a ticker
+/// counts once per post no matter how many times one author repeats it.
+pub fn cashtags(text: &str) -> Vec<String> {
+    let bytes = text.as_bytes();
+    let mut found: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' {
+            let start = i + 1;
+            let mut end = start;
+            while end < bytes.len() && bytes[end].is_ascii_alphabetic() && end - start < 6 {
+                end += 1;
+            }
+            let boundary_ok = end == bytes.len() || !bytes[end].is_ascii_alphanumeric();
+            if end > start && end - start <= 5 && boundary_ok {
+                if let Ok(t) = Ticker::parse(&text[start..end]) {
+                    let sym = t.as_str().to_string();
+                    if !found.contains(&sym) {
+                        found.push(sym);
+                    }
+                }
+            }
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+    found
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MentionCounts {
+    pub total_posts: usize,
+    pub counts: BTreeMap<String, usize>,
+}
+
+/// Count cashtag mentions across posts — once per ticker per post.
+pub fn count_mentions(texts: &[&str]) -> MentionCounts {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for text in texts {
+        for sym in cashtags(text) {
+            *counts.entry(sym).or_insert(0) += 1;
+        }
+    }
+    MentionCounts {
+        total_posts: texts.len(),
+        counts,
+    }
+}
+
+/// One appended baseline line: what one platform's scan counted on one day.
+/// `fingerprint` identifies the listening set the counts came from — velocity
+/// against a changed set is flagged, never silently claimed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaselineLine {
+    pub date: NaiveDate,
+    pub platform: String,
+    pub fingerprint: String,
+    pub total_posts: usize,
+    pub counts: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Velocity {
+    pub mentions: usize,
+    /// mentions ÷ total posts scanned — set-size-independent.
+    pub share: f64,
+    pub baseline_days: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline_share_mean: Option<f64>,
+    /// today's share ÷ baseline mean share. None until the honesty gates pass.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ratio: Option<f64>,
+    pub elevated: bool,
+    pub flags: Vec<String>,
+}
+
+/// Velocity for one ticker on one platform. `history` is prior days' lines
+/// for the same platform (any fingerprint — mismatches are flagged); today's
+/// line must not be included.
+pub fn velocity(
+    ticker: &str,
+    today: &MentionCounts,
+    history: &[BaselineLine],
+    fingerprint: &str,
+) -> Velocity {
+    let mentions = today.counts.get(ticker).copied().unwrap_or(0);
+    let share = if today.total_posts > 0 {
+        mentions as f64 / today.total_posts as f64
+    } else {
+        0.0
+    };
+    let mut flags = Vec::new();
+
+    let matching: Vec<&BaselineLine> = history
+        .iter()
+        .filter(|l| l.fingerprint == fingerprint && l.total_posts > 0)
+        .collect();
+    if matching.len() < history.len() {
+        flags.push("listening set changed within the baseline window".into());
+    }
+    // One line per day: a re-run same day would double-weight it.
+    let mut days: Vec<NaiveDate> = matching.iter().map(|l| l.date).collect();
+    days.sort();
+    days.dedup();
+    let baseline_days = days.len();
+
+    let baseline_share_mean = (baseline_days > 0).then(|| {
+        let sum: f64 = days
+            .iter()
+            .map(|d| {
+                // Last line per day wins.
+                let line = matching.iter().rev().find(|l| l.date == *d).unwrap();
+                line.counts.get(ticker).copied().unwrap_or(0) as f64 / line.total_posts as f64
+            })
+            .sum();
+        sum / baseline_days as f64
+    });
+
+    let ratio = match (baseline_share_mean, mentions, baseline_days) {
+        (Some(mean), m, d) if m >= MIN_VELOCITY_MENTIONS && d >= MIN_BASELINE_DAYS => {
+            if mean > 0.0 {
+                Some(share / mean)
+            } else {
+                flags.push("first appearance — no baseline to compare against".into());
+                None
+            }
+        }
+        _ => {
+            if baseline_days < MIN_BASELINE_DAYS {
+                flags.push(format!(
+                    "baseline building — {baseline_days}/{MIN_BASELINE_DAYS} prior days; raw counts only"
+                ));
+            } else if mentions < MIN_VELOCITY_MENTIONS {
+                flags.push(format!(
+                    "below velocity floor ({mentions} < {MIN_VELOCITY_MENTIONS} mentions); raw counts only"
+                ));
+            }
+            None
+        }
+    };
+    let elevated = ratio.is_some_and(|r| r >= ELEVATED_RATIO);
+
+    Velocity {
+        mentions,
+        share,
+        baseline_days,
+        baseline_share_mean,
+        ratio,
+        elevated,
+        flags,
+    }
+}
+
+/// The "before the chart" read: chatter elevated while the tape is quiet.
+/// None when any input is missing — never a claim without evidence.
+pub fn before_the_chart(
+    elevated: bool,
+    change_pct: Option<f64>,
+    rvol: Option<f64>,
+) -> Option<bool> {
+    match (change_pct, rvol) {
+        (Some(change), Some(rvol)) => Some(elevated && change.abs() < 2.0 && rvol < 1.5),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn d(day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 8, day).unwrap()
+    }
+
+    fn line(day: u32, fp: &str, total: usize, pairs: &[(&str, usize)]) -> BaselineLine {
+        BaselineLine {
+            date: d(day),
+            platform: "x".into(),
+            fingerprint: fp.into(),
+            total_posts: total,
+            counts: pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect(),
+        }
+    }
+
+    #[test]
+    fn cashtags_validate_and_dedupe() {
+        assert_eq!(
+            cashtags("Long $NVDA and $nvda, watching $TSLA. $5k gain, $TOOLONGX no"),
+            vec!["NVDA", "TSLA"]
+        );
+        assert!(cashtags("price is $50 and 100$").is_empty());
+        assert_eq!(cashtags("$BRK.B maybe"), vec!["BRK"]); // cashtag grammar stops at '.'
+    }
+
+    #[test]
+    fn mentions_count_once_per_post() {
+        let m = count_mentions(&["$NVDA $NVDA $NVDA to the moon", "$NVDA dip", "no tags"]);
+        assert_eq!(m.total_posts, 3);
+        assert_eq!(m.counts["NVDA"], 2);
+    }
+
+    #[test]
+    fn velocity_gates_on_baseline_days_and_mentions() {
+        let today = count_mentions(&["$NVDA", "$NVDA", "$NVDA", "$NVDA", "$NVDA", "x"]);
+        // Only 2 baseline days -> no ratio, building flag.
+        let v = velocity(
+            "NVDA",
+            &today,
+            &[
+                line(18, "fp", 100, &[("NVDA", 2)]),
+                line(19, "fp", 100, &[("NVDA", 2)]),
+            ],
+            "fp",
+        );
+        assert_eq!(v.mentions, 5);
+        assert!(v.ratio.is_none());
+        assert!(v.flags.iter().any(|f| f.contains("baseline building")));
+
+        // 3 days -> ratio appears: share 5/6 vs mean 0.02.
+        let history = [
+            line(17, "fp", 100, &[("NVDA", 2)]),
+            line(18, "fp", 100, &[("NVDA", 2)]),
+            line(19, "fp", 100, &[("NVDA", 2)]),
+        ];
+        let v = velocity("NVDA", &today, &history, "fp");
+        let ratio = v.ratio.unwrap();
+        assert!((ratio - (5.0 / 6.0) / 0.02).abs() < 1e-9);
+        assert!(v.elevated);
+
+        // Below the mention floor -> raw counts only.
+        let sparse = count_mentions(&["$NVDA", "$NVDA", "$NVDA", "a", "b", "c"]);
+        let v = velocity("NVDA", &sparse, &history, "fp");
+        assert!(v.ratio.is_none());
+        assert!(v.flags.iter().any(|f| f.contains("below velocity floor")));
+    }
+
+    #[test]
+    fn changed_fingerprint_is_flagged_and_excluded() {
+        let today = count_mentions(&["$NVDA", "$NVDA", "$NVDA", "$NVDA", "$NVDA"]);
+        let history = [
+            line(17, "old", 100, &[("NVDA", 50)]),
+            line(18, "fp", 100, &[("NVDA", 2)]),
+            line(19, "fp", 100, &[("NVDA", 2)]),
+        ];
+        let v = velocity("NVDA", &today, &history, "fp");
+        assert_eq!(v.baseline_days, 2);
+        assert!(v.flags.iter().any(|f| f.contains("listening set changed")));
+    }
+
+    #[test]
+    fn same_day_rerun_counts_once_with_last_line_winning() {
+        let today = count_mentions(&["$NVDA", "$NVDA", "$NVDA", "$NVDA", "$NVDA"]);
+        let history = [
+            line(17, "fp", 100, &[("NVDA", 2)]),
+            line(18, "fp", 100, &[("NVDA", 2)]),
+            line(19, "fp", 10, &[("NVDA", 9)]),
+            line(19, "fp", 100, &[("NVDA", 2)]), // re-run: this one counts
+        ];
+        let v = velocity("NVDA", &today, &history, "fp");
+        assert_eq!(v.baseline_days, 3);
+        assert!((v.baseline_share_mean.unwrap() - 0.02).abs() < 1e-12);
+    }
+
+    #[test]
+    fn first_appearance_has_no_ratio() {
+        let today = count_mentions(&["$NEWCO", "$NEWCO", "$NEWCO", "$NEWCO", "$NEWCO"]);
+        let history = [
+            line(17, "fp", 100, &[]),
+            line(18, "fp", 100, &[]),
+            line(19, "fp", 100, &[]),
+        ];
+        let v = velocity("NEWCO", &today, &history, "fp");
+        assert!(v.ratio.is_none());
+        assert!(v.flags.iter().any(|f| f.contains("first appearance")));
+    }
+
+    #[test]
+    fn before_the_chart_needs_all_evidence() {
+        assert_eq!(before_the_chart(true, Some(0.5), Some(1.0)), Some(true));
+        assert_eq!(before_the_chart(true, Some(8.0), Some(1.0)), Some(false));
+        assert_eq!(before_the_chart(true, Some(0.5), Some(4.0)), Some(false));
+        assert_eq!(before_the_chart(false, Some(0.5), Some(1.0)), Some(false));
+        assert_eq!(before_the_chart(true, None, Some(1.0)), None);
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod chatter;
 pub mod dip;
 pub mod dip_review;
 pub mod discover;

--- a/src/domain/ports/listening_feed.rs
+++ b/src/domain/ports/listening_feed.rs
@@ -1,0 +1,33 @@
+use async_trait::async_trait;
+
+use crate::domain::entities::pulse::PulsePost;
+use crate::domain::error::DomainError;
+
+/// What one ticker-less listening fetch yielded. `posts_returned` is what the
+/// upstream API actually returned (= what a pay-per-read API bills), which
+/// can exceed `posts.len()` due to client-side skips.
+#[derive(Debug, Clone)]
+pub struct ListeningFetch {
+    pub posts: Vec<PulsePost>,
+    pub posts_returned: u32,
+}
+
+/// Ticker-less feed for chatter discovery: recent posts from a listening set,
+/// no symbol required. `handles` are accounts for X/Bluesky and subreddits
+/// for Reddit. Posts reuse `PulsePost` deliberately — like pulse, they never
+/// enter the fusion engine's sentiment averaging.
+#[async_trait]
+pub trait ListeningFeed: Send + Sync {
+    /// Stable platform label ("x" / "bluesky" / "reddit") — keys the chatter
+    /// baseline journal.
+    fn platform(&self) -> &'static str;
+    /// True when every read bills real money — callers must gate on explicit
+    /// user opt-in and disclose the cost first.
+    fn paid(&self) -> bool;
+    async fn listening_posts(
+        &self,
+        handles: &[String],
+        hours_back: u32,
+        limit: usize,
+    ) -> Result<ListeningFetch, DomainError>;
+}

--- a/src/domain/ports/mod.rs
+++ b/src/domain/ports/mod.rs
@@ -1,6 +1,7 @@
 pub mod bar_source;
 pub mod filings_source;
 pub mod influencer_feed;
+pub mod listening_feed;
 pub mod market_data_source;
 pub mod movers_source;
 pub mod news_source;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -15,6 +15,7 @@ use crate::mcp::tools;
 pub struct OpenIntelServer {
     tool_router: ToolRouter<OpenIntelServer>,
     social: Arc<Vec<Box<dyn SocialDataSource>>>,
+    listening: Arc<Vec<Box<dyn crate::domain::ports::listening_feed::ListeningFeed>>>,
     market: YahooMarketSource,
     filings: Arc<crate::adapters::filings::edgar::EdgarSource>,
     pulse_feed: Option<Arc<crate::adapters::sources::x::XPulseSource>>,
@@ -23,6 +24,7 @@ pub struct OpenIntelServer {
 impl OpenIntelServer {
     pub fn new(
         social: Vec<Box<dyn SocialDataSource>>,
+        listening: Vec<Box<dyn crate::domain::ports::listening_feed::ListeningFeed>>,
         market: YahooMarketSource,
         filings: crate::adapters::filings::edgar::EdgarSource,
         pulse_feed: Option<crate::adapters::sources::x::XPulseSource>,
@@ -30,6 +32,7 @@ impl OpenIntelServer {
         Self {
             tool_router: Self::tool_router(),
             social: Arc::new(social),
+            listening: Arc::new(listening),
             market,
             filings: Arc::new(filings),
             pulse_feed: pulse_feed.map(Arc::new),
@@ -111,8 +114,9 @@ impl OpenIntelServer {
                        actually matter for this ticker — CEO/founder, major institutional holders \
                        or activist funds, respected sector journalists, and market-moving macro \
                        figures — then propose the account list and estimated max cost \
-                       (max(limit, 10) × $0.005 — X bills a minimum of 10 reads) to the user \
-                       and get their confirmation. Also propose \
+                       (up to max(limit, 10) × $0.005 — billing is per post returned, deduped \
+                       over 24h; the search floor can return up to 10 posts even for smaller \
+                       limits) to the user and get their confirmation. Also propose \
                        company-language keywords (e.g. \"Tesla\" for TSLA) — these accounts \
                        rarely write cashtags, so symbol-only matching misses their posts. \
                        Omit `accounts` only if the user asks for the default macro list. \
@@ -212,21 +216,49 @@ impl OpenIntelServer {
     }
 
     #[tool(
-        description = "Answer \"where are trades today?\" without a ticker: pull Yahoo's \
-                       predefined screens (gainers / losers / most actives), apply the quality \
-                       floor, and annotate a bounded slice with evidence — day change, RVOL, \
+        description = "Answer \"where are trades today?\" without a ticker. Mode \"movers\" \
+                       (default): Yahoo's predefined screens (gainers / losers / most actives), \
+                       quality floor, then evidence per candidate — day change, RVOL, \
                        ATR-stretch, distance to 3-month and ~1-year period extremes (a proxy, \
                        NOT support/resistance), same-day SEC-filing and catalyst-headline gates \
                        (unverifiable evidence reads Unknown), and social attention where \
-                       configured. NO ranking, NO verdicts, NO picks — present the evidence and \
-                       let the user reason. For gated dip verdicts on losers run dip_scan; for \
-                       a deep read on one name run analyze_ticker; before any trade run \
-                       risk_frame and get explicit user approval. Read-only — does not trade."
+                       configured. Mode \"chatter\": cashtag mention velocity from the user's \
+                       listening set (~/.openintel/listening.json — propose curation additions \
+                       for the user to approve), graded against a baseline journal with honesty \
+                       gates (no velocity claim below 5 mentions / 3 baseline days), plus the \
+                       raw recent posts (influencers write company names, not cashtags — read \
+                       them). include_x adds the PAID X leg: ~$0.005 per post returned, deduped \
+                       24h, default cap 20 ≈ $0.10 max — state the cost and get the user's \
+                       confirmation BEFORE calling with include_x. NO ranking, NO verdicts, NO \
+                       picks. For gated dip verdicts on losers run dip_scan; before any trade \
+                       run risk_frame and get explicit user approval. Read-only — never trades."
     )]
     async fn discover(
         &self,
         Parameters(args): Parameters<tools::DiscoverToolArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if matches!(args.mode, Some(tools::DiscoverModeArg::Chatter)) {
+            let mut feeds: Vec<&dyn crate::domain::ports::listening_feed::ListeningFeed> =
+                self.listening.iter().map(|f| f.as_ref() as _).collect();
+            if args.include_x.unwrap_or(false) {
+                match self.pulse_feed.as_deref() {
+                    Some(x) => feeds.push(x),
+                    None => {
+                        return Err(ErrorData::invalid_request(
+                            "include_x set but X is not configured — run `openintel setup x`"
+                                .to_string(),
+                            None,
+                        ))
+                    }
+                }
+            }
+            let out = tools::run_chatter(&args, &feeds, Some(&self.market))
+                .await
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+            let json = serde_json::to_string_pretty(&out)
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+            return Ok(CallToolResult::success(vec![ContentBlock::text(json)]));
+        }
         let deps = crate::application::discover::DiscoverDeps {
             movers: &self.market,
             bars: &self.market,
@@ -353,7 +385,8 @@ pub async fn serve() -> Result<(), Box<dyn std::error::Error>> {
         },
         None => None,
     };
-    let service = OpenIntelServer::new(social, market, filings, pulse_feed)
+    let listening = crate::adapters::sources::build_free_listening_feeds(&credentials);
+    let service = OpenIntelServer::new(social, listening, market, filings, pulse_feed)
         .serve(stdio())
         .await?;
     service.waiting().await?;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -362,8 +362,9 @@ pub struct PulseToolArgs {
     pub keywords: Option<Vec<String>>,
     /// Lookback window in hours (default 24, max 167).
     pub hours_back: Option<u32>,
-    /// Max posts to read — each read costs ~$0.005 (default 20, max 100).
-    /// X bills a minimum of 10 reads per call.
+    /// Max posts to read — ~$0.005 per post returned, deduped over 24h
+    /// (default 20, max 100). The search floor can return up to 10 posts
+    /// even for smaller limits — budget the worst case.
     pub limit: Option<usize>,
 }
 
@@ -682,12 +683,83 @@ impl ScreenArg {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DiscoverToolArgs {
+    /// "movers" (default) or "chatter" (mention velocity from the listening set).
+    pub mode: Option<DiscoverModeArg>,
     /// Screens to pull: "gainers", "losers", "actives" (default: all three).
     pub screens: Option<Vec<ScreenArg>>,
     /// Rows pulled per screen (1-100, default 25).
     pub count: Option<usize>,
     /// Total candidates deep-annotated across screens (1-25, default 9).
     pub deep: Option<usize>,
+    /// Chatter only: include the PAID X leg (~$0.005 per post returned).
+    /// Confirm the cost with the user BEFORE setting this.
+    pub include_x: Option<bool>,
+    /// Chatter only: lookback hours (1-167, default 24).
+    pub hours: Option<u32>,
+    /// Chatter only: max X posts returned (1-100, default 20 ≈ $0.10 max).
+    pub x_read_cap: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum DiscoverModeArg {
+    Movers,
+    Chatter,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChatterToolOutput {
+    pub summary: String,
+    pub report: crate::application::chatter::ChatterReport,
+    pub framing: &'static str,
+    pub disclaimer: &'static str,
+}
+
+pub async fn run_chatter(
+    args: &DiscoverToolArgs,
+    feeds: &[&dyn crate::domain::ports::listening_feed::ListeningFeed],
+    market: Option<&dyn crate::domain::ports::market_data_source::MarketDataSource>,
+) -> Result<ChatterToolOutput, DomainError> {
+    let listening_path =
+        crate::config::listening::default_path().ok_or_else(|| DomainError::SourceFailure {
+            name: "chatter".into(),
+            message: "cannot resolve a home directory".into(),
+        })?;
+    let (listening, _created) = crate::config::listening::load_or_seed(&listening_path)?;
+    let req = crate::application::chatter::ChatterRequest {
+        listening,
+        hours: args
+            .hours
+            .unwrap_or(crate::application::chatter::DEFAULT_HOURS)
+            .clamp(1, 167),
+        free_limit: crate::application::chatter::DEFAULT_FREE_LIMIT,
+        x_read_cap: args
+            .x_read_cap
+            .unwrap_or(crate::application::chatter::DEFAULT_X_READ_CAP)
+            .clamp(1, 100),
+        baseline_path: crate::application::chatter::default_baseline_path(),
+    };
+    let report = crate::application::chatter::chatter(&req, feeds, market, Utc::now()).await?;
+    let spent: f64 = report
+        .platforms
+        .iter()
+        .filter_map(|p| p.estimated_cost_usd)
+        .sum();
+    let summary = format!(
+        "{} platforms scanned · {} tickers surfaced · ${spent:.2} spent",
+        report.platforms.len(),
+        report
+            .platforms
+            .iter()
+            .map(|p| p.tickers.len())
+            .sum::<usize>()
+    );
+    Ok(ChatterToolOutput {
+        summary,
+        report,
+        framing: crate::application::chatter::FRAMING,
+        disclaimer: DISCLAIMER,
+    })
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
Completes #63 (PR 2 of 2). Plan (approved, v3): https://xurbod9eldbn.postplan.dev

## Problem

Movers mode answers "what moved?"; nothing answered "what are the voices worth hearing talking about, before the chart shows it?"

## Solution

`openintel discover --chatter` + `mode: "chatter"` on the `discover` MCP tool, built on a new ticker-less `ListeningFeed` port:

- **Listening set** at `~/.openintel/listening.json` (seeded with the macro defaults on first run, hand-editable; the MCP description tells the agent to propose curation additions for user approval).
- **Three legs:** Bluesky author feeds (free, always), Reddit subreddit hot (optional, degrades gracefully), and X accounts-only search (**paid, strictly opt-in** via `--x` / `include_x`, capped at 20 reads ≈ $0.10/run by default, actual spend reported per leg; the pulse query builder's `from:` chain is reused with the ticker terms dropped).
- **Honest velocity:** cashtags counted once per post, graded by mention **share** (set-size independent, so a grown listening set can't fake a spike) against an appended baseline journal; changed sets are fingerprint-flagged. No velocity claim below 5 mentions today + 3 prior baseline days — cold start reports raw counts labeled "baseline building". Same-day re-runs count once (last line wins).
- **"Chatter leading the chart":** velocity ≥ 3× baseline while |day move| < 2% and RVOL < 1.5 — emitted only when the tape evidence exists, `None` otherwise.
- **Recent posts ride along raw** — influencers write "Tesla", not "$TSLA"; the reading agent connects names to tickers (the #56 lesson in reverse). Yahoo-search name resolution stays a noted follow-up.
- **Cost-copy correction (planned amendment):** all "X bills a minimum of 10 reads per call" copy (pulse CLI/MCP/README) corrected to current documentation — billing is per post returned, deduped over a 24h UTC day, prepaid, no per-call minimum; the `max_results ≥ 10` floor is a worst case, not a fee.

Tests: 296 unit + 3 integration green (14 new: cashtag grammar, velocity gates, fingerprint flagging, same-day dedupe, cold-start journaling, paid-leg cost accounting, failed-leg isolation), clippy `-D warnings`, fmt. Offline smoke verified both unconfigured paths fail with clean errors, the listening file seeds correctly, and nothing is billed without `--x`.

---
Changes made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)