### PR TITLE
fix(bluesky): accept custom-domain handles and a leading @

### DIFF
--- a/src/adapters/sources/bluesky/mod.rs
+++ b/src/adapters/sources/bluesky/mod.rs
@@ -28,8 +28,11 @@ pub struct BlueskySource {
 
 /// ATProto identifiers never carry the display `@`, and custom-domain handles
 /// (kloudysky.io) are as valid as *.bsky.social — accept both spellings.
+/// Exactly one leading `@` is stripped: `@@name` stays malformed and fails
+/// the live verify loudly instead of silently querying a different actor.
 fn normalize_handle(raw: &str) -> String {
-    raw.trim().trim_start_matches('@').to_string()
+    let trimmed = raw.trim();
+    trimmed.strip_prefix('@').unwrap_or(trimmed).to_string()
 }
 
 impl BlueskySource {
@@ -235,10 +238,13 @@ mod tests_handle {
     use super::normalize_handle;
 
     #[test]
-    fn strips_at_and_whitespace_keeps_domains() {
+    fn strips_one_at_and_whitespace_keeps_domains() {
         assert_eq!(normalize_handle("@kloudysky.io "), "kloudysky.io");
         assert_eq!(normalize_handle("name.bsky.social"), "name.bsky.social");
         assert_eq!(normalize_handle(" @name.bsky.social"), "name.bsky.social");
+        // Double @ stays malformed -> fails the live verify instead of
+        // silently resolving to a different actor.
+        assert_eq!(normalize_handle("@@name.bsky.social"), "@name.bsky.social");
     }
 }
 

--- a/src/adapters/sources/bluesky/mod.rs
+++ b/src/adapters/sources/bluesky/mod.rs
@@ -26,8 +26,15 @@ pub struct BlueskySource {
     token: RwLock<Option<CachedToken>>,
 }
 
+/// ATProto identifiers never carry the display `@`, and custom-domain handles
+/// (kloudysky.io) are as valid as *.bsky.social — accept both spellings.
+fn normalize_handle(raw: &str) -> String {
+    raw.trim().trim_start_matches('@').to_string()
+}
+
 impl BlueskySource {
     pub fn new(handle: String, app_password: SecretString) -> Result<Self, DomainError> {
+        let handle = normalize_handle(&handle);
         let user_agent = format!("rust:openintel:v{}", env!("CARGO_PKG_VERSION"));
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(TIMEOUT_SECS))
@@ -180,7 +187,7 @@ impl crate::domain::ports::listening_feed::ListeningFeed for BlueskySource {
                 reqwest::Url::parse(&format!("{PDS_BASE}/xrpc/app.bsky.feed.getAuthorFeed"))
                     .map_err(|e| fail(format!("bad feed url: {e}")))?;
             url.query_pairs_mut()
-                .append_pair("actor", handle)
+                .append_pair("actor", &normalize_handle(handle))
                 .append_pair("filter", "posts_no_replies")
                 .append_pair("limit", &per_handle);
             let resp = self
@@ -220,6 +227,18 @@ impl crate::domain::ports::listening_feed::ListeningFeed for BlueskySource {
             posts,
             posts_returned: returned,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests_handle {
+    use super::normalize_handle;
+
+    #[test]
+    fn strips_at_and_whitespace_keeps_domains() {
+        assert_eq!(normalize_handle("@kloudysky.io "), "kloudysky.io");
+        assert_eq!(normalize_handle("name.bsky.social"), "name.bsky.social");
+        assert_eq!(normalize_handle(" @name.bsky.social"), "name.bsky.social");
     }
 }
 

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -639,7 +639,7 @@ Bluesky needs a free app password — search requires auth. ~2 minutes:
   4. Put your handle and the app password in your shell (or a gitignored
      .env — see .env.example), then re-run this command:
 
-       export OPENINTEL_BLUESKY_HANDLE=yourname.bsky.social
+       export OPENINTEL_BLUESKY_HANDLE=yourname.bsky.social   # or your own domain
        export OPENINTEL_BLUESKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
        openintel setup bluesky
 

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -168,8 +168,9 @@ const REDDIT_UNAUTHORIZED_HINT: &str =
          name; the secret is labelled \"secret\").";
 
 const BLUESKY_UNAUTHORIZED_HINT: &str =
-    "Your handle or app password looks wrong. Check the handle\n   \
-         (e.g. yourname.bsky.social) and generate a fresh app password at\n   \
+    "Your handle or app password looks wrong. Check the handle — either\n   \
+         yourname.bsky.social or your own domain (kloudysky.io style), no @ needed —\n   \
+         and generate a fresh app password at\n   \
          https://bsky.app/settings/app-passwords (the value is shown only once).";
 
 /// Everything the shared interactive loop needs to know about one source.
@@ -220,7 +221,7 @@ const BLUESKY_SPEC: SourceSpec = SourceSpec {
     label: "Bluesky",
     first_key: "OPENINTEL_BLUESKY_HANDLE",
     second_key: Some("OPENINTEL_BLUESKY_APP_PASSWORD"),
-    first_prompt: "Handle (e.g. yourname.bsky.social)",
+    first_prompt: "Handle (yourname.bsky.social or your own domain; @ optional)",
     second_prompt: Some("App password"),
     pre_probe_confirm: None,
     condensed_guide: "\


### PR DESCRIPTION
## Problem

A user whose Bluesky handle is a custom domain (`@kloudysky.io`) can't get through `openintel setup bluesky`: the input is only whitespace-trimmed, so the literal `@kloudysky.io` is sent as the ATProto `createSession` identifier and rejected. The prompts and error hints all say `yourname.bsky.social`, wrongly implying domain handles aren't supported — when the only actual problem is the `@`.

## Solution

- `normalize_handle` (trim + strip leading `@`) applied once in `BlueskySource::new` — the single choke point, covering setup, env vars, and both composition roots — and on each listening-feed actor, so `@`-prefixed entries in `listening.json` work too.
- Prompt and unauthorized-hint copy now say custom domains are fine and the `@` is optional.
- Unit test for the normalization.

Mirrors the existing `@`-stripping precedent in pulse's `normalize_accounts`.

Tests: 297 unit + 3 integration green, clippy `-D warnings`, fmt.

---
Changes made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluesky handle recognition by trimming whitespace and accepting handles with or without a leading `@`.
  * Added support for both `.bsky.social` handles and custom-domain handles.

* **Documentation**
  * Updated Bluesky setup guidance and authentication messages to clarify accepted handle formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->